### PR TITLE
Add explicit nullable type hints for PHP 8.5 compatibility

### DIFF
--- a/src/Entity/Location.php
+++ b/src/Entity/Location.php
@@ -101,7 +101,7 @@ class Location implements RouteableInterface, AuditableInterface
         return $this->city;
     }
 
-    public function setTitle($title = null): Location
+    public function setTitle(?string $title = null): Location
     {
         $this->title = $title;
 

--- a/src/Repository/PhotoRepository.php
+++ b/src/Repository/PhotoRepository.php
@@ -291,7 +291,7 @@ class PhotoRepository extends ServiceEntityRepository
     public function findForTimelineRidePhotoCollector(
         ?\DateTime $startDateTime = null,
         ?\DateTime $endDateTime = null,
-        $limit = null
+        ?int $limit = null
     ) {
         $builder = $this->createQueryBuilder('p');
 

--- a/src/Repository/PostRepository.php
+++ b/src/Repository/PostRepository.php
@@ -102,7 +102,7 @@ class PostRepository extends ServiceEntityRepository
     public function findForTimelineThreadPostCollector(
         ?\DateTime $startDateTime = null,
         ?\DateTime $endDateTime = null,
-        $limit = null
+        ?int $limit = null
     ): array {
         $builder = $this->createQueryBuilder('p');
 
@@ -142,7 +142,7 @@ class PostRepository extends ServiceEntityRepository
     public function findForTimelineRideCommentCollector(
         ?\DateTime $startDateTime = null,
         ?\DateTime $endDateTime = null,
-        $limit = null
+        ?int $limit = null
     ): array {
         $builder = $this->createQueryBuilder('p');
 
@@ -180,7 +180,7 @@ class PostRepository extends ServiceEntityRepository
     public function findForTimelinePhotoCommentCollector(
         ?\DateTime $startDateTime = null,
         ?\DateTime $endDateTime = null,
-        $limit = null
+        ?int $limit = null
     ): array {
         $builder = $this->createQueryBuilder('p');
 

--- a/src/Repository/RideEstimateRepository.php
+++ b/src/Repository/RideEstimateRepository.php
@@ -17,7 +17,7 @@ class RideEstimateRepository extends ServiceEntityRepository
     public function findForTimelineRideParticipationEstimateCollector(
         ?\DateTime $startDateTime = null,
         ?\DateTime $endDateTime = null,
-        $limit = null
+        ?int $limit = null
     ): array {
         $builder = $this->createQueryBuilder('e');
 

--- a/src/Repository/ThreadRepository.php
+++ b/src/Repository/ThreadRepository.php
@@ -67,7 +67,7 @@ class ThreadRepository extends ServiceEntityRepository
         return $query->getSingleResult();
     }
 
-    public function findForTimelineThreadCollector(?\DateTime $startDateTime = null, ?\DateTime $endDateTime = null, $limit = null): array
+    public function findForTimelineThreadCollector(?\DateTime $startDateTime = null, ?\DateTime $endDateTime = null, ?int $limit = null): array
     {
         $builder = $this->createQueryBuilder('t');
 

--- a/src/Repository/TrackRepository.php
+++ b/src/Repository/TrackRepository.php
@@ -60,7 +60,7 @@ class TrackRepository extends ServiceEntityRepository
         return $result;
     }
 
-    public function findForTimelineRideTrackCollector(?\DateTime $startDateTime = null, ?\DateTime $endDateTime = null, $limit = null): array
+    public function findForTimelineRideTrackCollector(?\DateTime $startDateTime = null, ?\DateTime $endDateTime = null, ?int $limit = null): array
     {
         $builder = $this->createQueryBuilder('t');
 


### PR DESCRIPTION
## Summary

- Add explicit nullable type hints to all parameters that used implicit nullable types (`$param = null` without `?Type`)
- Implicit nullable parameters were deprecated in PHP 8.4 and emit deprecation notices in PHP 8.5
- Affected: `Location::setTitle()` (`?string`) and `$limit` parameters across 5 repository classes (`?int`)

## Test plan

- [x] Full test suite passes locally (763 tests, 3071 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)