### PR TITLE
Fix XXE vulnerabilities in XML parsing

### DIFF
--- a/src/Criticalmass/CriticalmassBlog/CriticalmassBlog.php
+++ b/src/Criticalmass/CriticalmassBlog/CriticalmassBlog.php
@@ -9,7 +9,7 @@ class CriticalmassBlog implements CriticalmassBlogInterface
     public function getArticles(): array
     {
         try {
-            $xml = @simplexml_load_file(static::BLOG_FEED_URL, 'SimpleXMLElement', LIBXML_NOCDATA);
+            $xml = @simplexml_load_file(static::BLOG_FEED_URL, 'SimpleXMLElement', LIBXML_NOCDATA | LIBXML_NONET | LIBXML_NOENT);
 
             if (!$xml || !isset($xml->channel->item)) {
                 return [];

--- a/src/Criticalmass/UploadValidator/TrackValidator.php
+++ b/src/Criticalmass/UploadValidator/TrackValidator.php
@@ -45,7 +45,7 @@ class TrackValidator implements UploadValidatorInterface
     {
         //echo "checkForXmlContent";
         try {
-            $this->simpleXml = new \SimpleXMLElement($this->rawFileContent);
+            $this->simpleXml = new \SimpleXMLElement($this->rawFileContent, LIBXML_NONET | LIBXML_NOENT);
         } catch (Exception $e) {
             throw new NoXmlException();
         }


### PR DESCRIPTION
## Summary
- Add `LIBXML_NONET` and `LIBXML_NOENT` flags to `simplexml_load_file()` in `CriticalmassBlog.php` to prevent external entity loading
- Add `LIBXML_NONET` and `LIBXML_NOENT` flags to `SimpleXMLElement` constructor in `TrackValidator.php` to prevent XXE via malicious GPX uploads

## Test plan
- [ ] Verify blog feed still loads correctly
- [ ] Upload a GPX track and verify validation still works
- [ ] Verify that XXE payloads in GPX files are rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)