### PR TITLE
Replace uniqid with random_bytes for filenames

### DIFF
--- a/src/Criticalmass/Image/ExifWrapper/ExifWrapper.php
+++ b/src/Criticalmass/Image/ExifWrapper/ExifWrapper.php
@@ -32,7 +32,7 @@ class ExifWrapper implements ExifWrapperInterface
 
     protected function dumpFileToTmp(Photo $photo): string
     {
-        $path = sprintf('/tmp/%s', uniqid('', true));
+        $path = sprintf('/tmp/%s', bin2hex(random_bytes(16)));
 
         $imageContent = $this->flysystemFilesystem->read($photo->getImageName());
 

--- a/src/Criticalmass/Image/PhotoManipulator/Storage/PhotoStorage.php
+++ b/src/Criticalmass/Image/PhotoManipulator/Storage/PhotoStorage.php
@@ -20,7 +20,7 @@ class PhotoStorage extends AbstractPhotoStorage
     public function save(ManipulateablePhotoInterface $photo, ImageInterface $image): string
     {
         if (!$photo->getBackupName()) {
-            $newFilename = sprintf('%s.jpg', uniqid('', true));
+            $newFilename = sprintf('%s.jpg', bin2hex(random_bytes(16)));
 
             $photo->setBackupName($photo->getImageName());
 

--- a/src/Criticalmass/ProfilePhotoGenerator/ProfilePhotoGenerator.php
+++ b/src/Criticalmass/ProfilePhotoGenerator/ProfilePhotoGenerator.php
@@ -107,7 +107,7 @@ class ProfilePhotoGenerator implements ProfilePhotoGeneratorInterface
 
     protected function generateFilename(): string
     {
-        $filename = sprintf('%s.jpg', uniqid('', true));
+        $filename = sprintf('%s.jpg', bin2hex(random_bytes(16)));
 
         $this->user->setImageName($filename);
 

--- a/src/Criticalmass/UploadFaker/UploadFaker.php
+++ b/src/Criticalmass/UploadFaker/UploadFaker.php
@@ -33,7 +33,7 @@ class UploadFaker extends AbstractUploadFaker
 
     protected function generateFilename(): string
     {
-        return sprintf('%s/%s', self::TMP, uniqid('', true));
+        return sprintf('%s/%s', self::TMP, bin2hex(random_bytes(16)));
     }
 
     protected function dumpContentToTmp(string $filename, string $fileContent): UploadFaker


### PR DESCRIPTION
## Summary
- Replaces `uniqid('', true)` with `bin2hex(random_bytes(16))` in 4 filename generation locations
- `uniqid()` produces predictable values based on microtime; `random_bytes()` is cryptographically secure
- Affected files: UploadFaker, PhotoStorage, ExifWrapper, ProfilePhotoGenerator

## Test plan
- [ ] Verify photo upload still works (filename generation)
- [ ] Verify photo manipulation/storage still works
- [ ] Verify profile photo generation still works
- [ ] Run PHPStan and PHPUnit

🤖 Generated with [Claude Code](https://claude.com/claude-code)