### PR TITLE
Redesign Track templates to modern card design

### DIFF
--- a/templates/Track/_track_list_item.html.twig
+++ b/templates/Track/_track_list_item.html.twig
@@ -1,115 +1,128 @@
-<div class="col-md-4 margin-bottom-medium">
-    <div class="panel panel-default{% if not track.enabled %} panel-warning{% elseif not track.reviewed %} panel-danger{% endif %}">
-        <div class="panel-heading">
-            <a href="{{ object_path(track.ride) }}">
-                {{ track.ride.title }}
-            </a>
+<div class="col-md-4 mb-4">
+    <div class="card border-0 shadow-sm{% if not track.enabled %} border-start border-warning border-3{% elseif not track.reviewed %} border-start border-danger border-3{% endif %}">
+        <div class="card-header bg-white">
+            <div class="d-flex justify-content-between align-items-center">
+                <a href="{{ object_path(track.ride) }}" class="text-decoration-none fw-bold">
+                    <i class="far fa-bicycle text-muted me-1"></i>{{ track.ride.title }}
+                </a>
+                {% if not track.enabled %}
+                    <span class="badge bg-warning text-dark">
+                        <i class="far fa-eye-slash me-1"></i>Deaktiviert
+                    </span>
+                {% elseif not track.reviewed %}
+                    <span class="badge bg-danger">
+                        <i class="far fa-exclamation-triangle me-1"></i>Unbestätigt
+                    </span>
+                {% endif %}
+            </div>
         </div>
-        <div class="panel-body">
-            <div class="row margin-bottom-medium">
-                <div class="col-md-12">
-                    <div
-                        id="map-{{ track.id }}"
-                        class="map"
-                        style="height: 150px;"
-                        data-controller="map--map"
-                        data-map--map-lock-map-value="true"
-                        data-map--map-polyline-color-value="{{ track.user.color }}"
-                        data-map--map-polyline-value="{{ track.polyline }}"
-                    ></div>
 
-                </div>
+        <div class="card-body">
+            <div class="mb-3">
+                <div
+                    id="map-{{ track.id }}"
+                    class="map rounded"
+                    style="height: 150px;"
+                    data-controller="map--map"
+                    data-map--map-lock-map-value="true"
+                    data-map--map-polyline-color-value="{{ track.user.color }}"
+                    data-map--map-polyline-value="{{ track.polyline }}"
+                ></div>
             </div>
 
-            <div class="row">
+            <div class="row g-3 mb-3">
                 {% if show_city is not defined or show_city == true %}
-                    <div class="col-md-6">
-                        <dl>
-                            <dt>
-                                Stadt
-                            </dt>
-
-                            <dd>
-                                <a href="{{ object_path(track.ride.city) }}">
-                                    {{ track.ride.city.city }}
+                    <div class="col-6">
+                        <div class="d-flex align-items-center">
+                            <div class="bg-warning bg-opacity-10 rounded-circle d-flex align-items-center justify-content-center me-2"
+                                 style="width: 36px; height: 36px; min-width: 36px;">
+                                <i class="far fa-map-marker-alt text-warning"></i>
+                            </div>
+                            <div>
+                                <small class="text-muted d-block">Stadt</small>
+                                <a href="{{ object_path(track.ride.city) }}" class="text-decoration-none">
+                                    <strong>{{ track.ride.city.city }}</strong>
                                 </a>
-                            </dd>
-                        </dl>
+                            </div>
+                        </div>
                     </div>
                 {% endif %}
 
                 {% if show_user is not defined or show_user == true %}
-                    <div class="col-md-6">
-                        <dl>
-                            <dt>
-                                Teilnehmer
-                            </dt>
-
-                            <dd>
-                                {{ track.user.username }}
-                            </dd>
-                        </dl>
+                    <div class="col-6">
+                        <div class="d-flex align-items-center">
+                            <div class="bg-info bg-opacity-10 rounded-circle d-flex align-items-center justify-content-center me-2"
+                                 style="width: 36px; height: 36px; min-width: 36px;">
+                                <i class="far fa-user text-info"></i>
+                            </div>
+                            <div>
+                                <small class="text-muted d-block">Teilnehmer</small>
+                                <strong>{{ track.user.username }}</strong>
+                            </div>
+                        </div>
                     </div>
                 {% endif %}
 
-                <div class="col-md-6">
-                    <dl>
-                        <dt>
-                            Datum
-                        </dt>
-
-                        <dd>
-                            <a href="{{ object_path(track) }}">
-                                {{ track.ride.dateTime|date('d.m.Y') }}
+                <div class="col-6">
+                    <div class="d-flex align-items-center">
+                        <div class="bg-primary bg-opacity-10 rounded-circle d-flex align-items-center justify-content-center me-2"
+                             style="width: 36px; height: 36px; min-width: 36px;">
+                            <i class="far fa-calendar-alt text-primary"></i>
+                        </div>
+                        <div>
+                            <small class="text-muted d-block">Datum</small>
+                            <a href="{{ object_path(track) }}" class="text-decoration-none">
+                                <strong>{{ track.ride.dateTime|date('d.m.Y') }}</strong>
                             </a>
-                        </dd>
-                    </dl>
+                        </div>
+                    </div>
                 </div>
             </div>
 
-            <div class="row">
-                <div class="col-md-4">
-                    <dl>
-                        <dt>
-                            Länge
-                        </dt>
-
-                        <dd>
-                            {{ track.distance|number_format(2) }}&nbsp;km
-                        </dd>
-                    </dl>
+            <div class="row g-3">
+                <div class="col-4">
+                    <div class="d-flex align-items-center">
+                        <div class="bg-success bg-opacity-10 rounded-circle d-flex align-items-center justify-content-center me-2"
+                             style="width: 36px; height: 36px; min-width: 36px;">
+                            <i class="far fa-route text-success"></i>
+                        </div>
+                        <div>
+                            <small class="text-muted d-block">Länge</small>
+                            <strong>{{ track.distance|number_format(2) }}&nbsp;km</strong>
+                        </div>
+                    </div>
                 </div>
 
-                <div class="col-md-4">
-                    <dl>
-                        <dt>
-                            Beginn
-                        </dt>
-
-                        <dd>
-                            {{ track.startDateTime|date('H:i', track.ride.city.timezone) }}&nbsp;Uhr
-                        </dd>
-                    </dl>
+                <div class="col-4">
+                    <div class="d-flex align-items-center">
+                        <div class="bg-secondary bg-opacity-10 rounded-circle d-flex align-items-center justify-content-center me-2"
+                             style="width: 36px; height: 36px; min-width: 36px;">
+                            <i class="far fa-clock text-secondary"></i>
+                        </div>
+                        <div>
+                            <small class="text-muted d-block">Beginn</small>
+                            <strong>{{ track.startDateTime|date('H:i', track.ride.city.timezone) }}</strong>
+                        </div>
+                    </div>
                 </div>
 
-                <div class="col-md-4">
-                    <dl>
-                        <dt>
-                            Ende
-                        </dt>
-
-                        <dd>
-                            {{ track.endDateTime|date('H:i', track.ride.city.timezone) }}&nbsp;Uhr
-                        </dd>
-                    </dl>
+                <div class="col-4">
+                    <div class="d-flex align-items-center">
+                        <div class="bg-secondary bg-opacity-10 rounded-circle d-flex align-items-center justify-content-center me-2"
+                             style="width: 36px; height: 36px; min-width: 36px;">
+                            <i class="far fa-clock text-secondary"></i>
+                        </div>
+                        <div>
+                            <small class="text-muted d-block">Ende</small>
+                            <strong>{{ track.endDateTime|date('H:i', track.ride.city.timezone) }}</strong>
+                        </div>
+                    </div>
                 </div>
             </div>
 
             {% if is_granted('edit', track) %}
-                <div class="row">
-                    <div class="col-md-12">
-                        {% include('Track/_track_options_menu.html.twig') with { 'track': track } %}
-                    </div>
+                <div class="mt-3">
+                    {% include('Track/_track_options_menu.html.twig') with { 'track': track } %}
                 </div>
             {% endif %}
         </div>

--- a/templates/Track/_track_options_menu.html.twig
+++ b/templates/Track/_track_options_menu.html.twig
@@ -1,20 +1,19 @@
-<div class="btn-group pull-right">
-    <button type="button" class="btn btn-secondary btn-xs dropdown-toggle"
+<div class="float-end">
+    <button type="button" class="btn btn-outline-secondary btn-sm dropdown-toggle"
             data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-        Bearbeiten    </button>
-    <ul class="dropdown-menu">
+        <i class="far fa-cog me-1"></i>Bearbeiten
+    </button>
+    <ul class="dropdown-menu dropdown-menu-end">
         {% if track.source == constant('TRACK_SOURCE_DRAW', track) %}
             <li>
-                <a href="{{ object_path(track, 'caldera_criticalmass_track_edit') }}">
-                    <i class="far fa-pencil"></i>
-                    Track editieren
+                <a class="dropdown-item" href="{{ object_path(track, 'caldera_criticalmass_track_edit') }}">
+                    <i class="far fa-edit me-2"></i>Track editieren
                 </a>
             </li>
         {% else %}
             <li>
-                <a href="{{ object_path(track, 'caldera_criticalmass_track_download') }}">
-                    <i class="far fa-download"></i>
-                    Herunterladen
+                <a class="dropdown-item" href="{{ object_path(track, 'caldera_criticalmass_track_download') }}">
+                    <i class="far fa-download me-2"></i>Herunterladen
                 </a>
             </li>
             {% if track.enabled %}
@@ -22,8 +21,7 @@
                     <form method="post" action="{{ object_path(track, 'caldera_criticalmass_track_toggle') }}">
                         <input type="hidden" name="_token" value="{{ csrf_token('track_toggle_' ~ track.id) }}">
                         <button type="submit" class="dropdown-item">
-                            <i class="far fa-eye-slash"></i>
-                            Deaktivieren
+                            <i class="far fa-eye-slash me-2"></i>Deaktivieren
                         </button>
                     </form>
                 </li>
@@ -32,8 +30,7 @@
                     <form method="post" action="{{ object_path(track, 'caldera_criticalmass_track_toggle') }}">
                         <input type="hidden" name="_token" value="{{ csrf_token('track_toggle_' ~ track.id) }}">
                         <button type="submit" class="dropdown-item">
-                            <i class="far fa-eye"></i>
-                            Aktivieren
+                            <i class="far fa-eye me-2"></i>Aktivieren
                         </button>
                     </form>
                 </li>
@@ -43,36 +40,33 @@
 
             {% if not track.isReviewed %}
                 <li>
-                    <a href="{{ object_path(track, 'caldera_criticalmass_track_approve') }}">
-                        <i class="far fa-check"></i>
-                        Bestätigen
+                    <a class="dropdown-item" href="{{ object_path(track, 'caldera_criticalmass_track_approve') }}">
+                        <i class="far fa-check me-2"></i>Bestätigen
                     </a>
                 </li>
             {% endif %}
 
             <li>
-                <a href="{{ object_path(track, 'caldera_criticalmass_track_range') }}">
-                    <i class="far fa-cut"></i>
-                    Beschneiden
+                <a class="dropdown-item" href="{{ object_path(track, 'caldera_criticalmass_track_range') }}">
+                    <i class="far fa-cut me-2"></i>Beschneiden
                 </a>
             </li>
 
             <li>
-                <a href="{{ object_path(track, 'caldera_criticalmass_track_time') }}">
-                    <i class="far fa-clock"></i>
-                    Zeit anpassen
+                <a class="dropdown-item" href="{{ object_path(track, 'caldera_criticalmass_track_time') }}">
+                    <i class="far fa-clock me-2"></i>Zeit anpassen
                 </a>
             </li>
 
         {% endif %}
+        <li><hr class="dropdown-divider"></li>
         <li>
-            <a href="{{ path('caldera_criticalmass_rest_track_delete', { id: track.id }) }}"
+            <a class="dropdown-item text-danger" href="{{ path('caldera_criticalmass_rest_track_delete', { id: track.id }) }}"
                    data-controller="delete-modal"
                    data-action="click->delete-modal#open"
                    data-delete-modal-title-value="Track löschen"
                    data-delete-modal-text-value="Möchtest du diesen Track von der {{ track.ride.city.title }} vom {{ track.ride.dateTime|date('d.m.Y') }} wirklich löschen?">
-                <i class="far fa-trash-alt"></i>
-                Löschen
+                <i class="far fa-trash-alt me-2"></i>Löschen
             </a>
         </li>
     </ul>

--- a/templates/Track/draw.html.twig
+++ b/templates/Track/draw.html.twig
@@ -11,10 +11,11 @@
 {% block content %}
 
     <div class="container">
-        <div class="row">
+        <div class="row mb-4">
             <div class="col-md-12">
-                <div id="map" style="height: 400px;">
-
+                <div class="card border-0 shadow-sm overflow-hidden">
+                    <div id="map" style="height: 400px;">
+                    </div>
                 </div>
             </div>
         </div>
@@ -27,9 +28,11 @@
                     <input type="hidden" id="polyline" name="polyline"/>
                     <input type="hidden" id="geojson" name="geojson"/>
 
-                    <button type="submit" id="save-track" class="btn btn-secondary">
-                        Speichern
-                    </button>
+                    <div class="d-flex justify-content-end">
+                        <button type="submit" id="save-track" class="btn btn-success btn-sm">
+                            <i class="far fa-save me-1"></i>Speichern
+                        </button>
+                    </div>
                 </form>
             </div>
         </div>

--- a/templates/Track/list.html.twig
+++ b/templates/Track/list.html.twig
@@ -10,59 +10,65 @@
 
 {% block content %}
     <div class="container main-container">
-        <div class="row">
+        <div class="row mb-4">
             <div class="col-md-12">
                 <h1>
-                    Deine Gpx-Tracks
+                    <i class="far fa-route text-muted me-2"></i>Deine Gpx-Tracks
                 </h1>
-            </div>
-        </div>
 
-        <div class="row">
-            <div class="col-md-12">
                 <p class="lead">
                     Hier siehst du alle Tracks, die du bei deinen bisherigen Critical-Mass-Teilnahmen aufgezeichnet
                     hast.
                 </p>
 
                 <p>
-                    Klicke in der Übersicht einer Radtour im Reiter „Tracks“ auf den grünen Button, um einen neuen Track
+                    Klicke in der Übersicht einer Radtour im Reiter „Tracks" auf den grünen Button, um einen neuen Track
                     hinzuzufügen.
                 </p>
             </div>
         </div>
 
-        <div class="row">
-            {% for track in pagination %}
-                {% include('Track/_track_list_item.html.twig') with { 'track': track, 'show_user': false } %}
-            {% endfor %}
-        </div>
-    </div>
+        {% if pagination|length > 0 %}
+            <div class="row">
+                {% for track in pagination %}
+                    {% include('Track/_track_list_item.html.twig') with { 'track': track, 'show_user': false } %}
+                {% endfor %}
+            </div>
+        {% else %}
+            <div class="text-center py-5">
+                <i class="far fa-route fa-3x text-muted mb-3"></i>
+                <h5 class="text-muted">Keine Tracks vorhanden</h5>
+                <p class="text-muted mb-0">Du hast noch keine GPX-Tracks hochgeladen.</p>
+            </div>
+        {% endif %}
 
-    <div class="row">
-        <div class="col-md-12">
-            <div class="text-center">
-                {{ knp_pagination_render(pagination) }}
+        <div class="row">
+            <div class="col-md-12">
+                <div class="text-center">
+                    {{ knp_pagination_render(pagination) }}
+                </div>
             </div>
         </div>
     </div>
 
-    <div class="modal fade" id="modalDelete" tabindex="-1" role="dialog">
-        <div class="modal-dialog">
+    <div class="modal fade" id="modalDelete" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
             <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title">Track löschen</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                <div class="modal-header border-0">
+                    <h5 class="modal-title">
+                        <i class="far fa-trash-alt text-danger me-2"></i>Track löschen
+                    </h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Schließen"></button>
                 </div>
                 <div class="modal-body">
                     <span id="trackIdLabel"></span>
                     <p>Willst Du diesen Track wirklich löschen?</p>
                 </div>
-                <div class="modal-footer">
-                    <div class="btn-group" role="group" aria-label="...">
-                        <a id="deleteButton" href="#" class="btn btn-success">Ja, löschen</a>
-                        <button id="cancelButton" class="btn btn-secondary">Nein, abbrechen</button>
-                    </div>
+                <div class="modal-footer border-0">
+                    <button id="cancelButton" class="btn btn-light" data-bs-dismiss="modal">Nein, abbrechen</button>
+                    <a id="deleteButton" href="#" class="btn btn-danger">
+                        <i class="far fa-trash-alt me-1"></i>Ja, löschen
+                    </a>
                 </div>
             </div>
         </div>

--- a/templates/Track/range.html.twig
+++ b/templates/Track/range.html.twig
@@ -11,54 +11,61 @@
 
 {% block content %}
     <div class="container" id="track-range-page">
-        <div class="row">
+        <div class="row mb-3">
             <div class="col-md-12">
                 <h2>
-                    Track beschneiden
+                    <i class="far fa-cut text-muted me-2"></i>Track beschneiden
                 </h2>
             </div>
         </div>
 
-        <div class="row">
+        <div class="row mb-4">
             <div class="col-md-12">
-                <p>Weniger ist manchmal mehr. Hier kannst du Anfang und Ende deiner Tour festlegen, falls du
-                    versehentlich zu viel aufgezeichnet hast und nicht möchtest, dass dir jemand nach Hause folgt.</p>
-
-                <p>
-                    Das Beschneiden beschädigt deinen Track nicht, du kannst den für andere Nutzer sichtbaren Bereich
-                    jederzeit wieder ändern.
-                </p>
-            </div>
-        </div>
-
-        <div class="row">
-            <div class="col-md-12">
-                <div id="map-range"
-                     class="map"
-                     data-controller="map--track-range-map"
-                     data-map--lock-map="true"
-                     style="height: 50vh;">
+                <div class="card border-0 shadow-sm">
+                    <div class="card-body">
+                        <p class="mb-2">Weniger ist manchmal mehr. Hier kannst du Anfang und Ende deiner Tour festlegen, falls du
+                            versehentlich zu viel aufgezeichnet hast und nicht möchtest, dass dir jemand nach Hause folgt.</p>
+                        <p class="mb-0">
+                            Das Beschneiden beschädigt deinen Track nicht, du kannst den für andere Nutzer sichtbaren Bereich
+                            jederzeit wieder ändern.
+                        </p>
+                    </div>
                 </div>
             </div>
         </div>
 
-        <div class="row margin-top-medium">
+        <div class="row mb-4">
+            <div class="col-md-12">
+                <div class="card border-0 shadow-sm overflow-hidden">
+                    <div id="map-range"
+                         class="map"
+                         data-controller="map--track-range-map"
+                         data-map--lock-map="true"
+                         style="height: 50vh;">
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="row mb-4">
             <div class="col-md-12">
                 <input id="slider" type="text" value="" style="width: 100%;"/>
             </div>
         </div>
 
-        <div class="row margin-top-medium">
+        <div class="row">
             <div class="col-md-12">
                 <input type="hidden" id="track_range_latLngList" value="{{ latLngList }}" />
                 {{ form_start(form) }}
-                <div class="btn-group pull-right" role="group" aria-label="...">
-                    <button class="btn btn-success" type="submit">
-                        Speichern
-                    </button>
-                    <a class="btn btn-secondary" href="{{ path('caldera_criticalmass_track_list') }}">
-                        Abbrechen
-                    </a>
+                <div class="d-flex justify-content-end">
+                    <div class="btn-group" role="group">
+                        <a class="btn btn-outline-secondary btn-sm" href="{{ path('caldera_criticalmass_track_list') }}">
+                            Abbrechen
+                        </a>
+                        <button class="btn btn-success btn-sm" type="submit">
+                            <i class="far fa-save me-1"></i>Speichern
+                        </button>
+                    </div>
                 </div>
                 {{ form_end(form) }}
             </div>

--- a/templates/Track/time.html.twig
+++ b/templates/Track/time.html.twig
@@ -11,10 +11,10 @@
 
 {% block content %}
     <div class="container">
-        <div class="row">
+        <div class="row mb-4">
             <div class="col-md-12">
                 <h1>
-                    Zeit anpassen
+                    <i class="far fa-clock text-muted me-2"></i>Zeit anpassen
                 </h1>
 
                 <p class="lead">
@@ -26,78 +26,58 @@
 
         {{ form_start(form) }}
 
-        <div class="row">
-            <div class="col-md-5 col-md-offset-1">
-                <div class="panel panel-default">
-                    <div class="panel-heading">
-                        Alte Uhrzeit
+        <div class="row g-4 mb-4">
+            <div class="col-md-5 offset-md-1">
+                <div class="card border-0 shadow-sm">
+                    <div class="card-header bg-white">
+                        <h5 class="card-title mb-0">
+                            <i class="far fa-clock text-muted me-2"></i>Alte Uhrzeit
+                        </h5>
                     </div>
-                    <div class="panel-body">
-                        <div class="row">
-                            <div class="col-md-12">
-                                <div class="form-group">
-                                    <label class="control-label" for="">Datum:</label>
-                                    <input class="form-control" type="text" disabled="disabled"
-                                           value="{{ track.startDate.format('d.m.Y') }}"/>
-                                </div>
-                            </div>
+                    <div class="card-body">
+                        <div class="mb-3">
+                            <label class="form-label">Datum:</label>
+                            <input class="form-control" type="text" disabled="disabled"
+                                   value="{{ track.startDate.format('d.m.Y') }}"/>
                         </div>
 
-                        <div class="row">
-                            <div class="col-md-12">
-                                <div class="form-group">
-                                    <label class="control-label" for="">Uhrzeit:</label>
-                                    <input class="form-control" type="text" disabled="disabled"
-                                           value="{{ track.startDate.format('H:i') }}"/>
-                                </div>
-                            </div>
+                        <div class="mb-3">
+                            <label class="form-label">Uhrzeit:</label>
+                            <input class="form-control" type="text" disabled="disabled"
+                                   value="{{ track.startDate.format('H:i') }}"/>
                         </div>
 
-                        <div class="row">
-                            <div class="col-md-12">
-                                <div class="form-group">
-                                    <label class="control-label" for="">Zeitzone:</label>
-                                    <input class="form-control" type="text" disabled="disabled"
-                                           value="{{ track.ride.city.timezone }}"/>
-                                </div>
-                            </div>
+                        <div class="mb-3">
+                            <label class="form-label">Zeitzone:</label>
+                            <input class="form-control" type="text" disabled="disabled"
+                                   value="{{ track.ride.city.timezone }}"/>
                         </div>
                     </div>
                 </div>
             </div>
 
             <div class="col-md-5">
-                <div class="panel panel-default">
-                    <div class="panel-heading">
-                        Neue Uhrzeit
+                <div class="card border-0 shadow-sm">
+                    <div class="card-header bg-white">
+                        <h5 class="card-title mb-0">
+                            <i class="far fa-edit text-primary me-2"></i>Neue Uhrzeit
+                        </h5>
                     </div>
-                    <div class="panel-body">
-                        <div class="row">
-                            <div class="col-md-12">
-                                <div class="form-group{% if form_errors(form.startDate) %} has-error has-feedback{% endif %}">
-                                    <label class="control-label" for="">Datum:</label>
-                                    {{ form_widget(form.startDate, { 'attr' : { 'class': 'form-control'} }) }}
-                                </div>
-                            </div>
+                    <div class="card-body">
+                        <div class="mb-3">
+                            <label class="form-label">Datum:</label>
+                            {{ form_widget(form.startDate, { 'attr' : { 'class': 'form-control'} }) }}
                         </div>
 
-                        <div class="row">
-                            <div class="col-md-12">
-                                <div class="form-group{% if form_errors(form.startTime) %} has-error has-feedback{% endif %}">
-                                    <label class="control-label" for="">Uhrzeit:</label>
-                                    {{ form_widget(form.startTime, { 'attr' : { 'class': 'form-control'} }) }}
-                                </div>
-                            </div>
+                        <div class="mb-3">
+                            <label class="form-label">Uhrzeit:</label>
+                            {{ form_widget(form.startTime, { 'attr' : { 'class': 'form-control'} }) }}
                         </div>
 
-                        <div class="row">
-                            <div class="col-md-12">
-                                <div class="form-group">
-                                    <label class="control-label" for="">Zeitzone:</label>
-                                    <input class="form-control" type="text" disabled="disabled"
-                                           value="{{ track.ride.city.timezone }}"/>
-                                </div>
-                            </div>
+                        <div class="mb-3">
+                            <label class="form-label">Zeitzone:</label>
+                            <input class="form-control" type="text" disabled="disabled"
+                                   value="{{ track.ride.city.timezone }}"/>
                         </div>
                     </div>
                 </div>
@@ -107,11 +87,11 @@
         <div class="row">
             <div class="col-md-12 text-center">
                 <div class="btn-group">
-                    <a href="{{ path('caldera_criticalmass_track_list') }}" class="btn btn-secondary">
+                    <a href="{{ path('caldera_criticalmass_track_list') }}" class="btn btn-outline-secondary btn-sm">
                         Abbrechen
                     </a>
-                    <button type="submit" class="btn btn-success">
-                        Speichern
+                    <button type="submit" class="btn btn-success btn-sm">
+                        <i class="far fa-save me-1"></i>Speichern
                     </button>
                 </div>
             </div>

--- a/templates/Track/upload.html.twig
+++ b/templates/Track/upload.html.twig
@@ -13,20 +13,15 @@
 {% block content %}
     <div class="container">
         <div class="row">
-            <div class="col-md-6 col-offset-md-3">
+            <div class="col-md-6 offset-md-3">
                 <h2>
-                    Gpx-Datei hochladen
+                    <i class="far fa-upload text-muted me-2"></i>Gpx-Datei hochladen
                 </h2>
-            </div>
-        </div>
 
-        <div class="row">
-            <div class="col-md-6 col-offset-md-3">
                 <p>
                     Wenn du deine Fahrt bei der <strong>{{ ride.city.title }}</strong> am
                     <strong>{{ ride.dateTime|date('d.m.Y', ride.city.timezone) }}</strong> aufgezeichnet hast, kannst du
-                    hier
-                    deinen Track als GPX-Datei hochladen.
+                    hier deinen Track als GPX-Datei hochladen.
                 </p>
             </div>
         </div>
@@ -34,32 +29,25 @@
         {{ form_start(form, {'attr': {'role': 'form', 'id': 'track-upload-form'}}) }}
 
         <div class="row">
-            <div class="col-md-6 col-offset-md-3">
-                <div class="panel panel-default">
-                    <div class="panel-heading">
-                        <h3 class="panel-title">
-                            Gpx-Datei hochladen
-                        </h3>
+            <div class="col-md-6 offset-md-3">
+                <div class="card border-0 shadow-sm mb-4">
+                    <div class="card-header bg-white">
+                        <h5 class="card-title mb-0">
+                            <i class="far fa-file me-2"></i>Gpx-Datei hochladen
+                        </h5>
                     </div>
-                    <div class="panel-body">
+                    <div class="card-body">
                         {% if errorMessage %}
-                            <div class="row">
-                                <div class="col-md-12">
-                                    <div class="alert alert-danger" role="alert">
-                                        <strong>Hochladen fehlgeschlagen :(</strong>
-                                        {{ errorMessage }}
-                                    </div>
-                                </div>
+                            <div class="alert alert-danger" role="alert">
+                                <i class="far fa-exclamation-triangle me-2"></i>
+                                <strong>Hochladen fehlgeschlagen :(</strong>
+                                {{ errorMessage }}
                             </div>
                         {% endif %}
 
-                        <div class="row">
-                            <div class="col-md-12">
-                                <div class="form-group">
-                                    <label for="">Datei:</label>
-                                    {{ form_widget(form.trackFile, {'attr': {'class': 'form-control' }}) }}
-                                </div>
-                            </div>
+                        <div class="mb-3">
+                            <label class="form-label">Datei:</label>
+                            {{ form_widget(form.trackFile, {'attr': {'class': 'form-control' }}) }}
                         </div>
                     </div>
                 </div>
@@ -67,17 +55,19 @@
         </div>
 
         <div class="row">
-            <div class="col-md-6 col-offset-md-3">
-                <div class="btn-group pull-right" role="group" aria-label="...">
-                    <button type="submit" class="btn btn-success"
-                        data-controller="submit-disabler"
-                        data-action="click->submit-disabler#disable"
-                        data-submit-disabler-message-value="Bitte warten…">
-                        Track hochladen
-                    </button>
-                    <a href="{{ object_path(ride) }}" class="btn btn-secondary">
-                        Abbrechen
-                    </a>
+            <div class="col-md-6 offset-md-3">
+                <div class="d-flex justify-content-end">
+                    <div class="btn-group" role="group">
+                        <a href="{{ object_path(ride) }}" class="btn btn-outline-secondary btn-sm">
+                            Abbrechen
+                        </a>
+                        <button type="submit" class="btn btn-success btn-sm"
+                            data-controller="submit-disabler"
+                            data-action="click->submit-disabler#disable"
+                            data-submit-disabler-message-value="Bitte warten…">
+                            <i class="far fa-upload me-1"></i>Track hochladen
+                        </button>
+                    </div>
                 </div>
             </div>
         </div>

--- a/templates/Track/view.html.twig
+++ b/templates/Track/view.html.twig
@@ -22,106 +22,134 @@
         </div>
 
         {% if not track.reviewed %}
-            <div class="row">
+            <div class="row mb-4">
                 <div class="col-md-12">
-                    <div class="alert alert-danger">
-                        <div class="btn-group pull-right">
-                            <a class="btn btn-success"
-                               href="{{ object_path(track, 'caldera_criticalmass_track_range') }}">
-                                <i class="far fa-cut"></i>&nbsp;Track beschneiden
-                            </a>
-                            <a class="btn btn-secondary"
-                               href="{{ object_path(track, 'caldera_criticalmass_track_approve') }}">
-                                <i class="far fa-check"></i>&nbsp;Track bestätigen
-                            </a>
+                    <div class="card border-0 shadow-sm border-start border-danger border-3">
+                        <div class="card-body">
+                            <div class="d-flex justify-content-between align-items-start">
+                                <div>
+                                    <h5 class="card-title text-danger mb-2">
+                                        <i class="far fa-exclamation-triangle me-2"></i>Dein Track wurde noch nicht bestätigt!
+                                    </h5>
+                                    <p class="mb-0">
+                                        Bitte bestätige, dass dein Track nur den tatsächlichen Routenverlauf der Critical Mass abbildet
+                                        und etwaige An- und Abfahrten nicht enthalten sind. Du kannst deinen Track <a
+                                                href="{{ object_path(track, 'caldera_criticalmass_track_range') }}">ganz einfach online
+                                            beschneiden</a>.
+                                    </p>
+                                </div>
+                                <div class="btn-group ms-3 flex-shrink-0">
+                                    <a class="btn btn-outline-success btn-sm"
+                                       href="{{ object_path(track, 'caldera_criticalmass_track_range') }}">
+                                        <i class="far fa-cut me-1"></i><span class="d-none d-sm-inline">Track beschneiden</span>
+                                    </a>
+                                    <a class="btn btn-outline-secondary btn-sm"
+                                       href="{{ object_path(track, 'caldera_criticalmass_track_approve') }}">
+                                        <i class="far fa-check me-1"></i><span class="d-none d-sm-inline">Track bestätigen</span>
+                                    </a>
+                                </div>
+                            </div>
                         </div>
-
-                        <strong>
-                            Dein Track wurde noch nicht bestätigt!
-                        </strong>
-                        <br/>
-                        Bitte bestägtige, dass dein Track nur den tatsächlichen Routenverlauf der Critical Mass abbildet
-                        und etwaige An- und Abfahrten nicht enthalten sind. Du kannst deinen Track <a
-                                href="{{ object_path(track, 'caldera_criticalmass_track_range') }}">ganz einfach online
-                            beschneiden</a>.
                     </div>
                 </div>
             </div>
         {% endif %}
 
-        <div class="row">
+        <div class="row mb-4">
             <div class="col-md-12">
-                <div
-                        id="map"
-                        class="map"
-                        style="height: 350px;"
-                        data-controller="map--map"
-                        data-map--map-polyline-value="{{ track.polyline }}"
-                        data-map--map-polyline-color-value="{{ track.user.color }}"
-                ></div>
+                <div class="card border-0 shadow-sm overflow-hidden">
+                    <div
+                            id="map"
+                            class="map"
+                            style="height: 350px;"
+                            data-controller="map--map"
+                            data-map--map-polyline-value="{{ track.polyline }}"
+                            data-map--map-polyline-color-value="{{ track.user.color }}"
+                    ></div>
+                </div>
             </div>
         </div>
 
-        <div class="row margin-top-medium">
-            <div class="col-md-3">
-                <dl>
-                    <dt>
-                        Tour:
-                    </dt>
-                    <dd>
-                        <a href="{{ object_path(track.ride) }}">
-                            {{ track.ride.title }}
-                        </a>
-                    </dd>
-                </dl>
-            </div>
+        <div class="row mb-4">
+            <div class="col-md-12">
+                <div class="card border-0 shadow-sm">
+                    <div class="card-body">
+                        <div class="row g-3">
+                            <div class="col-6 col-md-3">
+                                <div class="d-flex align-items-center">
+                                    <div class="bg-primary bg-opacity-10 rounded-circle d-flex align-items-center justify-content-center me-2"
+                                         style="width: 36px; height: 36px; min-width: 36px;">
+                                        <i class="far fa-bicycle text-primary"></i>
+                                    </div>
+                                    <div>
+                                        <small class="text-muted d-block">Tour</small>
+                                        <a href="{{ object_path(track.ride) }}" class="text-decoration-none">
+                                            <strong>{{ track.ride.title }}</strong>
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
 
-            <div class="col-md-2">
-                <dl>
-                    <dt>
-                        Datum:
-                    </dt>
-                    <dd>
-                        {{ track.ride.dateTime|date('d.m.Y H:i', track.ride.city.timezone) }}&nbsp;Uhr
-                    </dd>
-                </dl>
-            </div>
+                            <div class="col-6 col-md-2">
+                                <div class="d-flex align-items-center">
+                                    <div class="bg-primary bg-opacity-10 rounded-circle d-flex align-items-center justify-content-center me-2"
+                                         style="width: 36px; height: 36px; min-width: 36px;">
+                                        <i class="far fa-calendar-alt text-primary"></i>
+                                    </div>
+                                    <div>
+                                        <small class="text-muted d-block">Datum</small>
+                                        <strong>{{ track.ride.dateTime|date('d.m.Y H:i', track.ride.city.timezone) }}&nbsp;Uhr</strong>
+                                    </div>
+                                </div>
+                            </div>
 
-            <div class="col-md-3">
-                <dl>
-                    <dt>
-                        Treffpunkt:
-                    </dt>
-                    <dd>
-                        {% if track.ride.location and track.ride.latitude and track.ride.longitude %}
-                            {{ track.ride.location }}
-                        {% else %}
-                            nicht bekannt
-                        {% endif %}
-                    </dd>
-                </dl>
-            </div>
+                            <div class="col-6 col-md-3">
+                                <div class="d-flex align-items-center">
+                                    <div class="bg-warning bg-opacity-10 rounded-circle d-flex align-items-center justify-content-center me-2"
+                                         style="width: 36px; height: 36px; min-width: 36px;">
+                                        <i class="far fa-map-marker-alt text-warning"></i>
+                                    </div>
+                                    <div>
+                                        <small class="text-muted d-block">Treffpunkt</small>
+                                        <strong>
+                                            {% if track.ride.location and track.ride.latitude and track.ride.longitude %}
+                                                {{ track.ride.location }}
+                                            {% else %}
+                                                nicht bekannt
+                                            {% endif %}
+                                        </strong>
+                                    </div>
+                                </div>
+                            </div>
 
-            <div class="col-md-2">
-                <dl>
-                    <dt>
-                        Distanz:
-                    </dt>
-                    <dd>
-                        {{ track.distance|number_format(2) }}&nbsp;km
-                    </dd>
-                </dl>
-            </div>
+                            <div class="col-6 col-md-2">
+                                <div class="d-flex align-items-center">
+                                    <div class="bg-success bg-opacity-10 rounded-circle d-flex align-items-center justify-content-center me-2"
+                                         style="width: 36px; height: 36px; min-width: 36px;">
+                                        <i class="far fa-route text-success"></i>
+                                    </div>
+                                    <div>
+                                        <small class="text-muted d-block">Distanz</small>
+                                        <strong>{{ track.distance|number_format(2) }}&nbsp;km</strong>
+                                    </div>
+                                </div>
+                            </div>
 
-            <div class="col-md-2">
-                <dl>
-                    <dt>
-                        Dauer:
-                    </dt>
-                    <dd>
-                        {{ human_duration(track.getDurationInSeconds()) }}
-                    </dd>
-                </dl>
+                            <div class="col-6 col-md-2">
+                                <div class="d-flex align-items-center">
+                                    <div class="bg-info bg-opacity-10 rounded-circle d-flex align-items-center justify-content-center me-2"
+                                         style="width: 36px; height: 36px; min-width: 36px;">
+                                        <i class="far fa-clock text-info"></i>
+                                    </div>
+                                    <div>
+                                        <small class="text-muted d-block">Dauer</small>
+                                        <strong>{{ human_duration(track.getDurationInSeconds()) }}</strong>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
 


### PR DESCRIPTION
## Summary
- Replace BS3 panels (`panel-default`, `panel-warning`, `panel-danger`) with modern cards (`card border-0 shadow-sm`) with colored border accents for status states
- Convert definition lists (`dl/dt/dd`) to icon-badge pattern with colored rounded-circle icons
- Fix legacy classes: `pull-right` to `float-end`, `btn-xs` to `btn-sm`, `col-offset-md-*` to `offset-md-*`, `margin-top-medium`/`margin-bottom-medium` to `mb-3`/`mb-4`
- Replace BS3 form classes (`form-group`, `control-label`, `has-error`) with BS5 equivalents (`mb-3`, `form-label`)
- Add proper Font Awesome 5 icons with `far` prefix and spacing (`me-1`/`me-2`)
- Modernize modal dialog (centered, border-0 header/footer, icon in title, proper delete button styling)
- Add dropdown-menu-end and dropdown-item classes to options menu
- Add empty state pattern to track list page
- Wrap map in card with overflow-hidden in draw template

## Files changed
- `_track_list_item.html.twig` — Complete redesign from panels to cards with icon-badges
- `_track_options_menu.html.twig` — Fix pull-right, btn-xs, add dropdown-item classes and icons
- `upload.html.twig` — Panel to card, fix col-offset, modernize buttons
- `view.html.twig` — Replace alert with danger-accent card, dl/dt/dd to icon-badges, fix pull-right
- `range.html.twig` — Fix margin-top-medium, pull-right, add card wrapper and icons
- `time.html.twig` — Panels to cards, fix col-md-offset, form-group, control-label, btn sizing
- `list.html.twig` — Add empty state, modernize modal, fix spacing
- `draw.html.twig` — Wrap map in card, modernize save button

## Test plan
- [ ] Verify track list page renders cards correctly with pagination
- [ ] Check track list item shows warning/danger border accents for disabled/unreviewed tracks
- [ ] Verify track view page displays icon-badges for tour details
- [ ] Check unreviewed track warning card with action buttons on view page
- [ ] Test track upload form with file selection and error message display
- [ ] Verify track range (trim) page with map and slider
- [ ] Test time adjustment page with old/new time cards side by side
- [ ] Verify track draw page with map and save button
- [ ] Check options dropdown menu works (edit, download, toggle, approve, trim, time, delete)
- [ ] Test responsive behavior on mobile devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)