### PR TITLE
Replace rand() with random_int() in User entity

### DIFF
--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -131,9 +131,9 @@ class User implements SocialNetworkProfileAble, RouteableInterface, PhotoInterfa
 
     public function __construct()
     {
-        $this->colorRed = rand(0, 255);
-        $this->colorGreen = rand(0, 255);
-        $this->colorBlue = rand(0, 255);
+        $this->colorRed = random_int(0, 255);
+        $this->colorGreen = random_int(0, 255);
+        $this->colorBlue = random_int(0, 255);
         $this->createdAt = new \DateTime();
 
         $this->tracks = new ArrayCollection();


### PR DESCRIPTION
## Summary
- Replaces `rand(0, 255)` with `random_int(0, 255)` for profile color generation in `User::__construct()`
- `rand()` uses a weak PRNG; `random_int()` uses a CSPRNG and is the modern replacement

## Test plan
- [ ] Verify new user registration still assigns random profile colors
- [ ] Run PHPStan and PHPUnit

🤖 Generated with [Claude Code](https://claude.com/claude-code)