### PR TITLE
Remove unused incenteev/composer-parameter-handler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
         "knplabs/knp-paginator-bundle": "^5.0",
         "emcconville/google-map-polyline-encoding-tool": ">=1.2.1",
         "symfony/monolog-bundle": "^3.3",
-        "incenteev/composer-parameter-handler": "^2.0",
         "hwi/oauth-bundle": "^2.2",
         "malenki/slug": "1.0.0",
         "sonata-project/intl-bundle": "^2.3",
@@ -153,9 +152,6 @@
         "symfony-web-dir": "web",
         "symfony-tests-dir": "tests",
         "symfony-assets-install": "relative",
-        "incenteev-parameters": {
-            "file": "app/config/parameters.yml"
-        },
         "branch-alias": {
             "dev-master": "3.0-dev"
         }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fd9ce43d2034740dd624585e8e302072",
+    "content-hash": "75823e42c8163c32f687d469cd72c16b",
     "packages": [
         {
             "name": "beberlei/doctrineextensions",
@@ -2831,63 +2831,6 @@
                 "source": "https://github.com/php-imagine/Imagine/tree/1.5.2"
             },
             "time": "2026-01-09T10:45:12+00:00"
-        },
-        {
-            "name": "incenteev/composer-parameter-handler",
-            "version": "v2.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Incenteev/ParameterHandler.git",
-                "reference": "4d9a7c72322daaa11343fb885c15dc3fa096e3ac"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Incenteev/ParameterHandler/zipball/4d9a7c72322daaa11343fb885c15dc3fa096e3ac",
-                "reference": "4d9a7c72322daaa11343fb885c15dc3fa096e3ac",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.4",
-                "symfony/yaml": "^5.4 || ^6.0 || ^7.0 || ^8.0"
-            },
-            "require-dev": {
-                "composer/composer": "^2.0@dev",
-                "phpspec/prophecy-phpunit": "^2.1",
-                "phpunit/phpunit": "^9.6",
-                "symfony/filesystem": "^5.4 || ^6.0 || ^7.0 || ^8.0",
-                "symfony/phpunit-bridge": "^6.4.1 || ^7.0.1 || ^8.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Incenteev\\ParameterHandler\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Christophe Coevoet",
-                    "email": "stof@notk.org"
-                }
-            ],
-            "description": "Composer script handling your ignored parameter file",
-            "homepage": "https://github.com/Incenteev/ParameterHandler",
-            "keywords": [
-                "parameters management"
-            ],
-            "support": {
-                "issues": "https://github.com/Incenteev/ParameterHandler/issues",
-                "source": "https://github.com/Incenteev/ParameterHandler/tree/v2.3.0"
-            },
-            "time": "2025-11-26T14:10:46+00:00"
         },
         {
             "name": "jaybizzle/crawler-detect",
@@ -15966,5 +15909,5 @@
         "ext-zip": "*"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
## Summary

- Remove `incenteev/composer-parameter-handler` from composer dependencies
- Remove obsolete `incenteev-parameters` configuration from `extra` section
- This package handled parameter management for Symfony 3 (`app/config/parameters.yml`), which no longer exists in the current Symfony 7 project structure

## Test plan

- [ ] Run `composer install` to verify dependency resolution still works
- [ ] Verify application boots without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)