### PR TITLE
Add file upload MIME type validation

### DIFF
--- a/src/Entity/Photo.php
+++ b/src/Entity/Photo.php
@@ -20,6 +20,7 @@ use MalteHuebner\DataQueryBundle\Attribute\EntityAttribute as DataQuery;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Serializer\Annotation\Ignore;
+use Symfony\Component\Validator\Constraints as Assert;
 use Vich\UploaderBundle\Mapping\Annotation as Vich;
 
 #[Vich\Uploadable]
@@ -87,6 +88,7 @@ class Photo implements FakeUploadable, ManipulateablePhotoInterface, RouteableIn
     protected ?\DateTime $creationDateTime = null;
 
     #[Vich\UploadableField(mapping: 'photo_photo', fileNameProperty: 'imageName', size: 'imageSize', mimeType: 'imageMimeType')]
+    #[Assert\File(maxSize: '30M', mimeTypes: ['image/jpeg', 'image/png', 'image/gif', 'image/webp'])]
     protected ?File $imageFile = null;
 
     #[ORM\Column(type: 'string', length: 255)]

--- a/src/Entity/Track.php
+++ b/src/Entity/Track.php
@@ -14,6 +14,7 @@ use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Serializer\Annotation\Ignore;
 use Symfony\Component\Serializer\Annotation\SerializedName;
+use Symfony\Component\Validator\Constraints as Assert;
 use Vich\UploaderBundle\Mapping\Annotation as Vich;
 
 #[Vich\Uploadable]
@@ -127,6 +128,7 @@ class Track extends GeoTrack implements RouteableInterface, TrackInterface, Uplo
     protected ?string $reducedPolyline = null;
 
     #[Vich\UploadableField(mapping: 'track_file', fileNameProperty: 'trackFilename', size: 'trackSize', mimeType: 'trackMimeType')]
+    #[Assert\File(maxSize: '20M', mimeTypes: ['application/gpx+xml', 'application/xml', 'text/xml', 'application/octet-stream'])]
     protected ?File $trackFile = null;
 
     #[ORM\Column(type: 'string', length: 255, nullable: true)]


### PR DESCRIPTION
## Summary
- Add `Assert\File` constraint to `Track::trackFile` — allows GPX/XML files up to 20MB
- Add `Assert\File` constraint to `Photo::imageFile` — allows JPEG/PNG/GIF/WebP up to 30MB
- Prevents uploading of executable files or other unauthorized file types

## Test plan
- [ ] Verify GPX track upload still works
- [ ] Verify photo upload still works for JPEG/PNG files
- [ ] Verify non-allowed file types are rejected with validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)