### PR TITLE
Add security response headers

### DIFF
--- a/src/EventSubscriber/SecurityHeadersEventSubscriber.php
+++ b/src/EventSubscriber/SecurityHeadersEventSubscriber.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace App\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class SecurityHeadersEventSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::RESPONSE => 'onResponse',
+        ];
+    }
+
+    public function onResponse(ResponseEvent $event): void
+    {
+        $response = $event->getResponse();
+
+        $response->headers->set('X-Frame-Options', 'SAMEORIGIN');
+        $response->headers->set('X-Content-Type-Options', 'nosniff');
+        $response->headers->set('Referrer-Policy', 'strict-origin-when-cross-origin');
+        $response->headers->set('Permissions-Policy', 'camera=(), microphone=(), geolocation=(self)');
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `SecurityHeadersEventSubscriber` that sets security headers on all responses:
  - `X-Frame-Options: SAMEORIGIN` - prevents clickjacking
  - `X-Content-Type-Options: nosniff` - prevents MIME-type sniffing
  - `Referrer-Policy: strict-origin-when-cross-origin` - limits referrer leakage
  - `Permissions-Policy: camera=(), microphone=(), geolocation=(self)` - restricts browser features

## Test plan
- [ ] Verify responses include the new security headers
- [ ] Verify existing functionality is not affected
- [ ] Run PHPStan and PHPUnit

🤖 Generated with [Claude Code](https://claude.com/claude-code)