### PR TITLE
Fix open redirect vulnerabilities

### DIFF
--- a/src/Controller/Photo/PhotoManagementController.php
+++ b/src/Controller/Photo/PhotoManagementController.php
@@ -255,6 +255,10 @@ class PhotoManagementController extends AbstractController
     {
         $referer = $request->headers->get('referer');
 
+        if ($referer && !$this->isLocalUrl($referer, $request)) {
+            $referer = '/';
+        }
+
         $request->getSession()->set('referer', $referer);
 
         return $referer;
@@ -269,10 +273,21 @@ class PhotoManagementController extends AbstractController
     {
         $referer = $this->getSavedReferer($request);
 
-        if (!$referer) {
-            throw new \Exception('No saved referer found to redirect to.');
+        if (!$referer || !$this->isLocalUrl($referer, $request)) {
+            return new RedirectResponse('/');
         }
 
         return new RedirectResponse($referer);
+    }
+
+    private function isLocalUrl(string $url, Request $request): bool
+    {
+        $parsedUrl = parse_url($url);
+
+        if (!isset($parsedUrl['host'])) {
+            return true;
+        }
+
+        return $parsedUrl['host'] === $request->getHost();
     }
 }

--- a/src/Controller/RedirectingController.php
+++ b/src/Controller/RedirectingController.php
@@ -22,6 +22,10 @@ class RedirectingController extends AbstractController
 
         $url = str_replace($pathInfo, rtrim($pathInfo, ' /'), $requestUri);
 
+        if (str_starts_with($url, '//') || str_contains($url, '://')) {
+            $url = '/';
+        }
+
         return $this->redirect($url, RedirectResponse::HTTP_MOVED_PERMANENTLY);
     }
 }


### PR DESCRIPTION
## Summary
- Validate referer-based redirects in `PhotoManagementController` against the current host
- Reject protocol-relative and absolute external URLs in `RedirectingController`
- Fall back to `/` when redirect target is invalid

## Test plan
- [ ] Verify photo management referer redirect works for same-host URLs
- [ ] Verify external referer URLs are rejected and redirect to `/`
- [ ] Verify trailing slash removal still works for normal URLs
- [ ] Verify protocol-relative URLs (`//evil.com`) are blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)