### PR TITLE
Remove unused sunra/php-simple-html-dom-parser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,6 @@
         "php-http/message": "^1.6",
         "symfony/security-bundle": "^6.0",
         "symfony/apache-pack": "^1.0",
-        "sunra/php-simple-html-dom-parser": "^1.5",
         "symfony/flex": "^1.0",
         "khill/php-duration": "^1.0",
         "sabre/vobject": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "75823e42c8163c32f687d469cd72c16b",
+    "content-hash": "8d15d64522bf96ec5c6f0168ae70855b",
     "packages": [
         {
             "name": "beberlei/doctrineextensions",
@@ -6805,58 +6805,6 @@
                 }
             ],
             "time": "2025-12-16T16:56:46+00:00"
-        },
-        {
-            "name": "sunra/php-simple-html-dom-parser",
-            "version": "v1.5.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sunra/php-simple-html-dom-parser.git",
-                "reference": "75b9b1cb64502d8f8c04dc11b5906b969af247c6"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sunra/php-simple-html-dom-parser/zipball/75b9b1cb64502d8f8c04dc11b5906b969af247c6",
-                "reference": "75b9b1cb64502d8f8c04dc11b5906b969af247c6",
-                "shasum": ""
-            },
-            "require": {
-                "ext-mbstring": "*",
-                "php": ">=5.3.2"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "Sunra\\PhpSimple\\HtmlDomParser": "Src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Sunra",
-                    "email": "sunra@yandex.ru",
-                    "homepage": "https://github.com/sunra"
-                },
-                {
-                    "name": "S.C. Chen",
-                    "homepage": "http://sourceforge.net/projects/simplehtmldom/"
-                }
-            ],
-            "description": "Composer adaptation of: A HTML DOM parser written in PHP5+ let you manipulate HTML in a very easy way! Require PHP 5+. Supports invalid HTML. Find tags on an HTML page with selectors just like jQuery. Extract contents from HTML in a single line.",
-            "homepage": "https://github.com/sunra/php-simple-html-dom-parser",
-            "keywords": [
-                "dom",
-                "html",
-                "parser"
-            ],
-            "support": {
-                "issues": "https://github.com/sunra/php-simple-html-dom-parser/issues",
-                "source": "https://github.com/sunra/php-simple-html-dom-parser/tree/master"
-            },
-            "time": "2016-11-22T22:57:47+00:00"
         },
         {
             "name": "symfony/apache-pack",


### PR DESCRIPTION
## Summary

- Remove `sunra/php-simple-html-dom-parser` from composer dependencies
- This HTML DOM parser library is not imported or referenced anywhere in the codebase (no `use` statements, no service configuration)

## Test plan

- [ ] Run `composer install` to verify dependency resolution still works
- [ ] Verify application boots without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)