### PR TITLE
Fix SQL injection antipattern in RideRepository

### DIFF
--- a/src/Repository/RideRepository.php
+++ b/src/Repository/RideRepository.php
@@ -463,7 +463,8 @@ class RideRepository extends ServiceEntityRepository
         if ($pastOnly) {
             $dateTime = new \DateTime();
 
-            $builder->andWhere($builder->expr()->lt('ride.dateTime', '\'' . $dateTime->format('Y-m-d H:i:s') . '\''));
+            $builder->andWhere($builder->expr()->lt('ride.dateTime', ':pastDateTime'))
+                ->setParameter('pastDateTime', $dateTime);
         }
         $builder->orderBy('ride.dateTime', 'DESC');
 
@@ -543,11 +544,13 @@ class RideRepository extends ServiceEntityRepository
         $builder->where($builder->expr()->eq('region1.parent', $region->getId()));
 
         if ($startDateTime) {
-            $builder->andWhere($builder->expr()->gt('ride.dateTime', '\'' . $startDateTime->format('Y-m-d') . '\''));
+            $builder->andWhere($builder->expr()->gt('ride.dateTime', ':startDateTime'))
+                ->setParameter('startDateTime', $startDateTime);
         }
 
         if ($endDateTime) {
-            $builder->andWhere($builder->expr()->lt('ride.dateTime', '\'' . $endDateTime->format('Y-m-d') . '\''));
+            $builder->andWhere($builder->expr()->lt('ride.dateTime', ':endDateTime'))
+                ->setParameter('endDateTime', $endDateTime);
         }
 
         $builder->addOrderBy('city.city', 'ASC');


### PR DESCRIPTION
## Summary
- Replace string concatenation with Doctrine parameter binding in `findRidesWithoutStatisticsForCity()` (line 466)
- Replace string concatenation with Doctrine parameter binding in `findRidesInRegionInInterval()` (lines 546, 550)
- Uses `setParameter()` instead of manually quoting DateTime values

## Test plan
- [ ] Verify ride statistics queries still return correct results
- [ ] Verify region interval ride queries still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)