### PR TITLE
Fix SQL injection in SocialNetworkProfileRepository

### DIFF
--- a/src/Repository/SocialNetworkProfileRepository.php
+++ b/src/Repository/SocialNetworkProfileRepository.php
@@ -56,8 +56,13 @@ class SocialNetworkProfileRepository extends ServiceEntityRepository
                 ->setParameter('city', $city);
         }
 
-        /** @var string $entityClassName */
+        $allowedEntityFields = ['city', 'ride', 'subride', 'user'];
+
         foreach ($entityClassNames as $entityClassName) {
+            if (!in_array($entityClassName, $allowedEntityFields, true)) {
+                continue;
+            }
+
             $builder->andWhere($builder->expr()->isNotNull(sprintf('snp.%s', $entityClassName)));
         }
 


### PR DESCRIPTION
## Summary
- Add whitelist validation for entity field names in `findByProperties()` before using them in DQL
- Prevents SQL injection via the `?entities=` query parameter which was used directly as column names in `sprintf('snp.%s', $entityClassName)`
- Only allowed fields: `city`, `ride`, `subride`, `user`

## Test plan
- [ ] Verify social network profile listing still filters by entity type correctly
- [ ] Verify invalid entity names are silently ignored
- [ ] Verify SQL injection payloads are blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)