### PR TITLE
Fix default value for $blurGalleries.

### DIFF
--- a/src/AppBundle/Entity/User.php
+++ b/src/AppBundle/Entity/User.php
@@ -113,7 +113,7 @@ class User extends BaseUser
     /**
      * @ORM\Column(type="boolean", options={"default" = 0})
      */
-    protected $blurGalleries;
+    protected $blurGalleries = false;
 
     /**
      * @ORM\OneToMany(targetEntity="Participation", mappedBy="user")


### PR DESCRIPTION
Registration was not possible as there was no default value for `$blurGalleries` in `User` entity.