### PR TITLE
Fix TypeError in ViewEntities for anonymous users

### DIFF
--- a/src/Entity/RideView.php
+++ b/src/Entity/RideView.php
@@ -41,7 +41,7 @@ class RideView implements ViewEntity
         return $this;
     }
 
-    public function getUser(): User
+    public function getUser(): ?User
     {
         return $this->user;
     }

--- a/src/Entity/ThreadView.php
+++ b/src/Entity/ThreadView.php
@@ -42,7 +42,7 @@ class ThreadView implements ViewEntity
         return $this->id;
     }
 
-    public function getUser(): User
+    public function getUser(): ?User
     {
         return $this->user;
     }


### PR DESCRIPTION
## Summary

- Fix `getUser()` return type in `RideView` and `ThreadView` from `User` to `?User`
- The `ViewEntity` interface correctly declares `?User`, but these two implementations had a non-nullable return type
- Anonymous page views (user not logged in) caused a runtime `TypeError` because `null` was returned from a method typed as `User`
- `CityView`, `PhotoView`, and `PromotionView` already had the correct `?User` return type

## Production error

```
App\Entity\RideView::getUser(): Return value must be of type App\Entity\User, null returned
```

## Verification

- PHPStan: no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)