### PR TITLE
Restrict CORS wildcard to read-only API requests

### DIFF
--- a/src/EventSubscriber/CorsEventSubscriber.php
+++ b/src/EventSubscriber/CorsEventSubscriber.php
@@ -17,7 +17,13 @@ class CorsEventSubscriber implements EventSubscriberInterface
 
     public function onResponse(ResponseEvent $event): void
     {
-        if (!str_starts_with($event->getRequest()->getPathInfo(), '/api/')) {
+        $request = $event->getRequest();
+
+        if (!str_starts_with($request->getPathInfo(), '/api/')) {
+            return;
+        }
+
+        if (!$request->isMethod('GET') && !$request->isMethod('OPTIONS')) {
             return;
         }
 
@@ -25,8 +31,9 @@ class CorsEventSubscriber implements EventSubscriberInterface
         $response->headers->set('Access-Control-Allow-Origin', '*');
         $response->headers->set('Access-Control-Allow-Methods', 'GET, OPTIONS');
         $response->headers->set('Access-Control-Allow-Headers', 'Content-Type');
+        $response->headers->set('Access-Control-Max-Age', '3600');
 
-        if ($event->getRequest()->isMethod('OPTIONS')) {
+        if ($request->isMethod('OPTIONS')) {
             $response->setStatusCode(204);
             $response->setContent('');
         }


### PR DESCRIPTION
## Summary
- Only sets `Access-Control-Allow-Origin: *` on GET and OPTIONS requests to `/api/`
- Write endpoints (POST, PUT) no longer receive CORS wildcard headers, preventing cross-origin write requests from browsers
- Adds `Access-Control-Max-Age: 3600` for preflight response caching

## Test plan
- [ ] Verify public API GET endpoints still work cross-origin
- [ ] Verify OPTIONS preflight returns 204 with correct headers
- [ ] Verify POST/PUT responses no longer include CORS wildcard
- [ ] Run PHPStan and PHPUnit

🤖 Generated with [Claude Code](https://claude.com/claude-code)