### PR TITLE
Remove phpdocumentor/reflection-docblock from require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -80,7 +80,6 @@
         "symfony/property-access": "^5.0",
         "symfony/runtime": "^6.0",
         "symfony/stimulus-bundle": "^2.25",
-        "phpdocumentor/reflection-docblock": "^5.6",
         "phpstan/phpdoc-parser": "^2.1",
         "symfony/property-access": "^6.0",
         "symfony/property-info": "^6.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fd39d418aa691a71538f8cc0d59469d2",
+    "content-hash": "de2d3cffc4f34c6091456247b5aab994",
     "packages": [
         {
             "name": "beberlei/doctrineextensions",


### PR DESCRIPTION
## Summary

- Remove `phpdocumentor/reflection-docblock` from explicit `require` in composer.json
- The package is not directly imported or used anywhere in the codebase
- It remains available as a transitive dependency via `nelmio/api-doc-bundle` which requires it

## Test plan

- [ ] Run `composer install` to verify dependency resolution still works
- [ ] Verify application boots without errors
- [ ] Verify API documentation generation still works (nelmio/api-doc-bundle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)