### PR TITLE
Fix division by zero in photo censor action

### DIFF
--- a/src/Controller/Photo/PhotoManagementController.php
+++ b/src/Controller/Photo/PhotoManagementController.php
@@ -237,15 +237,21 @@ class PhotoManagementController extends AbstractController
         PhotoManipulatorInterface $photoManipulator,
         ?UserInterface $user = null
     ): Response {
-        $areaDataList = json_decode($request->getContent());
+        $areaDataList = json_decode($request->getContent(), true);
 
-        if (0 === count($areaDataList)) {
-            return new Response(null);
+        if (!is_array($areaDataList) || 0 === count($areaDataList)) {
+            return new Response(null, Response::HTTP_BAD_REQUEST);
+        }
+
+        $displayWidth = (int) $request->query->get('width');
+
+        if ($displayWidth <= 0) {
+            return new Response(null, Response::HTTP_BAD_REQUEST);
         }
 
         $newFilename = $photoManipulator
             ->open($photo)
-            ->censor($areaDataList, (int) $request->query->get('width'))
+            ->censor($areaDataList, $displayWidth)
             ->save();
 
         return new Response($newFilename);

--- a/src/Criticalmass/Image/PhotoManipulator/PhotoManipulator.php
+++ b/src/Criticalmass/Image/PhotoManipulator/PhotoManipulator.php
@@ -22,8 +22,17 @@ class PhotoManipulator extends AbstractPhotoManipulator
         $factor = $this->image->getSize()->getWidth() / $displayWidth;
 
         foreach ($areaDataList as $areaData) {
-            $topLeftPoint = new Point($areaData->x * $factor, $areaData->y * $factor);
-            $dimension = new Box($areaData->width * $factor, $areaData->height * $factor);
+            $x = (float) ($areaData['x'] ?? $areaData->x ?? 0);
+            $y = (float) ($areaData['y'] ?? $areaData->y ?? 0);
+            $width = (float) ($areaData['width'] ?? $areaData->width ?? 0);
+            $height = (float) ($areaData['height'] ?? $areaData->height ?? 0);
+
+            if ($width <= 0 || $height <= 0) {
+                continue;
+            }
+
+            $topLeftPoint = new Point((int) ($x * $factor), (int) ($y * $factor));
+            $dimension = new Box((int) ($width * $factor), (int) ($height * $factor));
 
             $this->applyBlurArea($topLeftPoint, $dimension);
         }


### PR DESCRIPTION
## Summary
- Validates `width` query parameter to prevent `DivisionByZeroError` when `width=0` or missing
- Fixes `json_decode()` to return associative arrays instead of objects (prevents `TypeError` with `count()`)
- Adds dimension validation in `PhotoManipulator::censor()` to skip invalid area data
- Returns `400 Bad Request` for invalid input instead of crashing

## Test plan
- [ ] Verify photo censoring still works normally
- [ ] Verify `?width=0` returns 400 instead of 500
- [ ] Verify missing width parameter returns 400
- [ ] Run PHPStan and PHPUnit

🤖 Generated with [Claude Code](https://claude.com/claude-code)