### PR TITLE
Harden session cookie configuration

### DIFF
--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -26,6 +26,9 @@ framework:
     session:
         handler_id:  session.handler.native_file
         save_path:   '%kernel.project_dir%/../var/sessions/%kernel.environment%'
+        cookie_secure: auto
+        cookie_httponly: true
+        cookie_samesite: lax
     fragments:
         path: /_fragment
     http_method_override: true


### PR DESCRIPTION
## Summary
- Add `cookie_secure: auto` — sends cookies only over HTTPS in production
- Add `cookie_httponly: true` — prevents JavaScript access to session cookie
- Add `cookie_samesite: lax` — prevents CSRF via cross-origin requests

## Test plan
- [ ] Verify session works correctly in development (HTTP)
- [ ] Verify session cookies are set with Secure flag on HTTPS
- [ ] Verify session cookies have HttpOnly flag
- [ ] Verify SameSite=Lax is set on session cookie

🤖 Generated with [Claude Code](https://claude.com/claude-code)