### PR TITLE
Modernize search autocomplete

### DIFF
--- a/assets/controllers/search_controller.js
+++ b/assets/controllers/search_controller.js
@@ -8,46 +8,72 @@ export default class extends Controller {
 
     searchResults = [];
     selectedIndex = -1;
+    isLoading = true;
+    boundOnClickOutside = null;
 
     connect() {
+        this.boundOnClickOutside = this.onClickOutside.bind(this);
         this.loadData();
         this.inputTarget.addEventListener('input', this.onInput.bind(this));
         this.inputTarget.addEventListener('keydown', this.onKeydown.bind(this));
-        document.addEventListener('click', this.onClickOutside.bind(this));
+        this.inputTarget.addEventListener('focus', this.onFocus.bind(this));
+        document.addEventListener('click', this.boundOnClickOutside);
     }
 
     disconnect() {
-        document.removeEventListener('click', this.onClickOutside.bind(this));
+        document.removeEventListener('click', this.boundOnClickOutside);
     }
 
     async loadData() {
+        this.isLoading = true;
         try {
             const response = await fetch(this.prefetchUrlValue);
             this.searchResults = await response.json();
         } catch (err) {
             console.warn('Search prefetch failed:', err);
+            this.searchResults = [];
+        }
+        this.isLoading = false;
+    }
+
+    onFocus() {
+        const query = this.inputTarget.value.trim();
+        if (query.length >= 1) {
+            this.performSearch(query);
         }
     }
 
     onInput(event) {
-        const query = event.target.value.toLowerCase().trim();
+        const query = event.target.value.trim();
 
         if (query.length < 1) {
             this.hideResults();
             return;
         }
 
-        const matches = this.searchResults.filter(item =>
-            item.value.toLowerCase().includes(query)
-        ).slice(0, 10);
+        this.performSearch(query);
+    }
 
-        this.showResults(matches);
+    performSearch(query) {
+        if (this.isLoading) {
+            this.showLoading();
+            return;
+        }
+
+        const lowerQuery = query.toLowerCase();
+        const matches = this.searchResults.filter(item =>
+            item.value.toLowerCase().includes(lowerQuery)
+        ).slice(0, 8);
+
+        this.showResults(matches, query);
     }
 
     onKeydown(event) {
         if (!this.hasResultsTarget) return;
+        if (!this.resultsTarget.classList.contains('is-visible')) return;
 
-        const items = this.resultsTarget.querySelectorAll('.search-result-item');
+        const items = this.resultsTarget.querySelectorAll('.search-autocomplete__item');
+        if (items.length === 0) return;
 
         switch (event.key) {
             case 'ArrowDown':
@@ -57,47 +83,157 @@ export default class extends Controller {
                 break;
             case 'ArrowUp':
                 event.preventDefault();
-                this.selectedIndex = Math.max(this.selectedIndex - 1, 0);
+                this.selectedIndex = Math.max(this.selectedIndex - 1, -1);
                 this.updateSelection(items);
                 break;
             case 'Enter':
                 if (this.selectedIndex >= 0 && items[this.selectedIndex]) {
-                    const link = items[this.selectedIndex].querySelector('a');
-                    if (link) window.location.href = link.href;
+                    event.preventDefault();
+                    const url = items[this.selectedIndex].dataset.url;
+                    if (url) window.location.href = url;
                 }
                 break;
             case 'Escape':
                 this.hideResults();
+                this.inputTarget.blur();
                 break;
         }
     }
 
     updateSelection(items) {
         items.forEach((item, index) => {
-            item.classList.toggle('active', index === this.selectedIndex);
+            item.classList.toggle('is-selected', index === this.selectedIndex);
+            if (index === this.selectedIndex) {
+                item.scrollIntoView({ block: 'nearest' });
+            }
         });
     }
 
-    showResults(matches) {
+    showLoading() {
+        if (!this.hasResultsTarget) return;
+
+        this.resultsTarget.innerHTML = `
+            <div class="search-autocomplete__loading">
+                <div class="spinner mx-auto"></div>
+            </div>
+        `;
+        this.resultsTarget.classList.add('is-visible');
+    }
+
+    showResults(matches, query) {
         if (!this.hasResultsTarget) return;
 
         this.selectedIndex = -1;
 
         if (matches.length === 0) {
-            this.hideResults();
+            this.showEmpty(query);
             return;
         }
 
-        const html = matches.map(item => this.renderSuggestion(item)).join('');
+        // Group results by type
+        const cities = matches.filter(m => m.type === 'city');
+        const rides = matches.filter(m => m.type === 'ride');
+        const content = matches.filter(m => m.type === 'content');
+
+        let html = '';
+
+        if (cities.length > 0) {
+            html += this.renderGroup('Staedte', cities);
+        }
+
+        if (rides.length > 0) {
+            html += this.renderGroup('Touren', rides);
+        }
+
+        if (content.length > 0) {
+            html += this.renderGroup('Inhalte', content);
+        }
+
+        html += this.renderFooter();
+
         this.resultsTarget.innerHTML = html;
-        this.resultsTarget.classList.remove('d-none');
+        this.resultsTarget.classList.add('is-visible');
+    }
+
+    renderGroup(title, items) {
+        return `
+            <div class="search-autocomplete__group">
+                <div class="search-autocomplete__group-header">${title}</div>
+                ${items.map(item => this.renderItem(item)).join('')}
+            </div>
+        `;
+    }
+
+    renderItem(data) {
+        const iconClass = this.getIconClass(data.type);
+        const icon = this.getIcon(data.type);
+
+        let metaHtml = '';
+        if (data.type === 'ride' && data.meta) {
+            const metaParts = [];
+            if (data.meta.dateTime) {
+                const dateTime = new Date(data.meta.dateTime);
+                const dateStr = dateTime.toLocaleDateString('de-DE', {
+                    weekday: 'short',
+                    day: 'numeric',
+                    month: 'short'
+                });
+                const timeStr = dateTime.toLocaleTimeString('de-DE', {
+                    hour: '2-digit',
+                    minute: '2-digit'
+                });
+                metaParts.push(`<i class="far fa-calendar-alt"></i> ${dateStr}, ${timeStr}`);
+            }
+            if (data.meta.location) {
+                metaParts.push(`<i class="far fa-map-marker-alt"></i> ${this.escapeHtml(data.meta.location)}`);
+            }
+            if (metaParts.length > 0) {
+                metaHtml = `<div class="search-autocomplete__item-meta">${metaParts.join(' ')}</div>`;
+            }
+        }
+
+        return `
+            <a href="${data.url}" class="search-autocomplete__item" data-url="${data.url}">
+                <div class="d-flex align-items-center">
+                    <span class="search-autocomplete__item-icon ${iconClass}">
+                        <i class="${icon}"></i>
+                    </span>
+                    <div class="search-autocomplete__item-content">
+                        <div class="search-autocomplete__item-title">${this.escapeHtml(data.value)}</div>
+                        ${metaHtml}
+                    </div>
+                </div>
+            </a>
+        `;
+    }
+
+    renderFooter() {
+        return `
+            <div class="search-autocomplete__footer">
+                <span><kbd class="search-autocomplete__kbd">↑</kbd><kbd class="search-autocomplete__kbd">↓</kbd> Navigation</span>
+                <span><kbd class="search-autocomplete__kbd">↵</kbd> Oeffnen</span>
+                <span><kbd class="search-autocomplete__kbd">esc</kbd> Schliessen</span>
+            </div>
+        `;
+    }
+
+    showEmpty(query) {
+        if (!this.hasResultsTarget) return;
+
+        this.resultsTarget.innerHTML = `
+            <div class="search-autocomplete__empty">
+                <i class="far fa-search"></i>
+                <p>Keine Ergebnisse fuer "${this.escapeHtml(query)}"</p>
+            </div>
+        `;
+        this.resultsTarget.classList.add('is-visible');
     }
 
     hideResults() {
         if (this.hasResultsTarget) {
-            this.resultsTarget.classList.add('d-none');
-            this.resultsTarget.innerHTML = '';
+            this.resultsTarget.classList.remove('is-visible');
         }
+        this.selectedIndex = -1;
     }
 
     onClickOutside(event) {
@@ -106,27 +242,27 @@ export default class extends Controller {
         }
     }
 
-    renderSuggestion(data) {
-        let html = '<div class="search-result-item p-2">';
+    getIconClass(type) {
+        const classes = {
+            city: 'search-autocomplete__item-icon--city',
+            ride: 'search-autocomplete__item-icon--ride',
+            content: 'search-autocomplete__item-icon--content'
+        };
+        return classes[type] || '';
+    }
 
-        if (data.type === 'city') {
-            html += `<a href="${data.url}"><i class="far fa-university"></i> ${data.value}</a>`;
-        } else if (data.type === 'ride') {
-            html += `<a href="${data.url}">`;
-            html += `<div><i class="far fa-bicycle"></i> ${data.value}</div>`;
-            if (data.meta?.location) {
-                html += `<div class="small text-muted">${data.meta.location}</div>`;
-            }
-            if (data.meta?.dateTime) {
-                const dateTime = new Date(data.meta.dateTime);
-                html += `<div class="small text-muted">${dateTime.toLocaleDateString('de-DE')} ${dateTime.toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' })} Uhr</div>`;
-            }
-            html += '</a>';
-        } else if (data.type === 'content') {
-            html += `<a href="${data.url}"><i class="far fa-file-text"></i> ${data.value}</a>`;
-        }
+    getIcon(type) {
+        const icons = {
+            city: 'far fa-city',
+            ride: 'far fa-bicycle',
+            content: 'far fa-file-alt'
+        };
+        return icons[type] || 'far fa-circle';
+    }
 
-        html += '</div>';
-        return html;
+    escapeHtml(text) {
+        const div = document.createElement('div');
+        div.textContent = text;
+        return div.innerHTML;
     }
 }

--- a/assets/scss/criticalmass/_search.scss
+++ b/assets/scss/criticalmass/_search.scss
@@ -1,14 +1,308 @@
-body {
-  .tt-dataset {
-    max-width: 320px;
-    min-width: 160px;
-    background-color: white;
-    border: 1px solid rgba(0, 0, 0, 0.15);
-    box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+// Modern Search Autocomplete Styles
 
-    .tt-cursor {
-      color: #333333;
-      background-color: whitesmoke;
+.search-autocomplete {
+  position: relative;
+
+  &__input {
+    border-radius: 8px;
+    padding: 0.625rem 1rem;
+    padding-left: 2.5rem;
+    border: 2px solid transparent;
+    background-color: rgba(255, 255, 255, 0.1);
+    color: inherit;
+    transition: all 0.2s ease;
+    font-size: 0.9375rem;
+
+    &::placeholder {
+      color: rgba(255, 255, 255, 0.6);
     }
+
+    &:focus {
+      outline: none;
+      background-color: white;
+      border-color: #48bb78;
+      color: #1a202c;
+      box-shadow: 0 0 0 3px rgba(72, 187, 120, 0.15);
+
+      &::placeholder {
+        color: #a0aec0;
+      }
+    }
+  }
+
+  &__icon {
+    position: absolute;
+    left: 0.875rem;
+    top: 50%;
+    transform: translateY(-50%);
+    color: rgba(255, 255, 255, 0.6);
+    pointer-events: none;
+    transition: color 0.2s ease;
+    z-index: 1;
+  }
+
+  &__input:focus ~ &__icon,
+  &__input:focus + &__icon {
+    color: #48bb78;
+  }
+
+  &__results {
+    position: absolute;
+    top: calc(100% + 8px);
+    left: 0;
+    right: 0;
+    background: white;
+    border-radius: 12px;
+    box-shadow:
+      0 4px 6px -1px rgba(0, 0, 0, 0.1),
+      0 10px 15px -3px rgba(0, 0, 0, 0.1),
+      0 20px 25px -5px rgba(0, 0, 0, 0.1);
+    border: 1px solid rgba(0, 0, 0, 0.05);
+    overflow: hidden;
+    z-index: 1050;
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(-8px);
+    transition: all 0.2s ease;
+    max-height: 400px;
+    overflow-y: auto;
+
+    &.is-visible {
+      opacity: 1;
+      visibility: visible;
+      transform: translateY(0);
+    }
+
+    // Custom scrollbar
+    &::-webkit-scrollbar {
+      width: 6px;
+    }
+
+    &::-webkit-scrollbar-track {
+      background: transparent;
+    }
+
+    &::-webkit-scrollbar-thumb {
+      background: #cbd5e0;
+      border-radius: 3px;
+    }
+  }
+
+  &__group {
+    &:not(:first-child) {
+      border-top: 1px solid #e2e8f0;
+    }
+  }
+
+  &__group-header {
+    padding: 0.5rem 1rem;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #718096;
+    background: #f7fafc;
+  }
+
+  &__item {
+    display: block;
+    padding: 0.75rem 1rem;
+    color: #1a202c;
+    text-decoration: none;
+    transition: background-color 0.15s ease;
+    cursor: pointer;
+    border-left: 3px solid transparent;
+
+    &:hover,
+    &.is-selected {
+      background-color: #f0fff4;
+      border-left-color: #48bb78;
+    }
+
+    &:active {
+      background-color: #c6f6d5;
+    }
+  }
+
+  &__item-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 2rem;
+    border-radius: 8px;
+    margin-right: 0.75rem;
+    flex-shrink: 0;
+    font-size: 0.875rem;
+
+    &--city {
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      color: white;
+    }
+
+    &--ride {
+      background: linear-gradient(135deg, #48bb78 0%, #38a169 100%);
+      color: white;
+    }
+
+    &--content {
+      background: linear-gradient(135deg, #ed8936 0%, #dd6b20 100%);
+      color: white;
+    }
+  }
+
+  &__item-content {
+    flex: 1;
+    min-width: 0;
+  }
+
+  &__item-title {
+    font-weight: 500;
+    color: #1a202c;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-size: 0.9375rem;
+  }
+
+  &__item-meta {
+    font-size: 0.8125rem;
+    color: #718096;
+    margin-top: 0.125rem;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+
+    i {
+      font-size: 0.75rem;
+      opacity: 0.7;
+    }
+  }
+
+  &__empty {
+    padding: 2rem 1rem;
+    text-align: center;
+    color: #718096;
+
+    i {
+      font-size: 2rem;
+      margin-bottom: 0.5rem;
+      opacity: 0.5;
+    }
+
+    p {
+      margin: 0;
+      font-size: 0.875rem;
+    }
+  }
+
+  &__loading {
+    padding: 1.5rem 1rem;
+    text-align: center;
+    color: #718096;
+
+    .spinner {
+      width: 1.5rem;
+      height: 1.5rem;
+      border: 2px solid #e2e8f0;
+      border-top-color: #48bb78;
+      border-radius: 50%;
+      animation: spin 0.8s linear infinite;
+    }
+  }
+
+  &__kbd {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.25rem;
+    height: 1.25rem;
+    padding: 0 0.375rem;
+    font-size: 0.6875rem;
+    font-family: inherit;
+    font-weight: 500;
+    color: #718096;
+    background: #edf2f7;
+    border: 1px solid #e2e8f0;
+    border-radius: 4px;
+    margin-left: 0.25rem;
+  }
+
+  &__footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.5rem 1rem;
+    background: #f7fafc;
+    border-top: 1px solid #e2e8f0;
+    font-size: 0.75rem;
+    color: #718096;
+
+    span {
+      display: flex;
+      align-items: center;
+      gap: 0.25rem;
+    }
+  }
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+// Dark navbar adjustments
+.navbar-dark .search-autocomplete {
+  &__input {
+    background-color: rgba(255, 255, 255, 0.1);
+    color: white;
+
+    &::placeholder {
+      color: rgba(255, 255, 255, 0.6);
+    }
+
+    &:focus {
+      background-color: white;
+      color: #1a202c;
+
+      &::placeholder {
+        color: #a0aec0;
+      }
+    }
+  }
+
+  &__icon {
+    color: rgba(255, 255, 255, 0.6);
+  }
+
+  &__input:focus ~ &__icon {
+    color: #48bb78;
+  }
+}
+
+// Light navbar adjustments
+.navbar-light .search-autocomplete {
+  &__input {
+    background-color: #f7fafc;
+    color: #1a202c;
+    border-color: #e2e8f0;
+
+    &::placeholder {
+      color: #a0aec0;
+    }
+
+    &:focus {
+      background-color: white;
+      border-color: #48bb78;
+    }
+  }
+
+  &__icon {
+    color: #a0aec0;
+  }
+
+  &__input:focus ~ &__icon {
+    color: #48bb78;
   }
 }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "npm": "^8.19.2",
     "polyline-encoded": "0.0.8",
     "requirejs": "^2.3.7",
-    "typeahead.js": "^0.11.1",
     "webpack-cli": "^5.1.4"
   },
   "packageManager": "yarn@3.4.1"

--- a/templates/Template/Navigation/_navbar_search.html.twig
+++ b/templates/Template/Navigation/_navbar_search.html.twig
@@ -1,13 +1,13 @@
-<form class="d-flex ms-auto position-relative" role="search"
+<form class="search-autocomplete" role="search"
       action="{{ path('caldera_criticalmass_search_query') }}"
       data-controller="search">
-    <input id="search-input" type="text" class="form-control me-2"
+    <i class="far fa-search search-autocomplete__icon"></i>
+    <input type="text"
+           class="form-control search-autocomplete__input"
            placeholder="{% trans %}criticalmass.navigation.search.search{% endtrans %}"
            name="query"
            data-search-target="input"
-           autocomplete="off"/>
-    <div class="dropdown-menu position-absolute w-100 d-none" style="top: 100%;" data-search-target="results"></div>
-    <button type="submit" class="btn btn-success">
-        {% trans %}criticalmass.navigation.search.search{% endtrans %}
-    </button>
+           autocomplete="off"
+           aria-label="{% trans %}criticalmass.navigation.search.search{% endtrans %}"/>
+    <div class="search-autocomplete__results" data-search-target="results"></div>
 </form>


### PR DESCRIPTION
## Summary
- Ersetzt die alte Typeahead-basierte Suche durch eine moderne Stimulus-Loesung
- Gruppiert Suchergebnisse nach Typ (Staedte, Touren, Inhalte) mit farblich codierten Icons
- Fuegt Tastaturnavigation hinzu mit visuellen Hinweisen (Pfeiltasten, Enter, Escape)
- Zeigt Ladezustand mit Spinner waehrend des Datenabrufs
- Verwendet sanfte CSS-Animationen fuer die Dropdown-Anzeige
- Entfernt unbenutzte typeahead.js Abhaengigkeit

## Test plan
- [ ] Suche im Browser testen - Eingabe in das Suchfeld sollte gruppierte Ergebnisse zeigen
- [ ] Tastaturnavigation pruefen (Pfeiltasten navigieren, Enter oeffnet, Escape schliesst)
- [ ] Ladezustand beim ersten Oeffnen pruefen (Spinner waehrend prefetch)
- [ ] Mobile Ansicht pruefen (Responsive Styling)

🤖 Generated with [Claude Code](https://claude.ai/code)