### PR TITLE
Redesign Timeline, Region & misc templates

### DIFF
--- a/templates/CityList/list.html.twig
+++ b/templates/CityList/list.html.twig
@@ -6,84 +6,73 @@
 {% block breadcrumb %}
     {{ breadcrumb.active('Städteliste') }}
 {% endblock %}
-    
+
 {% block content %}
     <div class="container">
-        <div class="row">
-            <div class="col-md-12">
-                <h1>
-                    Die nächste Masse ist ganz nah
-                </h1>
+        <h1 class="mb-2">
+            Die nächste Masse ist ganz nah
+        </h1>
 
-                <p class="lead">
-                    Die Critical-Mass-Bewegung ist in beinahe jeder größeren Stadt zu Hause.
-                </p>
+        <p class="lead text-muted">
+            Die Critical-Mass-Bewegung ist in beinahe jeder größeren Stadt zu Hause.
+        </p>
 
-                <p>
-                    Auf den Sattel, fertig, los: Die folgende Liste enthält mittlerweile {{ cityList|length }} Städte.
-                    Bitte bedenke, dass die folgenden Informationen aus verschiedenen Quellen im Internet stammen und
-                    womöglich veraltet oder schlichtweg falsch sein können. Überprüfe bitte vorher weitere Quellen,
-                    bevor du dich auf den Weg machst.
-                </p>
-            </div>
-        </div>
+        <p class="mb-4">
+            Auf den Sattel, fertig, los: Die folgende Liste enthält mittlerweile {{ cityList|length }} Städte.
+            Bitte bedenke, dass die folgenden Informationen aus verschiedenen Quellen im Internet stammen und
+            womöglich veraltet oder schlichtweg falsch sein können. Überprüfe bitte vorher weitere Quellen,
+            bevor du dich auf den Weg machst.
+        </p>
 
-        <div class="row">
-            <div class="col-md-12">
-                <table id="city-list-table" class="table tablesorter">
-                    <thead>
-                    <tr>
-                        <th>
-                            Stadt
-                        </th>
-                        <th>
-                            aktuelle Tour
-                        </th>
-                        <th>
-                            Turnus
-                        </th>
-                        <th>
-                            Touren
-                        </th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    {% for city in cityList %}
-                        <tr data-city-slug="{{ city.city.getMainSlugString() }}">
-                            <td>
-                                <a href="{{ object_path(city.city) }}">
-                                    {{ city.city.city }}
-                                </a>
-                            </td>
-                            <td>
-                                {% if city.currentRide %}
-                                    <a href="{{ object_path(city.currentRide) }}">
-                                        {{ city.currentRide.dateTime|format_datetime(dateFormat='long', timeFormat='short', locale='de', timezone=city.city.timezone) }}
-                                        &nbsp;Uhr
-                                    </a>
-                                {% endif %}
-                            </td>
-                            <td>
-                                <ul class="list-unstyled">
-                                    {% for cycle in city.cycles %}
-                                        <li>
-                                            am {{ ('cycle.event_date.month_week.' ~ cycle.weekOfMonth)|trans }} {{ ('cycle.event_date.day.' ~ cycle.dayOfWeek)|trans }}
-                                            um {{ cycle.time|date('H:i', 'UTC') }} Uhr
-                                        </li>
-                                    {% endfor %}
-                                </ul>
-                            </td>
-                            <td>
-                                <a href="{{ object_path(city.city, 'caldera_criticalmass_city_listrides') }}">
-                                    {{ city.countRides }}
-                                </a>
-                            </td>
-                        </tr>
-                    {% endfor %}
-                    </tbody>
-                </table>
+        <div class="card border-0 shadow-sm">
+            <div class="card-body p-0">
+                <div class="table-responsive">
+                    <table id="city-list-table" class="table table-hover tablesorter mb-0">
+                        <thead class="table-light">
+                            <tr>
+                                <th>Stadt</th>
+                                <th>aktuelle Tour</th>
+                                <th>Turnus</th>
+                                <th>Touren</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for city in cityList %}
+                                <tr data-city-slug="{{ city.city.getMainSlugString() }}">
+                                    <td>
+                                        <a href="{{ object_path(city.city) }}">
+                                            {{ city.city.city }}
+                                        </a>
+                                    </td>
+                                    <td>
+                                        {% if city.currentRide %}
+                                            <a href="{{ object_path(city.currentRide) }}">
+                                                {{ city.currentRide.dateTime|format_datetime(dateFormat='long', timeFormat='short', locale='de', timezone=city.city.timezone) }}
+                                                &nbsp;Uhr
+                                            </a>
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        <ul class="list-unstyled mb-0">
+                                            {% for cycle in city.cycles %}
+                                                <li>
+                                                    am {{ ('cycle.event_date.month_week.' ~ cycle.weekOfMonth)|trans }} {{ ('cycle.event_date.day.' ~ cycle.dayOfWeek)|trans }}
+                                                    um {{ cycle.time|date('H:i', 'UTC') }} Uhr
+                                                </li>
+                                            {% endfor %}
+                                        </ul>
+                                    </td>
+                                    <td>
+                                        <a href="{{ object_path(city.city, 'caldera_criticalmass_city_listrides') }}">
+                                            {{ city.countRides }}
+                                        </a>
+                                    </td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
             </div>
         </div>
     </div>
-
 {% endblock %}

--- a/templates/Region/index.html.twig
+++ b/templates/Region/index.html.twig
@@ -19,72 +19,56 @@
 
 {% block content %}
     <div class="container">
-        <div class="row">
-            <div class="col-md-12">
-                {% if app.getUser() and region.isLevel(3) %}
-                    <a href="{{ path('caldera_criticalmass_city_add', { slug1: region.parent.parent.slug, slug2: region.parent.slug, slug3: region.slug }) }}"
-                       class="btn btn-success margin-top-medium pull-right">
-                        <i class="far fa-plus"></i>
-                        Stadt hinzufügen
-                    </a>
+        <div class="d-flex justify-content-between align-items-center mb-4">
+            <h1 class="mb-0">
+                {% if region.isWorld() %}
+                    Critical Mass weltweit
+                {% else %}
+                    Critical Mass in {{ region.name }}
                 {% endif %}
-                <h1>
-                    {% if region.isWorld() %}
-                        Critical Mass weltweit
-                    {% else %}
-                        Critical Mass in {{ region.name }}
-                    {% endif %}
-                </h1>
-            </div>
+            </h1>
+
+            {% if app.getUser() and region.isLevel(3) %}
+                <a href="{{ path('caldera_criticalmass_city_add', { slug1: region.parent.parent.slug, slug2: region.parent.slug, slug3: region.slug }) }}"
+                   class="btn btn-success btn-sm">
+                    <i class="far fa-plus me-1"></i>
+                    Stadt hinzufügen
+                </a>
+            {% endif %}
         </div>
 
         {% if allCities|length > 0 %}
-            <div class="row">
-                <div class="col-md-12">
-                    <div class="map"
-                         id="region-map"
-                         data-controller="map--query-map"
-                         style="height: 350px;"
-                         data-map--query-map-api-type-value="city"
-                         data-map--query-map-api-query-value="{{ path('caldera_criticalmass_rest_city_list', { regionSlug: region.slug, size: 500 }) }}">
-                    </div>
+            <div class="card border-0 shadow-sm mb-4 overflow-hidden">
+                <div class="map"
+                     id="region-map"
+                     data-controller="map--query-map"
+                     style="height: 350px;"
+                     data-map--query-map-api-type-value="city"
+                     data-map--query-map-api-query-value="{{ path('caldera_criticalmass_rest_city_list', { regionSlug: region.slug, size: 500 }) }}">
                 </div>
             </div>
         {% endif %}
 
         {% if regions|length > 0 %}
-            <div class="row">
-                <div class="col-md-12">
-                    <h2>
-                        {% if region.isWorld() %}
-                            Kontinente
-                        {% else %}
-                            Unterregionen in {{ region.name }}
-                        {% endif %}
-                    </h2>
-                </div>
-            </div>
+            <h2 class="mb-3">
+                {% if region.isWorld() %}
+                    Kontinente
+                {% else %}
+                    Unterregionen in {{ region.name }}
+                {% endif %}
+            </h2>
 
-            <div class="row">
+            <div class="row g-3 mb-4">
                 {% for region2 in regions %}
-                    <div class="col-xs-6 col-sm-4 col-md-3">
-                        <div class="row">
-                            <div class="col-md-12">
-                                <div class="text-center">
-                                    <h4>
-                                        <a href="{{ object_path(region2) }}">
-                                            {{ region2.name }}
-                                        </a>
-                                    </h4>
-                                </div>
-                            </div>
-                        </div>
-
-                        <div class="row">
-                            <div class="col-md-12">
-                                <div class="text-center">
-                                    <small>{{ cityCounter[region2.id] }} Städte in dieser Region</small>
-                                </div>
+                    <div class="col-6 col-sm-4 col-md-3">
+                        <div class="card border-0 shadow-sm h-100">
+                            <div class="card-body text-center">
+                                <h5 class="mb-1">
+                                    <a href="{{ object_path(region2) }}" class="text-decoration-none">
+                                        {{ region2.name }}
+                                    </a>
+                                </h5>
+                                <small class="text-muted">{{ cityCounter[region2.id] }} Städte</small>
                             </div>
                         </div>
                     </div>
@@ -93,26 +77,20 @@
         {% endif %}
 
         {% if cities|length > 0 %}
-            <div class="row">
-                <div class="col-md-12">
-                    <h2>
-                        Städte in {{ region.name }}
-                    </h2>
-                </div>
-            </div>
+            <h2 class="mb-3">
+                Städte in {{ region.name }}
+            </h2>
 
-            <div class="row">
+            <div class="row g-3 mb-4">
                 {% for city in cities %}
-                    <div class="col-xs-6 col-sm-4 col-md-3">
-                        <div class="row">
-                            <div class="col-md-12">
-                                <div class="text-center">
-                                    <h4>
-                                        <a href="{{ object_path(city) }}">
-                                            {{ city.title }}
-                                        </a>
-                                    </h4>
-                                </div>
+                    <div class="col-6 col-sm-4 col-md-3">
+                        <div class="card border-0 shadow-sm h-100">
+                            <div class="card-body text-center">
+                                <h5 class="mb-0">
+                                    <a href="{{ object_path(city) }}" class="text-decoration-none">
+                                        {{ city.title }}
+                                    </a>
+                                </h5>
                             </div>
                         </div>
                     </div>

--- a/templates/RideEstimate/anonymous.html.twig
+++ b/templates/RideEstimate/anonymous.html.twig
@@ -3,47 +3,42 @@
 {% block title %}{% endblock title %}
 
 {% block masterContent %}
-    <div class="container text-center">
-        <div class="row">
-            <div class="col-md-12">
-                <h3>
-                    Teilnehmerzahl ergänzen
-                </h3>
+    <div class="container">
+        <div class="row justify-content-center">
+            <div class="col-md-8">
+                <div class="card border-0 shadow-sm">
+                    <div class="card-body text-center py-5">
+                        <i class="far fa-users fa-3x text-primary mb-3"></i>
 
-                <p>
-                    Wie viele Teilnehmer sind an der Critical Mass in <strong>{{ ride.city.city }}</strong> am
-                    <strong>{{ ride.dateTime|format_datetime(dateFormat='long', timeFormat='none', locale='de', timezone=ride.city.timezone) }}</strong>
-                    mitgefahren?
-                </p>
-            </div>
-        </div>
+                        <h3 class="mb-3">
+                            Teilnehmerzahl ergänzen
+                        </h3>
 
-        <div class="row">
-            <div class="col-md-12">
-                {{ form_start(estimateForm) }}
+                        <p class="text-muted mb-4">
+                            Wie viele Teilnehmer sind an der Critical Mass in <strong>{{ ride.city.city }}</strong> am
+                            <strong>{{ ride.dateTime|format_datetime(dateFormat='long', timeFormat='none', locale='de', timezone=ride.city.timezone) }}</strong>
+                            mitgefahren?
+                        </p>
 
-                <div class="row">
-                    <div class="col-md-12">
-                        <label for="">
-                            Teilnehmerzahl:
-                        </label>
+                        {{ form_start(estimateForm) }}
+
+                        <div class="mb-3">
+                            <label class="form-label fw-bold">
+                                Teilnehmerzahl:
+                            </label>
+                            {{ form_widget(estimateForm.estimatedParticipants) }}
+                        </div>
+
+                        <div class="mt-4">
+                            <button class="btn btn-primary" type="submit">
+                                <i class="far fa-save me-1"></i>
+                                Absenden
+                            </button>
+                        </div>
+
+                        {{ form_end(estimateForm) }}
                     </div>
                 </div>
-
-                <div class="row">
-                    <div class="col-md-12">
-                        {{ form_widget(estimateForm.estimatedParticipants) }}
-                    </div>
-                </div>
-
-                <div class="row margin-top-medium">
-                    <div class="col-md-12">
-                        <button class="btn btn-primary" type="submit">
-                            Absenden
-                        </button>
-                    </div>
-                </div>
-                {{ form_end(estimateForm) }}
             </div>
         </div>
     </div>

--- a/templates/Statistic/list_rides.html.twig
+++ b/templates/Statistic/list_rides.html.twig
@@ -10,78 +10,61 @@
 
 {% block content %}
     <div class="container">
-        <div class="row">
-            <div class="col-md-12">
-                <h2>
-                    Critical-Mass-Teilnehmerzahlen im {{ dateTime|format_datetime(pattern='MMMM yyyy') }}
-                </h2>
+        <h2 class="mb-2">
+            Critical-Mass-Teilnehmerzahlen im {{ dateTime|format_datetime(pattern='MMMM yyyy') }}
+        </h2>
 
-                <p class="lead">
-                    Hier siehst du die Liste der Touren im {{ dateTime|format_datetime(pattern='MMMM yyyy') }}.
-                </p>
+        <p class="lead text-muted mb-4">
+            Hier siehst du die Liste der Touren im {{ dateTime|format_datetime(pattern='MMMM yyyy') }}.
+        </p>
+
+        <div class="card border-0 shadow-sm mb-4">
+            <div class="card-body p-0">
+                <div class="table-responsive">
+                    <table class="table table-hover ride-list mb-0">
+                        <thead class="table-light">
+                            <tr>
+                                <th>Stadt</th>
+                                <th>Datum</th>
+                                <th>Teilnehmer</th>
+                                <th>Distanz</th>
+                                <th>Länge</th>
+                                <th>Durchschnittsgeschwindigkeit</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for ride in rides %}
+                                {% include 'Common/Ride/statistic_ride_table_row.html.twig' with { ride: ride } %}
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
             </div>
         </div>
 
-        <div class="row">
-            <div class="col-md-12">
-                <table class="table ride-list">
-                    <thead>
-                    <tr>
-                        <th>
-                            Stadt
-                        </th>
-                        <th>
-                            Datum
-                        </th>
-                        <th>
-                            Teilnehmer
-                        </th>
-                        <th>
-                            Distanz
-                        </th>
-                        <th>
-                            Länge
-                        </th>
-                        <th>
-                            Durchschnittsgeschwindigkeit
-                        </th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    {% for ride in rides %}
-                        {% include 'Common/Ride/statistic_ride_table_row.html.twig' with { ride: ride } %}
-                    {% endfor %}
-                    </tbody>
-                </table>
-            </div>
-        </div>
-
-        <div class="row">
-            <div class="col-md-12">
-                <p>
+        <div class="card bg-light border-0 mb-4">
+            <div class="card-body">
+                <p class="mb-0">
+                    <i class="far fa-info-circle text-muted me-2"></i>
                     Hier fehlt noch was? Du kannst fehlende Teilnehmerzahlen auf der jeweiligen Tourenseite nachtragen oder Streckenlängen mit hochgeladenen GPX-Dateien ergänzen. Auf <a href="https://criticalmass.blog/criticalmass-one/haeufig-gestellte-fragen-zu-dieser-webseite/haeufig-gestellte-fragen-zur-statistik/">unserer Hilfeseite</a> findest du weitere Informationen.
                 </p>
             </div>
         </div>
 
-        <div class="row">
-            <div class="col-md-12">
-                <nav aria-label="Monat Navigation">
-                    <ul class="pagination justify-content-between">
-                        <li class="page-item{% if not previousDateTime %} disabled{% endif %}">
-                            <a class="page-link" href="{% if previousDateTime %}{{ path('caldera_criticalmass_statistic_ride_month', { year: previousDateTime|date('Y'), month: previousDateTime|date('m') }) }}{% else %}#{% endif %}">
-                                &larr; Voriger Monat
-                            </a>
-                        </li>
+        <nav aria-label="Monat Navigation">
+            <ul class="pagination justify-content-between">
+                <li class="page-item{% if not previousDateTime %} disabled{% endif %}">
+                    <a class="page-link" href="{% if previousDateTime %}{{ path('caldera_criticalmass_statistic_ride_month', { year: previousDateTime|date('Y'), month: previousDateTime|date('m') }) }}{% else %}#{% endif %}">
+                        <i class="far fa-arrow-left me-1"></i> Voriger Monat
+                    </a>
+                </li>
 
-                        <li class="page-item{% if not nextDateTime %} disabled{% endif %}">
-                            <a class="page-link" href="{% if nextDateTime %}{{ path('caldera_criticalmass_statistic_ride_month', { year: nextDateTime|date('Y'), month: nextDateTime|date('m') }) }}{% else %}#{% endif %}">
-                                Nächster Monat &rarr;
-                            </a>
-                        </li>
-                    </ul>
-                </nav>
-            </div>
-        </div>
+                <li class="page-item{% if not nextDateTime %} disabled{% endif %}">
+                    <a class="page-link" href="{% if nextDateTime %}{{ path('caldera_criticalmass_statistic_ride_month', { year: nextDateTime|date('Y'), month: nextDateTime|date('m') }) }}{% else %}#{% endif %}">
+                        Nächster Monat <i class="far fa-arrow-right ms-1"></i>
+                    </a>
+                </li>
+            </ul>
+        </nav>
     </div>
 {% endblock %}

--- a/templates/Strava/list.html.twig
+++ b/templates/Strava/list.html.twig
@@ -12,75 +12,58 @@
 
 {% block content %}
     <div class="container">
-        <div class="row">
-            <div class="col-md-12">
-                <h1>
-                    Wähle eine Aktivität
-                </h1>
-            </div>
+        <div class="d-flex justify-content-between align-items-center mb-4">
+            <h1 class="mb-0">
+                <i class="far fa-route text-muted me-2"></i>
+                Wähle eine Aktivität
+            </h1>
+
+            <a href="{{ object_path(ride) }}" class="btn btn-outline-secondary btn-sm">
+                <i class="far fa-times me-1"></i>
+                Abbrechen
+            </a>
         </div>
 
-        <div class="row">
-            <div class="col-md-12">
-                <p>
-                    Am <strong>{{ ride.dateTime.format('d.m.Y') }}</strong> hast du die folgenden Aktivitäten mit Strava
-                    aufgezeichnet. Bitte wähle die Aktivität aus, die du als Track importieren möchtest.
-                </p>
-            </div>
-        </div>
+        <p class="text-muted mb-4">
+            Am <strong>{{ ride.dateTime.format('d.m.Y') }}</strong> hast du die folgenden Aktivitäten mit Strava
+            aufgezeichnet. Bitte wähle die Aktivität aus, die du als Track importieren möchtest.
+        </p>
 
-        <div class="row">
+        <div class="row g-3">
             {% if activities is iterable and activities|length > 0 %}
                 {% for activity in activities %}
                     <div class="col-md-4">
-                        <div class="row">
-                            <div class="col-md-12">
-                                <h3>
-                                    {{ activity.name }}
-                                </h3>
+                        <div class="card border-0 shadow-sm h-100">
+                            <div class="rounded-top overflow-hidden"
+                                 id="map-{{ activity.id }}"
+                                 data-controller="map--map"
+                                 style="height: 150px;"
+                                 data-map--map-lock-map-value="true"
+                                 data-map--map-polyline-value="{{ activity.map.summary_polyline }}"
+                                 data-map--map-polyline-color-value="{{ app.user.color }}">
                             </div>
-                        </div>
 
-                        <div class="row">
-                            <div class="col-md-12">
-                                <div id="map-{{ activity.id }}"
-                                     class="map"
-                                     data-controller="map--map"
-                                     style="height: 150px;"
-                                     data-map--map-lock-map-value="true"
-                                     data-map--map-polyline-value="{{ activity.map.summary_polyline }}"
-                                     data-map--map-polyline-color-value="{{ app.user.color }}">
+                            <div class="card-body">
+                                <h5 class="mb-3">{{ activity.name }}</h5>
+
+                                <div class="row g-3 mb-3">
+                                    <div class="col-4">
+                                        <small class="text-muted d-block">Distanz</small>
+                                        <strong>{{ (activity.distance / 1000)|round(2) }}&nbsp;km</strong>
+                                    </div>
+                                    <div class="col-4">
+                                        <small class="text-muted d-block">Start</small>
+                                        <strong>{{ activity.start_date|date('H:i') }}&nbsp;Uhr</strong>
+                                    </div>
+                                    <div class="col-4">
+                                        <small class="text-muted d-block">Dauer</small>
+                                        <strong>{{ (activity.elapsed_time / 60)|round() }}&nbsp;Min</strong>
+                                    </div>
                                 </div>
-                            </div>
-                        </div>
 
-                        <div class="row">
-                            <div class="col-md-4">
-                                <dl>
-                                    <dt>Distanz:</dt>
-                                    <dd>{{ (activity.distance / 1000)|round(2) }}&nbsp;km</dd>
-                                </dl>
-                            </div>
-                            <div class="col-md-4">
-                                <dl>
-                                    <dt>Start:</dt>
-                                    <dd>{{ activity.start_date|date('H:i') }}&nbsp;Uhr</dd>
-                                </dl>
-                            </div>
-                            <div class="col-md-4">
-                                <dl>
-                                    <dt>Dauer:</dt>
-                                    <dd>{{ (activity.elapsed_time / 60)|round() }}&nbsp;Minuten</dd>
-                                </dl>
-                            </div>
-                        </div>
-
-                        <div class="row">
-                            <div class="col-md-12">
                                 <div class="text-center">
-                                    <a class="btn btn-success" href="{{ object_path(ride, 'caldera_criticalmass_strava_import') }}?activityId={{ activity.id }}">
-                                        {# TODO #}
-                                        <i class="far fa-download"></i>
+                                    <a class="btn btn-success btn-sm" href="{{ object_path(ride, 'caldera_criticalmass_strava_import') }}?activityId={{ activity.id }}">
+                                        <i class="far fa-download me-1"></i>
                                         Track importieren
                                     </a>
                                 </div>
@@ -89,28 +72,26 @@
                     </div>
                 {% endfor %}
             {% elseif activities is iterable %}
-                <div class="col-md-12">
-                    <div class="alert alert-warning" role="alert">
-                        <strong>Keine Touren gefunden!</strong>
-                        Offenbar hast du mit Strava am {{ ride.dateTime.format('d.m.Y') }} keine Touren aufgezeichnet.
+                <div class="col-12">
+                    <div class="card bg-light border-0">
+                        <div class="card-body text-center py-5">
+                            <i class="far fa-exclamation-triangle fa-3x text-warning mb-3"></i>
+                            <h5>Keine Touren gefunden</h5>
+                            <p class="text-muted mb-0">
+                                Offenbar hast du mit Strava am {{ ride.dateTime.format('d.m.Y') }} keine Touren aufgezeichnet.
+                            </p>
+                        </div>
                     </div>
                 </div>
             {% else %}
-                <div class="col-md-12">
+                <div class="col-12">
                     <div class="alert alert-danger" role="alert">
+                        <i class="far fa-exclamation-triangle me-2"></i>
                         <strong>Hoppla!</strong>
                         Leider können wir momentan keine Touren von Strava auslesen — bitte versuche es später noch einmal.
                     </div>
                 </div>
             {% endif %}
-        </div>
-
-        <div class="row">
-            <div class="col-md-12">
-                <a href="{{ object_path(ride) }}" class="btn btn-secondary pull-right">
-                    Abbrechen
-                </a>
-            </div>
         </div>
     </div>
 {% endblock %}

--- a/templates/Timeline/Items/cityCreated.html.twig
+++ b/templates/Timeline/Items/cityCreated.html.twig
@@ -1,42 +1,32 @@
-<div class="row margin-bottom-medium">
-    {{ include('Timeline/_includes/user_column.html.twig') }}
-
-    <div class="col-xs-9 col-sm-9 col-md-10 col-lg-10">
+<div class="card border-0 shadow-sm mb-3">
+    <div class="card-body">
         <div class="row">
-            <div class="col-md-12">
-                <strong>
-                    {{ item.user.username }}
-                </strong>
-                hat eine neue Stadt hinzugefügt:
-            </div>
-        </div>
+            {{ include('Timeline/_includes/user_column.html.twig') }}
 
-        <div class="row">
-            <div class="col-md-12">
-                <a href="{{ object_path(item.city) }}">
-                    <h4>
+            <div class="col-9 col-md-10">
+                <p class="mb-2">
+                    <strong>{{ item.user.username }}</strong>
+                    hat eine neue Stadt hinzugefügt:
+                </p>
+
+                <h5 class="mb-3">
+                    <a href="{{ object_path(item.city) }}" class="text-decoration-none">
                         {{ item.cityName }}
-                    </h4>
-                </a>
-            </div>
-        </div>
+                    </a>
+                </h5>
 
-        <div class="row">
-            <div class="col-md-12">
-                <div
-                    id="map-{{ item.uniqId }}"
-                    class="map"
-                    data-controller="map--map"
-                    style="height: 150px;"
-                    data-map--map-center-latitude-value="{{ item.city.latitude }}"
-                    data-map--map-center-longitude-value="{{ item.city.longitude }}"
-                    data-map--map-zoom-value="13"
-                    data-map--map-lock-map-value="true"
-                    data-map--map-marker-latitude-value="{{ item.city.latitude }}"
-                    data-map--map-marker-longitude-value="{{ item.city.longitude }}"
-                    data-map--map-marker-type-value="city"
-                    data-map--map-vector-value="false"
-                >
+                <div class="rounded overflow-hidden"
+                     id="map-{{ item.uniqId }}"
+                     data-controller="map--map"
+                     style="height: 150px;"
+                     data-map--map-center-latitude-value="{{ item.city.latitude }}"
+                     data-map--map-center-longitude-value="{{ item.city.longitude }}"
+                     data-map--map-zoom-value="13"
+                     data-map--map-lock-map-value="true"
+                     data-map--map-marker-latitude-value="{{ item.city.latitude }}"
+                     data-map--map-marker-longitude-value="{{ item.city.longitude }}"
+                     data-map--map-marker-type-value="city"
+                     data-map--map-vector-value="false">
                 </div>
             </div>
         </div>

--- a/templates/Timeline/Items/cityEdit.html.twig
+++ b/templates/Timeline/Items/cityEdit.html.twig
@@ -1,47 +1,36 @@
-<div class="row margin-bottom-medium">
-    {{ include('Timeline/_includes/user_column.html.twig') }}
-
-    <div class="col-xs-9 col-sm-9 col-md-10 col-lg-10">
+<div class="card border-0 shadow-sm mb-3">
+    <div class="card-body">
         <div class="row">
-            <div class="col-md-12">
-                <strong>
-                    {{ item.user.username }}
-                </strong>
-                hat eine Stadt editiert:
-            </div>
-        </div>
+            {{ include('Timeline/_includes/user_column.html.twig') }}
 
-        <div class="row">
-            <div class="col-md-12">
-                <a href="{{ object_path(item.city) }}">
-                    <h4>
+            <div class="col-9 col-md-10">
+                <p class="mb-2">
+                    <strong>{{ item.user.username }}</strong>
+                    hat eine Stadt editiert:
+                </p>
+
+                <h5 class="mb-3">
+                    <a href="{{ object_path(item.city) }}" class="text-decoration-none">
                         {{ item.cityName }}
-                    </h4>
-                </a>
-            </div>
-        </div>
+                    </a>
+                </h5>
 
-        {% if item.city.latitude and item.city.longitude %}
-        <div class="row">
-            <div class="col-md-12">
-                <div
-                    id="map-{{ item.uniqId }}"
-                    class="map"
-                    data-controller="map--map"
-                    style="height: 150px;"
-                    data-map--map-center-latitude-value="{{ item.city.latitude }}"
-                    data-map--map-center-longitude-value="{{ item.city.longitude }}"
-                    data-map--map-zoom-value="13"
-                    data-map--map-lock-map-value="true"
-                    data-map--map-marker-latitude-value="{{ item.city.latitude }}"
-                    data-map--map-marker-longitude-value="{{ item.city.longitude }}"
-                    data-map--map-marker-type-value="city"
-                    data-map--map-vector-value="false"
-                >
-                </div>
+                {% if item.city.latitude and item.city.longitude %}
+                    <div class="rounded overflow-hidden"
+                         id="map-{{ item.uniqId }}"
+                         data-controller="map--map"
+                         style="height: 150px;"
+                         data-map--map-center-latitude-value="{{ item.city.latitude }}"
+                         data-map--map-center-longitude-value="{{ item.city.longitude }}"
+                         data-map--map-zoom-value="13"
+                         data-map--map-lock-map-value="true"
+                         data-map--map-marker-latitude-value="{{ item.city.latitude }}"
+                         data-map--map-marker-longitude-value="{{ item.city.longitude }}"
+                         data-map--map-marker-type-value="city"
+                         data-map--map-vector-value="false">
+                    </div>
+                {% endif %}
             </div>
         </div>
-        {% endif %}
     </div>
 </div>
-

--- a/templates/Timeline/Items/photoComment.html.twig
+++ b/templates/Timeline/Items/photoComment.html.twig
@@ -1,40 +1,36 @@
-<div class="row margin-bottom-medium">
-    {{ include('Timeline/_includes/user_column.html.twig') }}
-
-    <div class="col-xs-9 col-sm-9 col-md-10 col-lg-10">
+<div class="card border-0 shadow-sm mb-3">
+    <div class="card-body">
         <div class="row">
-            <div class="col-md-12">
-                <strong>
-                    {{ item.user.username }}
-                </strong>
-                hat {{ item.postList|length }} Fotos kommentiert:
-            </div>
-        </div>
+            {{ include('Timeline/_includes/user_column.html.twig') }}
 
-        <div class="row">
-            <div class="col-md-12">
-                <a href="{{ object_path(item.ride) }}">
-                    <h4>
-                        {{ item.ride.title }}
-                    </h4>
-                </a>
-            </div>
-        </div>
-
-        {% for post in item.postList %}
-        <div class="row">
-            <div class="col-md-4">
-                <a href="{{ object_path(post.photo) }}#post-{{ post.id }}">
-                    <img src="{{ vich_uploader_asset(post.photo, 'imageFile')|imagine_filter('gallery_photo_thumb') }}" class="img-responsive img-thumbnail" />
-                </a>
-            </div>
-
-            <div class="col-md-8">
-                <p>
-                    {{ post.message|markdown }}
+            <div class="col-9 col-md-10">
+                <p class="mb-2">
+                    <strong>{{ item.user.username }}</strong>
+                    hat {{ item.postList|length }} Fotos kommentiert:
                 </p>
+
+                <h5 class="mb-3">
+                    <a href="{{ object_path(item.ride) }}" class="text-decoration-none">
+                        {{ item.ride.title }}
+                    </a>
+                </h5>
+
+                {% for post in item.postList %}
+                    <div class="row g-3 mb-3">
+                        <div class="col-md-4">
+                            <a href="{{ object_path(post.photo) }}#post-{{ post.id }}">
+                                <img src="{{ vich_uploader_asset(post.photo, 'imageFile')|imagine_filter('gallery_photo_thumb') }}" class="img-fluid rounded" alt="" />
+                            </a>
+                        </div>
+
+                        <div class="col-md-8">
+                            <p class="mb-0">
+                                {{ post.message|markdown }}
+                            </p>
+                        </div>
+                    </div>
+                {% endfor %}
             </div>
         </div>
-        {% endfor %}
     </div>
 </div>

--- a/templates/Timeline/Items/rideComment.html.twig
+++ b/templates/Timeline/Items/rideComment.html.twig
@@ -1,29 +1,21 @@
-<div class="row margin-bottom-medium timeline-item-ride{% if not item.rideEnabled %}--disabled{% endif %}">
-    {{ include('Timeline/_includes/user_column.html.twig') }}
-
-    <div class="col-xs-9 col-sm-9 col-md-10 col-lg-10">
+<div class="card border-0 shadow-sm mb-3 timeline-item-ride{% if not item.rideEnabled %}--disabled{% endif %}">
+    <div class="card-body">
         <div class="row">
-            <div class="col-md-12">
-                <strong>
-                    {{ item.user.username }}
-                </strong>
-                hat eine Tour kommentiert:
-            </div>
-        </div>
+            {{ include('Timeline/_includes/user_column.html.twig') }}
 
-        <div class="row">
-            <div class="col-md-12">
-                <a href="{{ object_path(item.ride) }}#post-{{ item.post.id }}">
-                    <h4>
+            <div class="col-9 col-md-10">
+                <p class="mb-2">
+                    <strong>{{ item.user.username }}</strong>
+                    hat eine Tour kommentiert:
+                </p>
+
+                <h5 class="mb-2">
+                    <a href="{{ object_path(item.ride) }}#post-{{ item.post.id }}" class="text-decoration-none">
                         {{ item.rideTitle }}
-                    </h4>
-                </a>
-            </div>
-        </div>
+                    </a>
+                </h5>
 
-        <div class="row">
-            <div class="col-md-12">
-                <p>
+                <p class="text-muted mb-0">
                     {{ item.post.message }}
                 </p>
             </div>

--- a/templates/Timeline/Items/rideEdit.html.twig
+++ b/templates/Timeline/Items/rideEdit.html.twig
@@ -1,46 +1,36 @@
-<div class="row margin-bottom-medium timeline-item-ride{% if not item.enabled %}--disabled{% endif %}">
-    {{ include('Timeline/_includes/user_column.html.twig') }}
-
-    <div class="col-xs-9 col-sm-9 col-md-10 col-lg-10">
+<div class="card border-0 shadow-sm mb-3 timeline-item-ride{% if not item.enabled %}--disabled{% endif %}">
+    <div class="card-body">
         <div class="row">
-            <div class="col-md-12">
-                <strong>
-                    {{ item.user.username }}
-                </strong>
-                hat eine Tour editiert:
-            </div>
-        </div>
+            {{ include('Timeline/_includes/user_column.html.twig') }}
 
-        <div class="row">
-            <div class="col-md-12">
-                <a href="{{ object_path(item.ride) }}">
-                    <h4>
+            <div class="col-9 col-md-10">
+                <p class="mb-2">
+                    <strong>{{ item.user.username }}</strong>
+                    hat eine Tour editiert:
+                </p>
+
+                <h5 class="mb-3">
+                    <a href="{{ object_path(item.ride) }}" class="text-decoration-none">
                         {{ item.rideTitle }}
-                    </h4>
-                </a>
+                    </a>
+                </h5>
+
+                {% if item.ride.latitude and item.ride.longitude %}
+                    <div id="map-{{ item.uniqId }}"
+                         class="map timeline-item-ride-map rounded overflow-hidden"
+                         data-controller="map--map"
+                         style="height: 150px;"
+                         data-map--map-center-latitude-value="{{ item.ride.latitude }}"
+                         data-map--map-center-longitude-value="{{ item.ride.longitude }}"
+                         data-map--map-zoom-value="13"
+                         data-map--map-lock-map-value="true"
+                         data-map--map-marker-latitude-value="{{ item.ride.latitude }}"
+                         data-map--map-marker-longitude-value="{{ item.ride.longitude }}"
+                         data-map--map-marker-type-value="ride"
+                         data-map--map-vector-value="false">
+                    </div>
+                {% endif %}
             </div>
         </div>
-
-        {% if item.ride.latitude and item.ride.longitude %}
-            <div class="row">
-                <div class="col-md-12">
-                    <div
-                        id="map-{{ item.uniqId }}"
-                        class="map timeline-item-ride-map"
-                        data-controller="map--map"
-                        style="height: 150px;"
-                        data-map--map-center-latitude-value="{{ item.ride.latitude }}"
-                        data-map--map-center-longitude-value="{{ item.ride.longitude }}"
-                        data-map--map-zoom-value="13"
-                        data-map--map-lock-map-value="true"
-                        data-map--map-marker-latitude-value="{{ item.ride.latitude }}"
-                        data-map--map-marker-longitude-value="{{ item.ride.longitude }}"
-                        data-map--map-marker-type-value="ride"
-                        data-map--map-vector-value="false"
-                    >
-                    </div>
-                </div>
-            </div>
-        {% endif %}
     </div>
 </div>

--- a/templates/Timeline/Items/rideParticipationEstimate.html.twig
+++ b/templates/Timeline/Items/rideParticipationEstimate.html.twig
@@ -1,53 +1,41 @@
-<div class="row margin-bottom-medium timeline-item-ride{% if not item.rideEnabled %}--disabled{% endif %}">
-    {{ include('Timeline/_includes/user_column.html.twig') }}
-
-    <div class="col-xs-9 col-sm-9 col-md-10 col-lg-10">
+<div class="card border-0 shadow-sm mb-3 timeline-item-ride{% if not item.rideEnabled %}--disabled{% endif %}">
+    <div class="card-body">
         <div class="row">
-            <div class="col-md-12">
-                <strong>
-                    {{ item.user.username }}
-                </strong>
-                schätzt, dass {{ item.estimatedParticipants }} Radfahrer an
-                <strong class="ride-title">
-                    <a href="{{ object_path(item.ride) }}">
-                        {{ item.rideTitle }}
-                    </a>
-                </strong>
-                teilgenommen haben.
-            </div>
-        </div>
+            {{ include('Timeline/_includes/user_column.html.twig') }}
 
-        <div class="row">
-            <div class="col-md-12 text-center">
-                <div class="flipcounter">
-                    {% set counter = item.estimatedParticipants %}
+            <div class="col-9 col-md-10">
+                <p class="mb-2">
+                    <strong>{{ item.user.username }}</strong>
+                    schätzt, dass {{ item.estimatedParticipants }} Radfahrer an
+                    <strong>
+                        <a href="{{ object_path(item.ride) }}">
+                            {{ item.rideTitle }}
+                        </a>
+                    </strong>
+                    teilgenommen haben.
+                </p>
 
-                    {% if counter < 1000 %}
-                        {% set counter = 0 ~ counter %}
-                    {% endif %}
+                <div class="text-center">
+                    <div class="flipcounter">
+                        {% set counter = item.estimatedParticipants %}
 
-                    {% if counter < 100 %}
-                        {% set counter = 0 ~ counter %}
-                    {% endif %}
+                        {% if counter < 1000 %}
+                            {% set counter = 0 ~ counter %}
+                        {% endif %}
 
-                    {% if counter < 10 %}
-                        {% set counter = 0 ~ counter %}
-                    {% endif %}
+                        {% if counter < 100 %}
+                            {% set counter = 0 ~ counter %}
+                        {% endif %}
 
-                    <div class="flipbreak">
+                        {% if counter < 10 %}
+                            {% set counter = 0 ~ counter %}
+                        {% endif %}
 
-                    </div>
-                    <div class="digit">
-                        {{ counter[0:1] }}
-                    </div>
-                    <div class="digit">
-                        {{ counter[1:1] }}
-                    </div>
-                    <div class="digit">
-                        {{ counter[2:1] }}
-                    </div>
-                    <div class="digit">
-                        {{ counter[3:1] }}
+                        <div class="flipbreak"></div>
+                        <div class="digit">{{ counter[0:1] }}</div>
+                        <div class="digit">{{ counter[1:1] }}</div>
+                        <div class="digit">{{ counter[2:1] }}</div>
+                        <div class="digit">{{ counter[3:1] }}</div>
                     </div>
                 </div>
             </div>

--- a/templates/Timeline/Items/ridePhoto.html.twig
+++ b/templates/Timeline/Items/ridePhoto.html.twig
@@ -1,33 +1,33 @@
-<div class="row margin-bottom-medium timeline-item-ride{% if not item.rideEnabled %}--disabled{% endif %}">
-    {{ include('Timeline/_includes/user_column.html.twig') }}
-
-    <div class="col-xs-9 col-sm-9 col-md-10 col-lg-10">
+<div class="card border-0 shadow-sm mb-3 timeline-item-ride{% if not item.rideEnabled %}--disabled{% endif %}">
+    <div class="card-body">
         <div class="row">
-            <div class="col-md-12">
-                <strong>
-                    {{ item.user.username }}
-                </strong>
-                hat
-                <a href="{{ object_path(item.ride, 'caldera_criticalmass_photo_ride_list') }}">
-                    {{ item.counter }} Fotos
-                </a> zur Tour
-                <strong class="ride-title">
-                    <a href="{{ object_path(item.ride) }}">
-                        {{ item.ride.title }}
-                    </a>
-                </strong>
-                hochgeladen
-            </div>
-        </div>
+            {{ include('Timeline/_includes/user_column.html.twig') }}
 
-        <div class="row">
-            {% for previewPhoto in item.previewPhotoList %}
-            <div class="col-md-4">
-                <a href="{{ object_path(previewPhoto) }}">
-                    <img src="{{ vich_uploader_asset(previewPhoto, 'imageFile')|imagine_filter('gallery_photo_thumb') }}" class="img-responsive thumbnail" />
-                </a>
+            <div class="col-9 col-md-10">
+                <p class="mb-2">
+                    <strong>{{ item.user.username }}</strong>
+                    hat
+                    <a href="{{ object_path(item.ride, 'caldera_criticalmass_photo_ride_list') }}">
+                        {{ item.counter }} Fotos
+                    </a> zur Tour
+                    <strong>
+                        <a href="{{ object_path(item.ride) }}">
+                            {{ item.ride.title }}
+                        </a>
+                    </strong>
+                    hochgeladen
+                </p>
+
+                <div class="row g-3">
+                    {% for previewPhoto in item.previewPhotoList %}
+                        <div class="col-4">
+                            <a href="{{ object_path(previewPhoto) }}">
+                                <img src="{{ vich_uploader_asset(previewPhoto, 'imageFile')|imagine_filter('gallery_photo_thumb') }}" class="img-fluid rounded" alt="" />
+                            </a>
+                        </div>
+                    {% endfor %}
+                </div>
             </div>
-            {% endfor %}
         </div>
     </div>
 </div>

--- a/templates/Timeline/Items/rideTrack.html.twig
+++ b/templates/Timeline/Items/rideTrack.html.twig
@@ -1,82 +1,75 @@
-<div class="row margin-bottom-medium timeline-item-ride{% if not item.rideEnabled %}--disabled{% endif %}">
-    {{ include('Timeline/_includes/user_column.html.twig') }}
-
-    <div class="col-xs-9 col-sm-9 col-md-10 col-lg-10">
+<div class="card border-0 shadow-sm mb-3 timeline-item-ride{% if not item.rideEnabled %}--disabled{% endif %}">
+    <div class="card-body">
         <div class="row">
-            <div class="col-md-12">
-                <strong>
-                    {{ item.user.username }}
-                </strong>
-                hat einen Track hochgeladen:
-            </div>
-        </div>
+            {{ include('Timeline/_includes/user_column.html.twig') }}
 
-        <div class="row">
-            <div class="col-md-12">
-                <a href="{{ object_path(item.ride) }}">
-                    <h4>
+            <div class="col-9 col-md-10">
+                <p class="mb-2">
+                    <strong>{{ item.user.username }}</strong>
+                    hat einen Track hochgeladen:
+                </p>
+
+                <h5 class="mb-3">
+                    <a href="{{ object_path(item.ride) }}" class="text-decoration-none">
                         {{ item.rideTitle }}
-                    </h4>
-                </a>
-            </div>
-        </div>
+                    </a>
+                </h5>
 
-        {% if item.polyline %}
-        <div class="row">
-            <div class="col-md-12">
-                <div
-                    id="map-{{ item.uniqId }}"
-                    class="map timeline-item-ride-map"
-                    data-controller="map--map"
-                    style="height: 150px;"
-                    data-map--map-center-latitude-value="{{ item.ride.latitude }}"
-                    data-map--map-center-longitude-value="{{ item.ride.longitude }}"
-                    data-map--map-zoom-value="13"
-                    data-map--map-lock-map-value="true"
-                    data-map--map-polyline-color-value="{{ item.track.user.color }}"
-                    data-map--map-polyline-value="{{ item.track.polyline }}"
-                    data-map--map-vector-value="false"
-                >
+                {% if item.polyline %}
+                    <div class="rounded overflow-hidden mb-3"
+                         id="map-{{ item.uniqId }}"
+                         data-controller="map--map"
+                         style="height: 150px;"
+                         data-map--map-center-latitude-value="{{ item.ride.latitude }}"
+                         data-map--map-center-longitude-value="{{ item.ride.longitude }}"
+                         data-map--map-zoom-value="13"
+                         data-map--map-lock-map-value="true"
+                         data-map--map-polyline-color-value="{{ item.track.user.color }}"
+                         data-map--map-polyline-value="{{ item.track.polyline }}"
+                         data-map--map-vector-value="false">
+                    </div>
+                {% endif %}
+
+                <div class="row g-3">
+                    <div class="col-4">
+                        <div class="d-flex align-items-center">
+                            <div class="bg-primary bg-opacity-10 rounded-circle d-flex align-items-center justify-content-center me-2"
+                                 style="width: 36px; height: 36px; min-width: 36px;">
+                                <i class="far fa-calendar-alt text-primary"></i>
+                            </div>
+                            <div>
+                                <small class="text-muted d-block">Datum</small>
+                                <strong>{{ item.ride.dateTime|date('d.m.Y') }}</strong>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="col-4">
+                        <div class="d-flex align-items-center">
+                            <div class="bg-success bg-opacity-10 rounded-circle d-flex align-items-center justify-content-center me-2"
+                                 style="width: 36px; height: 36px; min-width: 36px;">
+                                <i class="far fa-route text-success"></i>
+                            </div>
+                            <div>
+                                <small class="text-muted d-block">Distanz</small>
+                                <strong>{{ item.distance|number_format(2, ',', '.') }}&nbsp;km</strong>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="col-4">
+                        <div class="d-flex align-items-center">
+                            <div class="bg-info bg-opacity-10 rounded-circle d-flex align-items-center justify-content-center me-2"
+                                 style="width: 36px; height: 36px; min-width: 36px;">
+                                <i class="far fa-clock text-info"></i>
+                            </div>
+                            <div>
+                                <small class="text-muted d-block">Dauer</small>
+                                <strong>{{ human_duration(item.duration) }}</strong>
+                            </div>
+                        </div>
+                    </div>
                 </div>
-            </div>
-        </div>
-        {% endif %}
-
-        <div class="row">
-            <div class="col-xs-4 col-sm-4 col-md-4 col-lg-4">
-                <dl>
-                    <dt>
-                        Datum:
-                    </dt>
-
-                    <dd>
-                        {{ item.ride.dateTime|date('d.m.Y') }}
-                    </dd>
-                </dl>
-            </div>
-
-            <div class="col-xs-4 col-sm-4 col-md-4 col-lg-4">
-                <dl>
-                    <dt>
-                        Länge:
-                    </dt>
-
-                    <dd>
-                        {{ item.distance|number_format(2, ',', '.') }}&nbsp;km
-                    </dd>
-                </dl>
-            </div>
-
-            <div class="col-xs-4 col-sm-4 col-md-4 col-lg-4">
-                <dl>
-                    <dt>
-                        Dauer:
-                    </dt>
-
-                    <dd>
-                        {{ human_duration(item.duration) }}
-                    </dd>
-                </dl>
             </div>
         </div>
     </div>

--- a/templates/Timeline/Items/socialNetworkFeed.html.twig
+++ b/templates/Timeline/Items/socialNetworkFeed.html.twig
@@ -1,117 +1,85 @@
-<div class="row margin-bottom-medium">
-    {{ include('Timeline/_includes/social_feed_item_column.html.twig') }}
+<div class="card border-0 shadow-sm mb-3">
+    <div class="card-body">
+        <div class="row">
+            {{ include('Timeline/_includes/social_feed_item_column.html.twig') }}
 
-    {% set city = item.socialNetworkFeedItem.socialNetworkProfile.city %}
+            {% set city = item.socialNetworkFeedItem.socialNetworkProfile.city %}
 
-    {% if city == null %}
-        {% set city = item.socialNetworkFeedItem.socialNetworkProfile.ride.city %}
-    {% endif %}
+            {% if city == null %}
+                {% set city = item.socialNetworkFeedItem.socialNetworkProfile.ride.city %}
+            {% endif %}
 
-    {% if item.socialNetworkFeedItem.socialNetworkProfile.network == 'twitter' %}
-        <div class="col-xs-9 col-sm-9 col-md-10 col-lg-10">
-            <div class="row">
-                <div class="col-md-12">
-                    <a href="{{ object_path(city) }}">
-                        <strong>
-                            {{ city.title }}
-                        </strong>
-                    </a>
-                    hat getwittert:
-                </div>
-            </div>
+            {% if item.socialNetworkFeedItem.socialNetworkProfile.network == 'twitter' %}
+                <div class="col-9 col-md-10">
+                    <p class="mb-2">
+                        <a href="{{ object_path(city) }}">
+                            <strong>{{ city.title }}</strong>
+                        </a>
+                        hat getwittert:
+                    </p>
 
-            <div class="row">
-                <div class="col-md-12">
-                    <p>
-                        <a href="{{ item.socialNetworkFeedItem.permalink }}">
+                    <p class="text-muted mb-0">
+                        <a href="{{ item.socialNetworkFeedItem.permalink }}" class="text-decoration-none">
                             {{ item.socialNetworkFeedItem.text }}
                         </a>
                     </p>
                 </div>
-            </div>
-        </div>
-    {% endif %}
+            {% endif %}
 
-    {% if item.socialNetworkFeedItem.socialNetworkProfile.network == 'homepage' %}
-        <div class="col-xs-9 col-sm-9 col-md-10 col-lg-10">
-            <div class="row">
-                <div class="col-md-12">
-                    <a href="{{ object_path(city) }}">
-                        <strong>
-                            {{ city.title }}
-                        </strong>
-                    </a>
-                    hat gebloggt:
-                </div>
-            </div>
+            {% if item.socialNetworkFeedItem.socialNetworkProfile.network == 'homepage' %}
+                <div class="col-9 col-md-10">
+                    <p class="mb-2">
+                        <a href="{{ object_path(city) }}">
+                            <strong>{{ city.title }}</strong>
+                        </a>
+                        hat gebloggt:
+                    </p>
 
-            <div class="row">
-                <div class="col-md-12">
-                    <a href="{{ item.socialNetworkFeedItem.permalink }}">
-                        <h4>
+                    <h5 class="mb-2">
+                        <a href="{{ item.socialNetworkFeedItem.permalink }}" class="text-decoration-none">
                             {{ item.socialNetworkFeedItem.title }}
-                        </h4>
-                    </a>
-                </div>
-            </div>
+                        </a>
+                    </h5>
 
-            <div class="row">
-                <div class="col-md-12">
-                    <p>
+                    <p class="text-muted mb-0">
                         {{ item.socialNetworkFeedItem.text|trim_intro }}
                     </p>
                 </div>
-            </div>
-        </div>
-    {% endif %}
+            {% endif %}
 
-    {% if item.socialNetworkFeedItem.socialNetworkProfile.network == 'instagram_profile' %}
-        <div class="col-xs-9 col-sm-9 col-md-10 col-lg-10">
-            <div class="row">
-                <div class="col-md-12">
-                    <a href="{{ object_path(city) }}">
-                        <strong>
-                            {{ city.title }}
-                        </strong>
-                    </a>
-                    hat etwas auf Instagram veröffentlicht:
-                </div>
-            </div>
+            {% if item.socialNetworkFeedItem.socialNetworkProfile.network == 'instagram_profile' %}
+                <div class="col-9 col-md-10">
+                    <p class="mb-2">
+                        <a href="{{ object_path(city) }}">
+                            <strong>{{ city.title }}</strong>
+                        </a>
+                        hat etwas auf Instagram veröffentlicht:
+                    </p>
 
-            <div class="row">
-                <div class="col-md-12">
-                    <p>
-                        <a href="{{ item.socialNetworkFeedItem.permalink }}">
+                    <p class="text-muted mb-0">
+                        <a href="{{ item.socialNetworkFeedItem.permalink }}" class="text-decoration-none">
                             {{ item.socialNetworkFeedItem.text }}
                         </a>
                     </p>
                 </div>
-            </div>
-        </div>
-    {% endif %}
+            {% endif %}
 
-    {% if item.socialNetworkFeedItem.socialNetworkProfile.network == 'mastodon' %}
-        <div class="col-xs-9 col-sm-9 col-md-10 col-lg-10">
-            <div class="row">
-                <div class="col-md-12">
-                    <a href="{{ object_path(city) }}">
-                        <strong>
-                            {{ city.title }}
-                        </strong>
-                    </a>
-                    hat etwas auf Mastodon veröffentlicht:
-                </div>
-            </div>
+            {% if item.socialNetworkFeedItem.socialNetworkProfile.network == 'mastodon' %}
+                <div class="col-9 col-md-10">
+                    <p class="mb-2">
+                        <a href="{{ object_path(city) }}">
+                            <strong>{{ city.title }}</strong>
+                        </a>
+                        hat etwas auf Mastodon veröffentlicht:
+                    </p>
 
-            <div class="row">
-                <div class="col-md-12">
-                    <p>
-                        <a href="{{ item.socialNetworkFeedItem.permalink }}">
+                    <p class="text-muted mb-0">
+                        <a href="{{ item.socialNetworkFeedItem.permalink }}" class="text-decoration-none">
                             {{ item.socialNetworkFeedItem.text|striptags }}
                         </a>
                     </p>
                 </div>
-            </div>
+            {% endif %}
         </div>
-    {% endif %}
+    </div>
 </div>

--- a/templates/Timeline/Items/thread.html.twig
+++ b/templates/Timeline/Items/thread.html.twig
@@ -1,29 +1,21 @@
-<div class="row margin-bottom-medium">
-    {{ include('Timeline/_includes/user_column.html.twig') }}
-
-    <div class="col-xs-9 col-sm-9 col-md-10 col-lg-10">
+<div class="card border-0 shadow-sm mb-3">
+    <div class="card-body">
         <div class="row">
-            <div class="col-md-12">
-                <strong>
-                    {{ item.user.username }}
-                </strong>
-                hat ein neues Diskussionsthema begonnen:
-            </div>
-        </div>
+            {{ include('Timeline/_includes/user_column.html.twig') }}
 
-        <div class="row">
-            <div class="col-md-12">
-                <a href="{{ object_path(item.thread) }}">
-                    <h4>
+            <div class="col-9 col-md-10">
+                <p class="mb-2">
+                    <strong>{{ item.user.username }}</strong>
+                    hat ein neues Diskussionsthema begonnen:
+                </p>
+
+                <h5 class="mb-2">
+                    <a href="{{ object_path(item.thread) }}" class="text-decoration-none">
                         {{ item.title }}
-                    </h4>
-                </a>
-            </div>
-        </div>
+                    </a>
+                </h5>
 
-        <div class="row">
-            <div class="col-md-12">
-                <p>
+                <p class="text-muted mb-0">
                     {{ item.text|slice(0, 140)|markdown }}…
                 </p>
             </div>

--- a/templates/Timeline/Items/threadPost.html.twig
+++ b/templates/Timeline/Items/threadPost.html.twig
@@ -1,29 +1,21 @@
-<div class="row margin-bottom-medium">
-    {{ include('Timeline/_includes/user_column.html.twig') }}
-
-    <div class="col-xs-9 col-sm-9 col-md-10 col-lg-10">
+<div class="card border-0 shadow-sm mb-3">
+    <div class="card-body">
         <div class="row">
-            <div class="col-md-12">
-                <strong>
-                    {{ item.user.username }}
-                </strong>
-                hat auf ein Diskussionsthema geantwortet:
-            </div>
-        </div>
+            {{ include('Timeline/_includes/user_column.html.twig') }}
 
-        <div class="row">
-            <div class="col-md-12">
-                <a href="{{ object_path(item.thread) }}#post-{{ item.postId }}">
-                    <h4>
+            <div class="col-9 col-md-10">
+                <p class="mb-2">
+                    <strong>{{ item.user.username }}</strong>
+                    hat auf ein Diskussionsthema geantwortet:
+                </p>
+
+                <h5 class="mb-2">
+                    <a href="{{ object_path(item.thread) }}#post-{{ item.postId }}" class="text-decoration-none">
                         {{ item.threadTitle }}
-                    </h4>
-                </a>
-            </div>
-        </div>
+                    </a>
+                </h5>
 
-        <div class="row">
-            <div class="col-md-12">
-                <p>
+                <p class="text-muted mb-0">
                     {{ item.text|slice(0, 140)|markdown }}…
                 </p>
             </div>

--- a/templates/Timeline/_includes/social_feed_item_column.html.twig
+++ b/templates/Timeline/_includes/social_feed_item_column.html.twig
@@ -1,6 +1,6 @@
-<div class="col-xs-3 col-sm-3 col-md-2 col-lg-2 text-center">
-    <p>
-        <small>
+<div class="col-3 col-md-2 text-center">
+    <p class="mb-0">
+        <small class="text-muted">
             <time title="{{ item.dateTime|date('d.m.Y H:i') }} Uhr">
                 {{ item.dateTime|time_ago_in_words }}
             </time>

--- a/templates/Timeline/_includes/user_column.html.twig
+++ b/templates/Timeline/_includes/user_column.html.twig
@@ -1,17 +1,18 @@
-<div class="col-xs-3 col-sm-3 col-md-2 col-lg-2 text-center">
+<div class="col-3 col-md-2 text-center">
     {% if item.user.imageName %}
-        <img class="media-object round-media-object img-responsive img-fluid"
-             src="{{ vich_uploader_asset(item.user, 'imageFile')|imagine_filter('user_profile_photo_small') }}"/>
+        <img class="rounded-circle img-fluid"
+             src="{{ vich_uploader_asset(item.user, 'imageFile')|imagine_filter('user_profile_photo_small') }}"
+             alt="{{ item.user.username }}" />
     {% endif %}
 
-    <p class="hidden-xs">
+    <p class="d-none d-sm-block mb-1">
         <strong>
             {{ item.user.username }}
         </strong>
     </p>
 
-    <p>
-        <small>
+    <p class="mb-0">
+        <small class="text-muted">
             <time title="{{ item.dateTime|date('d.m.Y H:i') }} Uhr">
                 {{ item.dateTime|time_ago_in_words }}
             </time>


### PR DESCRIPTION
## Summary
- **Timeline Items**: Redesigned all 11 timeline item templates and 2 shared includes to use Bootstrap 5 card pattern (`card border-0 shadow-sm`), replacing BS3 grid classes (`col-xs-*`), legacy spacing (`margin-bottom-medium`), and image classes (`img-responsive`, `thumbnail`) with modern equivalents
- **Region**: Replaced `pull-right` with flexbox layout, `col-xs-6` with `col-6`, wrapped sub-regions and cities in shadow cards for visual consistency
- **RideEstimate**: Wrapped anonymous estimate form in a centered card with icon, replacing nested row/col layout
- **Strava**: Replaced `pull-right` cancel button with outline button, wrapped activity cards properly, added empty state pattern for no results
- **Statistic/CityList**: Wrapped tables in `card border-0 shadow-sm` with `table-responsive` and `table-hover`, added `table-light` header styling

## Test plan
- [ ] Verify Timeline page renders all item types correctly (ride photos, tracks, threads, comments, city events, social feeds, participation estimates)
- [ ] Check Region page at different levels (world, continent, country) with map, sub-regions, and cities
- [ ] Test RideEstimate anonymous form submission
- [ ] Test Strava activity list with activities, empty list, and error states
- [ ] Verify Statistic ride list table with pagination
- [ ] Verify CityList table sorting still works
- [ ] Test responsive behavior on mobile viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)