### PR TITLE
Redesign ProfileManagement templates to BS5 cards

### DIFF
--- a/templates/ProfileManagement/edit_email.html.twig
+++ b/templates/ProfileManagement/edit_email.html.twig
@@ -13,7 +13,7 @@
 {% block content %}
     <div class="container">
         <div class="row">
-            <div class="col-md-6 col-md-offset-3">
+            <div class="col-md-6 offset-md-3">
                 <h2>
                     E-Mail-Adresse ändern
                 </h2>
@@ -28,36 +28,38 @@
         {{ form_start(userEmailForm) }}
 
         <div class="row">
-            <div class="col-md-6 col-md-offset-3">
-                <div class="panel panel-default">
-                    <div class="panel-heading">
-                        Deine E-Mail-Adresse
+            <div class="col-md-6 offset-md-3">
+                <div class="card border-0 shadow-sm mb-4">
+                    <div class="card-header bg-white">
+                        <i class="far fa-envelope text-primary me-2"></i>Deine E-Mail-Adresse
                     </div>
-                    <div class="panel-body form-group form-group{% if form_errors(userEmailForm.email) %} has-error has-feedback{% endif %}">
+                    <div class="card-body">
                         <p>
                             Deine E-Mail-Adresse wird selbstverständlich nirgendwo öffentlich angezeigt.
                         </p>
 
                         {{ form_errors(userEmailForm.email) }}
 
-                        <label class="control-label" for="">
-                            E-Mail-Adresse:
-                        </label>
-                        {{ form_widget(userEmailForm.email, { 'attr' : { 'class': 'form-control'} }) }}
+                        <div class="mb-3">
+                            <label class="form-label">
+                                E-Mail-Adresse:
+                            </label>
+                            {{ form_widget(userEmailForm.email, { 'attr' : { 'class': 'form-control'} }) }}
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
 
         <div class="row">
-            <div class="col-md-6 col-md-offset-3 text-center">
+            <div class="col-md-6 offset-md-3 text-center">
                 <div class="btn-group" role="group">
-                    <a href="{{ path('criticalmass_user_usermanagement') }}" class="btn btn-secondary">
-                        Abbrechen
+                    <a href="{{ path('criticalmass_user_usermanagement') }}" class="btn btn-light">
+                        <i class="far fa-times me-1"></i>Abbrechen
                     </a>
 
                     <button type="submit" class="btn btn-primary">
-                        Speichern
+                        <i class="far fa-save me-1"></i>Speichern
                     </button>
                 </div>
             </div>

--- a/templates/ProfileManagement/edit_username.html.twig
+++ b/templates/ProfileManagement/edit_username.html.twig
@@ -13,7 +13,7 @@
 {% block content %}
     <div class="container">
         <div class="row">
-            <div class="col-md-6 col-md-offset-3">
+            <div class="col-md-6 offset-md-3">
                 <h2>
                     Benutzername ändern
                 </h2>
@@ -28,12 +28,12 @@
         {{ form_start(usernameForm) }}
 
         <div class="row">
-            <div class="col-md-6 col-md-offset-3">
-                <div class="panel panel-default">
-                    <div class="panel-heading">
-                        Dein Benutzername
+            <div class="col-md-6 offset-md-3">
+                <div class="card border-0 shadow-sm mb-4">
+                    <div class="card-header bg-white">
+                        <i class="far fa-user text-primary me-2"></i>Dein Benutzername
                     </div>
-                    <div class="panel-body form-group form-group{% if form_errors(usernameForm.username) %} has-error has-feedback{% endif %}">
+                    <div class="card-body">
                         <p>
                             Dein Benutzername wird öffentlich angezeigt &mdash; außerdem brauchst du ihn zum Einloggen,
                             wenn du dich nicht über ein soziales Netzwerk anmeldest.
@@ -41,24 +41,26 @@
 
                         {{ form_errors(usernameForm.username) }}
 
-                        <label class="control-label" for="">
-                            Benutzername:
-                        </label>
-                        {{ form_widget(usernameForm.username, { 'attr' : { 'class': 'form-control'} }) }}
+                        <div class="mb-3">
+                            <label class="form-label">
+                                Benutzername:
+                            </label>
+                            {{ form_widget(usernameForm.username, { 'attr' : { 'class': 'form-control'} }) }}
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
 
         <div class="row">
-            <div class="col-md-6 col-md-offset-3 text-center">
+            <div class="col-md-6 offset-md-3 text-center">
                 <div class="btn-group" role="group">
-                    <a href="{{ path('criticalmass_user_usermanagement') }}" class="btn btn-secondary">
-                        Abbrechen
+                    <a href="{{ path('criticalmass_user_usermanagement') }}" class="btn btn-light">
+                        <i class="far fa-times me-1"></i>Abbrechen
                     </a>
 
                     <button type="submit" class="btn btn-primary">
-                        Speichern
+                        <i class="far fa-save me-1"></i>Speichern
                     </button>
                 </div>
             </div>

--- a/templates/ProfileManagement/manage.html.twig
+++ b/templates/ProfileManagement/manage.html.twig
@@ -10,7 +10,7 @@
 {% block content %}
     <div class="container">
         <div class="row">
-            <div class="col-md-10 col-md-offset-1">
+            <div class="col-md-10 offset-md-1">
                 <h2>
                     Hej {{ app.getUser().getUsername() }}, schön, dass du da bist!
                 </h2>
@@ -23,9 +23,8 @@
         </div>
 
         {% for flashMessage in app.session.flashbag.get('success') %}
-
             <div class="row">
-                <div class="col-md-10 col-md-offset-1">
+                <div class="col-md-10 offset-md-1">
                     <div class="alert alert-dismissible alert-success" role="alert">
                         {{ flashMessage }}
                         <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
@@ -35,61 +34,60 @@
         {% endfor %}
 
         <div class="row">
-            <div class="col-md-10 col-md-offset-1">
-                <div class="row">
+            <div class="col-md-10 offset-md-1">
+                <div class="row g-3">
                     <div class="col-md-6">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                Profilfoto ändern
+                        <div class="card border-0 shadow-sm h-100">
+                            <div class="card-header bg-white">
+                                <i class="far fa-camera text-primary me-2"></i>Profilfoto ändern
                             </div>
-                            <div class="panel-body">
+                            <div class="card-body d-flex flex-column">
                                 <p>
                                     Lade ein Foto für dein Profil hoch.
                                 </p>
 
-                                <p class="text-center">
-                                    <a class="btn btn-secondary"
+                                <div class="mt-auto text-center">
+                                    <a class="btn btn-outline-primary btn-sm"
                                        href="{{ path('criticalmass_user_profile_photo') }}">
-                                        Profilfoto ändern
+                                        <i class="far fa-camera me-1"></i>Profilfoto ändern
                                     </a>
-                                </p>
+                                </div>
                             </div>
                         </div>
                     </div>
 
                     <div class="col-md-6">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                Profilfarbe wählen
+                        <div class="card border-0 shadow-sm h-100">
+                            <div class="card-header bg-white">
+                                <i class="far fa-palette text-success me-2"></i>Profilfarbe wählen
                             </div>
-                            <div class="panel-body">
+                            <div class="card-body d-flex flex-column">
                                 <p>
                                     Ändere die Farbe deines Benutzerkontos.
                                 </p>
 
-                                <p class="text-center">
-                                    <a class="btn btn-secondary"
+                                <div class="mt-auto text-center">
+                                    <a class="btn btn-outline-success btn-sm"
                                        href="{{ path('criticalmass_user_profile_color') }}">
-                                        Profilfarbe wählen
+                                        <i class="far fa-palette me-1"></i>Profilfarbe wählen
                                     </a>
-                                </p>
+                                </div>
                             </div>
                         </div>
                     </div>
 
                     <div class="col-md-6">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                Deine Touren
+                        <div class="card border-0 shadow-sm h-100">
+                            <div class="card-header bg-white">
+                                <i class="far fa-bicycle text-warning me-2"></i>Deine Touren
                             </div>
-
-                            <div class="panel-body">
+                            <div class="card-body d-flex flex-column">
                                 {% if participationCounter == 0 %}
-                                    <div class="alert alert-info" role="alert">
-                                        <strong>Schade:</strong>
-                                        Du hast noch an keiner Critical Mass teilgenommen. Im <a
-                                                href="{{ path('caldera_criticalmass_calendar') }}">Kalender</a> findest
-                                        du Touren in deiner Nähe.
+                                    <div class="text-center py-3">
+                                        <i class="far fa-bicycle fa-2x text-muted mb-2"></i>
+                                        <p class="text-muted mb-0">
+                                            Du hast noch an keiner Critical Mass teilgenommen. Im <a href="{{ path('caldera_criticalmass_calendar') }}">Kalender</a> findest du Touren in deiner Nähe.
+                                        </p>
                                     </div>
                                 {% else %}
                                     <p>
@@ -97,27 +95,30 @@
                                         teilgenommen.
                                     </p>
 
-                                    <p class="text-center">
-                                        <a class="btn btn-secondary"
+                                    <div class="mt-auto text-center">
+                                        <a class="btn btn-outline-warning btn-sm"
                                            href="{{ path('criticalmass_user_participation_list') }}">
-                                            Tourenübersicht
+                                            <i class="far fa-bicycle me-1"></i>Tourenübersicht
                                         </a>
-                                    </p>
+                                    </div>
                                 {% endif %}
                             </div>
                         </div>
                     </div>
 
                     <div class="col-md-6">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                Deine Tracks
+                        <div class="card border-0 shadow-sm h-100">
+                            <div class="card-header bg-white">
+                                <i class="far fa-route text-info me-2"></i>Deine Tracks
                             </div>
-                            <div class="panel-body">
+                            <div class="card-body d-flex flex-column">
                                 {% if trackCounter == 0 %}
-                                    <div class="alert alert-info" role="alert">
-                                        Du hast bislang noch keine Tracks von Critical-Mass-Touren gespeichert. Schau in
-                                        die Hilfe, wenn du weitere Informationen zu diesem Thema benötigst.
+                                    <div class="text-center py-3">
+                                        <i class="far fa-route fa-2x text-muted mb-2"></i>
+                                        <p class="text-muted mb-0">
+                                            Du hast bislang noch keine Tracks von Critical-Mass-Touren gespeichert. Schau in
+                                            die Hilfe, wenn du weitere Informationen zu diesem Thema benötigst.
+                                        </p>
                                     </div>
                                 {% else %}
                                     <p>
@@ -125,11 +126,11 @@
                                         hochgeladen.
                                     </p>
 
-                                    <p class="text-center">
-                                        <a class="btn btn-secondary" href="{{ path('caldera_criticalmass_track_list') }}">
-                                            Tracks verwalten
+                                    <div class="mt-auto text-center">
+                                        <a class="btn btn-outline-info btn-sm" href="{{ path('caldera_criticalmass_track_list') }}">
+                                            <i class="far fa-route me-1"></i>Tracks verwalten
                                         </a>
-                                    </p>
+                                    </div>
                                 {% endif %}
                             </div>
                         </div>
@@ -137,27 +138,30 @@
 
                     {% if feature('photos') %}
                     <div class="col-md-6">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                Deine Fotos
+                        <div class="card border-0 shadow-sm h-100">
+                            <div class="card-header bg-white">
+                                <i class="far fa-images text-secondary me-2"></i>Deine Fotos
                             </div>
-                            <div class="panel-body">
+                            <div class="card-body d-flex flex-column">
                                 {% if photoCounter == 0 %}
-                                    <div class="alert alert-info" role="alert">
-                                        Du hast bislang noch keine Fotos hochgeladen. In der Hilfe findest du mehr
-                                        Informationen zu diesem Thema.
+                                    <div class="text-center py-3">
+                                        <i class="far fa-images fa-2x text-muted mb-2"></i>
+                                        <p class="text-muted mb-0">
+                                            Du hast bislang noch keine Fotos hochgeladen. In der Hilfe findest du mehr
+                                            Informationen zu diesem Thema.
+                                        </p>
                                     </div>
                                 {% else %}
                                     <p>
                                         Du hast von deinen Touren {{ photoCounter }} Fotos hochgeladen.
                                     </p>
 
-                                    <p class="text-center">
-                                        <a class="btn btn-secondary"
+                                    <div class="mt-auto text-center">
+                                        <a class="btn btn-outline-secondary btn-sm"
                                            href="{{ path('caldera_criticalmass_photo_user_list') }}">
-                                            Fotos verwalten
+                                            <i class="far fa-images me-1"></i>Fotos verwalten
                                         </a>
-                                    </p>
+                                    </div>
                                 {% endif %}
                             </div>
                         </div>
@@ -165,42 +169,42 @@
                     {% endif %}
 
                     <div class="col-md-6">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                Benutzername ändern
+                        <div class="card border-0 shadow-sm h-100">
+                            <div class="card-header bg-white">
+                                <i class="far fa-user text-primary me-2"></i>Benutzername ändern
                             </div>
-                            <div class="panel-body">
+                            <div class="card-body d-flex flex-column">
                                 <p>
                                     Hier kannst du deinen Benutzernamen ändern.
                                 </p>
 
-                                <p class="text-center">
-                                    <a class="btn btn-secondary"
+                                <div class="mt-auto text-center">
+                                    <a class="btn btn-outline-primary btn-sm"
                                        href="{{ path('criticalmass_user_usermanagement_editusername') }}">
-                                        Benutzername ändern
+                                        <i class="far fa-edit me-1"></i>Benutzername ändern
                                     </a>
-                                </p>
+                                </div>
                             </div>
                         </div>
                     </div>
 
                     <div class="col-md-6">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                E-Mail-Adresse ändern
+                        <div class="card border-0 shadow-sm h-100">
+                            <div class="card-header bg-white">
+                                <i class="far fa-envelope text-warning me-2"></i>E-Mail-Adresse ändern
                             </div>
-                            <div class="panel-body">
+                            <div class="card-body d-flex flex-column">
                                 <p>
                                     Hier kannst du deine E-Mail-Adresse ändern. Bedenke bitte, dass du dich künftig
                                     mit deinen neuen Benutzerdaten einloggen musst.
                                 </p>
 
-                                <p class="text-center">
-                                    <a class="btn btn-secondary"
+                                <div class="mt-auto text-center">
+                                    <a class="btn btn-outline-warning btn-sm"
                                        href="{{ path('criticalmass_user_usermanagement_editemail') }}">
-                                        E-Mail-Adresse ändern
+                                        <i class="far fa-edit me-1"></i>E-Mail-Adresse ändern
                                     </a>
-                                </p>
+                                </div>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- Replace all BS3 `panel panel-default` with modern `card border-0 shadow-sm` cards in all three ProfileManagement templates (`manage`, `edit_email`, `edit_username`)
- Update `col-md-offset-*` to BS5 `offset-md-*` throughout
- Add Font Awesome 5 icons (`far` prefix) to card headers and buttons
- Replace `control-label` with `form-label` in edit forms
- Convert empty states from `alert alert-info` to centered icon+text pattern
- Use `btn-outline-*` with `btn-sm` for action buttons, `btn-light` for cancel buttons with icons
- Add `h-100` and `d-flex flex-column` with `mt-auto` for equal-height cards in manage view
- Use `g-3` row gaps for consistent spacing between cards

## Test plan
- [ ] Visit profile management page and verify all 7 cards render correctly with icons and shadow
- [ ] Verify equal-height cards align properly in the two-column layout
- [ ] Check empty states for tours/tracks/photos when counters are 0
- [ ] Visit edit email page and verify card-based form layout with form-label
- [ ] Visit edit username page and verify card-based form layout with form-label
- [ ] Test form submission and validation error display on both edit pages
- [ ] Verify responsive layout on mobile viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)