### PR TITLE
Fix ride API response size by applying serializer groups

### DIFF
--- a/src/Controller/Api/RideController.php
+++ b/src/Controller/Api/RideController.php
@@ -160,7 +160,7 @@ class RideController extends BaseController
             $groups[] = 'extended-ride-list';
         }
 
-        return $this->createStandardResponse($rideList);
+        return $this->createStandardResponse($rideList, ['groups' => $groups]);
     }
 
     /**

--- a/src/Entity/Region.php
+++ b/src/Entity/Region.php
@@ -7,6 +7,7 @@ use App\EntityInterface\RouteableInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Annotation\Ignore;
 
 #[ORM\Table(name: 'region')]
 #[ORM\Entity(repositoryClass: 'App\Repository\RegionRepository')]
@@ -28,12 +29,15 @@ class Region implements RouteableInterface, AuditableInterface
 
     #[ORM\ManyToOne(targetEntity: 'Region', inversedBy: 'children', cascade: ['persist'])]
     #[ORM\JoinColumn(name: 'parent_id', referencedColumnName: 'id')]
+    #[Ignore]
     protected ?Region $parent = null;
 
     #[ORM\OneToMany(targetEntity: 'Region', mappedBy: 'parent')]
+    #[Ignore]
     protected Collection $children;
 
     #[ORM\OneToMany(targetEntity: 'City', mappedBy: 'region')]
+    #[Ignore]
     protected Collection $cities;
 
     #[ORM\Column(type: 'string', length: 255, nullable: true)]


### PR DESCRIPTION
## Summary

The ride list API at `/api/ride` was returning massive JSON responses (~380KB) including:
- Deeply nested region hierarchies (World → Europe → Germany → Hamburg)
- All city relations with their social network profiles
- Cycle relations

This was caused by the serializer groups (`ride-list`, `extended-ride-list`) not being passed to the serializer in `RideController::listAction()`.

## Changes

- **RideController.php**: Pass `$groups` array to `createStandardResponse()` (was being built but not used)
- **Region.php**: Add `#[Ignore]` to `parent`, `children`, and `cities` relations to prevent recursive/deep nesting
- **RideApiSchemaTest.php**: Add tests verifying:
  - Ride list excludes `city`, `cycle`, `tracks` relations
  - Extended view doesn't include deeply nested region hierarchy

## Impact

Response size reduction from ~380KB to ~1KB for typical queries like:
```
GET /api/ride?citySlug=hamburg&year=2024
```

## Test plan
- [x] All 409 API tests pass
- [x] New schema tests verify correct serialization groups
- [ ] Manual verification on production after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)