### PR TITLE
Fix query-map controller data attributes in Region and Promotion templates

### DIFF
--- a/templates/Promotion/index.html.twig
+++ b/templates/Promotion/index.html.twig
@@ -11,9 +11,9 @@
                         class="map"
                         id="promotion-map"
                         data-controller="map--query-map"
-                        data-map--popup-template-id-value="ride-popup"
-                        data-map--api-type-value="ride"
-                        data-map--api-query-value="{{ path('caldera_criticalmass_rest_ride_list') ~ '?' ~ promotion.query|raw }}&extended=true"
+                        data-map--query-map-popup-template-id-value="ride-popup"
+                        data-map--query-map-api-type-value="ride"
+                        data-map--query-map-api-query-value="{{ path('caldera_criticalmass_rest_ride_list') ~ '?' ~ promotion.query|raw }}&extended=true"
                         style="height: 350px;"
                     ></div>
                 </div>

--- a/templates/Region/index.html.twig
+++ b/templates/Region/index.html.twig
@@ -45,8 +45,8 @@
                          id="region-map"
                          data-controller="map--query-map"
                          style="height: 350px;"
-                         data-map--api-type-value="city"
-                         data-map--api-query-value="{{ path('caldera_criticalmass_rest_city_list', { regionSlug: region.slug, size: 500 }) }}">
+                         data-map--query-map-api-type-value="city"
+                         data-map--query-map-api-query-value="{{ path('caldera_criticalmass_rest_city_list', { regionSlug: region.slug, size: 500 }) }}">
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- Fixes map not rendering on Region index pages (directory)
- Fixes map not rendering on Promotion pages

## Problem
The Stimulus data attributes were using incorrect naming convention. For controller `map--query-map`, attributes must be prefixed with `data-map--query-map-` not just `data-map--`.

## Changes
- `data-map--api-type-value` → `data-map--query-map-api-type-value`
- `data-map--api-query-value` → `data-map--query-map-api-query-value`
- `data-map--popup-template-id-value` → `data-map--query-map-popup-template-id-value`

🤖 Generated with [Claude Code](https://claude.ai/code)