### PR TITLE
Fix XSS vulnerabilities in Twig templates

### DIFF
--- a/templates/City/ride_list.html.twig
+++ b/templates/City/ride_list.html.twig
@@ -26,7 +26,7 @@
             <div class="row">
                 <div class="col-md-12">
                     <div class="alert alert-success">
-                        {{ message|raw }}
+                        {{ message }}
                     </div>
                 </div>
             </div>

--- a/templates/PhotoGallery/example_gallery.html.twig
+++ b/templates/PhotoGallery/example_gallery.html.twig
@@ -20,7 +20,7 @@
 
         {% set cityString = '' %}
         {% for city in cities %}
-            {% set cityString = cityString ~ '<a href="' ~ object_path(city) ~ '">' ~ city.city ~ '</a>' %}
+            {% set cityString = cityString ~ '<a href="' ~ object_path(city) ~ '">' ~ city.city|e ~ '</a>' %}
 
             {% if loop.revindex0 > 1 %}
                 {% set cityString = cityString ~ ', ' %}

--- a/templates/PhotoManagement/city_gallery.html.twig
+++ b/templates/PhotoManagement/city_gallery.html.twig
@@ -20,7 +20,7 @@
 
         {% set cityString = '' %}
         {% for city in cities %}
-            {% set cityString = cityString ~ '<a href="' ~ object_path(city) ~ '">' ~ city.city ~ '</a>' %}
+            {% set cityString = cityString ~ '<a href="' ~ object_path(city) ~ '">' ~ city.city|e ~ '</a>' %}
 
             {% if loop.revindex0 > 1 %}
                 {% set cityString = cityString ~ ', ' %}

--- a/templates/Promotion/index.html.twig
+++ b/templates/Promotion/index.html.twig
@@ -13,7 +13,7 @@
                         data-controller="map--query-map"
                         data-map--query-map-popup-template-id-value="ride-popup"
                         data-map--query-map-api-type-value="ride"
-                        data-map--query-map-api-query-value="{{ path('caldera_criticalmass_rest_ride_list') ~ '?' ~ promotion.query|raw }}&extended=true"
+                        data-map--query-map-api-query-value="{{ path('caldera_criticalmass_rest_ride_list') ~ '?' ~ promotion.query }}&amp;extended=true"
                         style="height: 350px;"
                     ></div>
                 </div>

--- a/templates/SocialNetwork/list_city_items.html.twig
+++ b/templates/SocialNetwork/list_city_items.html.twig
@@ -49,7 +49,7 @@
                             </h3>
 
                             <p>
-                                {{ item.text|trim_intro|raw }}
+                                {{ item.text|trim_intro }}
                             </p>
 
                             <p class="text-right">

--- a/templates/Template/Includes/_alerts.html.twig
+++ b/templates/Template/Includes/_alerts.html.twig
@@ -5,7 +5,7 @@
                 {% for alert in alertList %}
                     <div class="alert alert-{{ alert.type }}">
                         <strong>{{ alert.title }}</strong>
-                        {{ alert.message|raw|nl2br }}
+                        {{ alert.message|nl2br }}
                     </div>
                 {% endfor %}
             </div>

--- a/templates/Timeline/Items/socialNetworkFeed.html.twig
+++ b/templates/Timeline/Items/socialNetworkFeed.html.twig
@@ -58,7 +58,7 @@
             <div class="row">
                 <div class="col-md-12">
                     <p>
-                        {{ item.socialNetworkFeedItem.text|trim_intro|raw }}
+                        {{ item.socialNetworkFeedItem.text|trim_intro }}
                     </p>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- Remove `|raw` from alert messages in `_alerts.html.twig` — use `|nl2br` only (auto-escapes)
- Remove `|raw` from flash messages in `ride_list.html.twig`
- Remove `|raw` from promotion query in `index.html.twig` — use default escaping
- Remove unnecessary `|raw` after `|trim_intro` (which already calls `strip_tags`) in social network feed templates
- Escape `city.city` in gallery template string concatenation

## Test plan
- [ ] Verify alerts display correctly with HTML entities properly escaped
- [ ] Verify flash messages on ride list page render safely
- [ ] Verify promotion map loads with properly escaped query parameters
- [ ] Verify social network feed items display correctly
- [ ] Verify photo gallery city links render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)