### PR TITLE
Remove phpstan/phpdoc-parser from require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -80,7 +80,6 @@
         "symfony/property-access": "^5.0",
         "symfony/runtime": "^6.0",
         "symfony/stimulus-bundle": "^2.25",
-        "phpstan/phpdoc-parser": "^2.1",
         "symfony/property-access": "^6.0",
         "symfony/property-info": "^6.0",
         "symfony/serializer": "^6.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "de2d3cffc4f34c6091456247b5aab994",
+    "content-hash": "290d5321199963d7fe2b01b91e89fa41",
     "packages": [
         {
             "name": "beberlei/doctrineextensions",


### PR DESCRIPTION
## Summary

- Remove `phpstan/phpdoc-parser` from explicit `require` in composer.json
- The package is not directly imported or used anywhere in the application code
- It remains available as a transitive dependency via `phpdocumentor/reflection-docblock`

## Test plan

- [ ] Run `composer install` to verify dependency resolution still works
- [ ] Verify application boots without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)