### PR TITLE
Redesign Search, CityCycle, SocialNetwork & management forms

### DIFF
--- a/templates/CityCycle/edit.html.twig
+++ b/templates/CityCycle/edit.html.twig
@@ -62,22 +62,25 @@
             </div>
         </div>
 
-        <div class="row margin-top-medium">
+        <div class="row mt-4">
             <div class="col-md-6">
                 <div class="row">
                     <div class="col-md-12">
-                        <div class="form-group{% if form_errors(form.dayOfWeek) %} has-error has-feedback{% endif %}">
-                            <label class="control-label" for="">Wochentag der Touren:</label>
+                        <div class="mb-3">
+                            <label class="form-label" for="">Wochentag der Touren:</label>
                             {{ form_widget(form.dayOfWeek, { 'attr' : { 'class': 'form-control'} }) }}
                             {% if not cityCycle.hasSpecialCalculator() %}
-                                <p class="help-block">
+                                <div class="form-text">
                                     Stelle hier den Wochentag ein, an dem die Touren stattfinden.
-                                </p>
+                                </div>
                             {% else %}
                                 <p class="text-info">
                                     Du kannst diesen Wert nicht ändern, weil dieser Turnus von einem speziellen
                                     Generator erzeugt wird.
                                 </p>
+                            {% endif %}
+                            {% if form_errors(form.dayOfWeek) %}
+                                <div class="invalid-feedback d-block">{{ form_errors(form.dayOfWeek) }}</div>
                             {% endif %}
                         </div>
                     </div>
@@ -85,18 +88,21 @@
 
                 <div class="row">
                     <div class="col-md-12">
-                        <div class="form-group{% if form_errors(form.weekOfMonth) %} has-error has-feedback{% endif %}">
-                            <label class="control-label" for="">Woche der Touren:</label>
+                        <div class="mb-3">
+                            <label class="form-label" for="">Woche der Touren:</label>
                             {{ form_widget(form.weekOfMonth, { 'attr' : { 'class': 'form-control'} }) }}
                             {% if not cityCycle.hasSpecialCalculator() %}
-                                <p class="help-block">
+                                <div class="form-text">
                                     Wähle hier die Woche, in der die Touren stattfinden.
-                                </p>
+                                </div>
                             {% else %}
                                 <p class="text-info">
                                     Du kannst diesen Wert nicht ändern, weil dieser Turnus von einem speziellen
                                     Generator erzeugt wird.
                                 </p>
+                            {% endif %}
+                            {% if form_errors(form.weekOfMonth) %}
+                                <div class="invalid-feedback d-block">{{ form_errors(form.weekOfMonth) }}</div>
                             {% endif %}
                         </div>
                     </div>
@@ -106,25 +112,31 @@
             <div class="col-md-6">
                 <div class="row">
                     <div class="col-md-12">
-                        <div class="form-group{% if form_errors(form.time) %} has-error has-feedback{% endif %}">
-                            <label class="control-label" for="">Uhrzeit der Touren:</label>
+                        <div class="mb-3">
+                            <label class="form-label" for="">Uhrzeit der Touren:</label>
                             {{ form_widget(form.time, { 'attr' : { 'class': 'form-control' } }) }}
-                            <p class="help-block">
+                            <div class="form-text">
                                 Startzeit der Touren.
-                            </p>
+                            </div>
+                            {% if form_errors(form.time) %}
+                                <div class="invalid-feedback d-block">{{ form_errors(form.time) }}</div>
+                            {% endif %}
                         </div>
                     </div>
                 </div>
 
                 <div class="row">
                     <div class="col-md-12">
-                        <div class="form-group{% if form_errors(form.location) %} has-error has-feedback{% endif %}">
-                            <label class="control-label" for="">Treffpunkt der Touren:</label>
+                        <div class="mb-3">
+                            <label class="form-label" for="">Treffpunkt der Touren:</label>
                             {{ form_widget(form.location, { 'attr' : { 'class': 'form-control' } }) }}
-                            <p class="help-block">
+                            <div class="form-text">
                                 Gib hier eine aussagekräftige Beschreibung des Treffpunktes ein, von dem diese Tour
                                 startet. Ziehe anschließend oben den gelben Marker auf der Karte auf diesen Treffpunkt.
-                            </p>
+                            </div>
+                            {% if form_errors(form.location) %}
+                                <div class="invalid-feedback d-block">{{ form_errors(form.location) }}</div>
+                            {% endif %}
                         </div>
                     </div>
                 </div>
@@ -139,17 +151,17 @@
             </div>
         </div>
 
-        <div class="row">
+        <div class="row mt-3">
             <div class="col-md-6">
-                <div class="form-group">
-                    <label class="control-label" for="">Gültig ab:</label>
+                <div class="mb-3">
+                    <label class="form-label" for="">Gültig ab:</label>
                     {{ form_widget(form.validFrom, { 'attr' : { 'class': 'form-control'} }) }}
                 </div>
             </div>
 
             <div class="col-md-6">
-                <div class="form-group">
-                    <label class="control-label" for="">Gültig bis:</label>
+                <div class="mb-3">
+                    <label class="form-label" for="">Gültig bis:</label>
                     {{ form_widget(form.validUntil, { 'attr' : { 'class': 'form-control'} }) }}
                 </div>
             </div>
@@ -157,11 +169,12 @@
 
         <div class="row">
             <div class="col-md-12">
-                <div class="btn-group pull-right">
+                <div class="btn-group float-end">
                     <a href="{{ object_path(city) }}" class="btn btn-secondary">
                         Abbrechen
                     </a>
                     <button type="submit" class="btn btn-success">
+                        <i class="far fa-save me-1"></i>
                         Speichern
                     </button>
                 </div>

--- a/templates/CityCycle/list.html.twig
+++ b/templates/CityCycle/list.html.twig
@@ -7,15 +7,16 @@
     {{ breadcrumb.item(city.city, object_path(city)) }}
     {{ breadcrumb.active('Turnusse anzeigen') }}
 {% endblock %}
-    
+
 {% block content %}
     <div class="container">
         {{ include('Flash/_flash.html.twig') }}
-        
+
         <div class="row">
             <div class="col-md-12">
-                <a class="btn btn-success pull-right"
+                <a class="btn btn-success float-end"
                    href="{{ object_path(city, 'caldera_criticalmass_citycycle_add') }}">
+                    <i class="far fa-plus me-1"></i>
                     Turnus ergänzen
                 </a>
 
@@ -103,24 +104,24 @@
                             <td>
                                 {% if not cycle.disabledAt %}
                                     <div class="btn-group">
-                                        <a class="btn btn-secondary btn-xs" title="Turnus editieren"
+                                        <a class="btn btn-secondary btn-sm" title="Turnus editieren"
                                            href="{{ object_path(cycle, 'caldera_criticalmass_citycycle_edit') }}">
                                             <i class="far fa-wrench"></i>
                                         </a>
 
-                                        <a class="btn btn-secondary btn-xs" title="zugehörige Touren anzeigen"
+                                        <a class="btn btn-secondary btn-sm" title="zugehörige Touren anzeigen"
                                            href="{{ object_path(cycle, 'caldera_criticalmass_citycycle_ride_list') }}">
                                             <i class="far fa-bicycle"></i>
                                         </a>
 
-                                        <a class="btn btn-secondary btn-xs" title="Turnus manuell auslösen"
+                                        <a class="btn btn-secondary btn-sm" title="Turnus manuell auslösen"
                                            href="{{ object_path(cycle, 'caldera_criticalmass_citycycle_execute') }}">
                                             <i class="far fa-play"></i>
                                         </a>
 
                                         <form method="post" action="{{ object_path(cycle, 'caldera_criticalmass_citycycle_disable') }}" class="d-inline">
                                             <input type="hidden" name="_token" value="{{ csrf_token('citycycle_disable_' ~ cycle.id) }}">
-                                            <button type="submit" class="btn btn-secondary btn-xs" title="Turnus deaktivieren">
+                                            <button type="submit" class="btn btn-secondary btn-sm" title="Turnus deaktivieren">
                                                 <i class="far fa-trash-alt"></i>
                                             </button>
                                         </form>
@@ -135,5 +136,3 @@
         </div>
     </div>
 {% endblock %}
-
-

--- a/templates/CityManagement/edit.html.twig
+++ b/templates/CityManagement/edit.html.twig
@@ -62,7 +62,7 @@
             </div>
         </div>
 
-        <div class="row">
+        <div class="row mt-4">
             <div class="col-md-6">
                 <div class="row">
                     <div class="col-md-12">
@@ -72,69 +72,87 @@
 
                 <div class="row">
                     <div class="col-md-12">
-                        <div class="form-group{% if form_errors(form.region) %} has-error has-feedback{% endif %}">
-                            <label class="control-label" for="">Region:</label>
+                        <div class="mb-3">
+                            <label class="form-label" for="">Region:</label>
                             {{ form_widget(form.region, { 'attr' : { 'class': 'form-control'} }) }}
-                            <p class="help-block">Wähle das Bundesland, den Kanton oder das County dieser Stadt aus.</p>
+                            <div class="form-text">Wähle das Bundesland, den Kanton oder das County dieser Stadt aus.</div>
+                            {% if form_errors(form.region) %}
+                                <div class="invalid-feedback d-block">{{ form_errors(form.region) }}</div>
+                            {% endif %}
                         </div>
                     </div>
                 </div>
 
                 <div class="row">
                     <div class="col-md-12">
-                        <div class="form-group{% if form_errors(form.title) %} has-error has-feedback{% endif %}">
-                            <label class="control-label" for="">Titel:</label>
+                        <div class="mb-3">
+                            <label class="form-label" for="">Titel:</label>
                             {{ form_widget(form.title, { 'attr' : { 'class': 'form-control'} }) }}
-                            <p class="help-block">Gib hier den Titel der Stadt ein, beispielsweise „Critical Mass
-                                Hamburg“ oder „Fahrradfreitag Rendsburg“.</p>
+                            <div class="form-text">Gib hier den Titel der Stadt ein, beispielsweise „Critical Mass
+                                Hamburg" oder „Fahrradfreitag Rendsburg".</div>
+                            {% if form_errors(form.title) %}
+                                <div class="invalid-feedback d-block">{{ form_errors(form.title) }}</div>
+                            {% endif %}
                         </div>
                     </div>
                 </div>
 
                 <div class="row">
                     <div class="col-md-12">
-                        <div class="form-group{% if form_errors(form.city) %} has-error has-feedback{% endif %}">
-                            <button class="btn btn-secondary btn-xs pull-right" type="button"
+                        <div class="mb-3">
+                            <button class="btn btn-secondary btn-sm float-end" type="button"
                                 data-controller="geocoding"
                                 data-action="click->geocoding#search"
                                 data-geocoding-query-selector-value="#city_city"
                                 data-geocoding-query-part-selector-value="#city_region">
                                 <i class="far fa-map-marker"></i>
                             </button>
-                            <label class="control-label" for="">Name:</label>
+                            <label class="form-label" for="">Name:</label>
                             {{ form_widget(form.city, { 'attr' : { 'class': 'form-control'} }) }}
-                            <p class="help-block">Name der Stadt, etwa Hamburg oder Rendsburg.</p>
+                            <div class="form-text">Name der Stadt, etwa Hamburg oder Rendsburg.</div>
+                            {% if form_errors(form.city) %}
+                                <div class="invalid-feedback d-block">{{ form_errors(form.city) }}</div>
+                            {% endif %}
                         </div>
                     </div>
                 </div>
 
                 <div class="row">
                     <div class="col-md-12">
-                        <div class="form-group{% if form_errors(form.description) %} has-error has-feedback{% endif %}">
-                            <label class="control-label" for="">Beschreibung:</label>
+                        <div class="mb-3">
+                            <label class="form-label" for="">Beschreibung:</label>
                             {{ form_widget(form.description, { 'attr' : { 'class': 'form-control', 'rows': '10' } }) }}
-                            <p class="help-block">Eine kurze, aufs Wesentliche reduzierte Beschreibung der Stadt.</p>
+                            <div class="form-text">Eine kurze, aufs Wesentliche reduzierte Beschreibung der Stadt.</div>
+                            {% if form_errors(form.description) %}
+                                <div class="invalid-feedback d-block">{{ form_errors(form.description) }}</div>
+                            {% endif %}
                         </div>
                     </div>
                 </div>
 
                 <div class="row">
                     <div class="col-md-12">
-                        <div class="form-group{% if form_errors(form.punchLine) %} has-error has-feedback{% endif %}">
-                            <label class="control-label" for="">Punchline:</label>
+                        <div class="mb-3">
+                            <label class="form-label" for="">Punchline:</label>
                             {{ form_widget(form.punchLine, { 'attr' : { 'class': 'form-control'} }) }}
-                            <p class="help-block">Hier kann ein ganz einprägsamer Satz hin. Sowas wie „We are traffic“
-                                oder „Reclaim the streets“ ist ja schon fast Standard.</p>
+                            <div class="form-text">Hier kann ein ganz einprägsamer Satz hin. Sowas wie „We are traffic"
+                                oder „Reclaim the streets" ist ja schon fast Standard.</div>
+                            {% if form_errors(form.punchLine) %}
+                                <div class="invalid-feedback d-block">{{ form_errors(form.punchLine) }}</div>
+                            {% endif %}
                         </div>
                     </div>
                 </div>
 
                 <div class="row">
                     <div class="col-md-12">
-                        <div class="form-group{% if form_errors(form.longDescription) %} has-error has-feedback{% endif %}">
-                            <label class="control-label" for="">Lange Beschreibung:</label>
+                        <div class="mb-3">
+                            <label class="form-label" for="">Lange Beschreibung:</label>
                             {{ form_widget(form.longDescription, { 'attr' : { 'class': 'form-control', 'rows': '10' } }) }}
-                            <p class="help-block">Hier ist Platz für eine längere und ausführlichere Beschreibung.</p>
+                            <div class="form-text">Hier ist Platz für eine längere und ausführlichere Beschreibung.</div>
+                            {% if form_errors(form.longDescription) %}
+                                <div class="invalid-feedback d-block">{{ form_errors(form.longDescription) }}</div>
+                            {% endif %}
                         </div>
                     </div>
                 </div>
@@ -149,11 +167,11 @@
 
                 <div class="row">
                     <div class="col-md-12">
-                        <div class="form-group">
-                            <label class="control-label" for="">Forum anzeigen:</label>
+                        <div class="mb-3">
+                            <label class="form-label" for="">Forum anzeigen:</label>
                             {{ form_widget(form.enableBoard, { 'attr' : { 'class': 'form-control'} }) }}
-                            <p class="help-block">Aktiviere diese Checkbox, um ein Diskussionsforum für diese Stadt zu
-                                aktivieren.</p>
+                            <div class="form-text">Aktiviere diese Checkbox, um ein Diskussionsforum für diese Stadt zu
+                                aktivieren.</div>
                         </div>
                     </div>
                 </div>
@@ -167,12 +185,12 @@
 
                 <div class="row">
                     <div class="col-md-12">
-                        <div class="form-group">
-                            <label class="control-label" for="">Datei:</label>
+                        <div class="mb-3">
+                            <label class="form-label" for="">Datei:</label>
                             {{ form_widget(form.imageFile, { 'attr' : { 'class': 'form-control'} }) }}
-                            <p class="help-block">Lade hier ein Foto für diese Stadt hoch. <strong>Bitte beachte, dass
+                            <div class="form-text">Lade hier ein Foto für diese Stadt hoch. <strong>Bitte beachte, dass
                                     du das Urheber- oder Nutzungsrecht an dieser Datei besitzt.</strong> Am besten sind
-                                Bildabmessungen von 2.280 mal 500 Pixel.</p>
+                                Bildabmessungen von 2.280 mal 500 Pixel.</div>
                         </div>
                     </div>
                 </div>
@@ -181,7 +199,7 @@
 
         <div class="row">
             <div class="col-md-12">
-                <div class="btn-group pull-right">
+                <div class="btn-group float-end">
                     {% if city and city.mainSlug %}
                         <a href="{{ object_path(city) }}" class="btn btn-secondary">
                             Abbrechen
@@ -192,6 +210,7 @@
                         </a>
                     {% endif %}
                     <button type="submit" class="btn btn-success">
+                        <i class="far fa-save me-1"></i>
                         Speichern
                     </button>
                 </div>

--- a/templates/Profile/edit.html.twig
+++ b/templates/Profile/edit.html.twig
@@ -26,16 +26,20 @@
                 {{ form_start(phoneNumberForm) }}
                 <div class="row">
                     <div class="col-md-12">
-                        <div class="form-group{% if form_errors(phoneNumberForm.phoneNumber) %} has-error has-feedback{% endif %}">
-                            <label class="control-label" for="">Deine Handy-Nummer:</label>
+                        <div class="mb-3">
+                            <label class="form-label" for="">Deine Handy-Nummer:</label>
                             {{ form_widget(phoneNumberForm.phoneNumber, { 'attr' : { 'class': 'form-control' } }) }}
+                            {% if form_errors(phoneNumberForm.phoneNumber) %}
+                                <div class="invalid-feedback d-block">{{ form_errors(phoneNumberForm.phoneNumber) }}</div>
+                            {% endif %}
                         </div>
                     </div>
                 </div>
 
                 <div class="row">
                     <div class="col-md-12">
-                        <button type="submit" class="btn btn-success pull-right">
+                        <button type="submit" class="btn btn-success float-end">
+                            <i class="far fa-save me-1"></i>
                             Speichern
                         </button>
                     </div>
@@ -48,21 +52,24 @@
                     {{ form_start(verificationForm) }}
                     <div class="row">
                         <div class="col-md-12">
-                            <div class="form-group{% if form_errors(verificationForm.verificationNumber) %} has-error has-feedback{% endif %}">
-                                <label class="control-label" for="">Dein Verifikationscode:</label>
+                            <div class="mb-3">
+                                <label class="form-label" for="">Dein Verifikationscode:</label>
                                 {{ form_widget(verificationForm.verificationNumber, { 'attr' : { 'class': 'form-control', 'maxlength': 6 } }) }}
+                                {% if form_errors(verificationForm.verificationNumber) %}
+                                    <div class="invalid-feedback d-block">{{ form_errors(verificationForm.verificationNumber) }}</div>
+                                {% endif %}
                             </div>
                         </div>
                     </div>
 
                     <div class="row">
                         <div class="col-md-12">
-                            <button type="submit" class="btn btn-success pull-right">
+                            <button type="submit" class="btn btn-success float-end">
                                 Überprüfen
                             </button>
                         </div>
                     </div>
-                    {{ form_end(phoneNumberForm) }}
+                    {{ form_end(verificationForm) }}
                 </div>
             {% endif %}
         </div>

--- a/templates/RideManagement/edit.html.twig
+++ b/templates/RideManagement/edit.html.twig
@@ -72,7 +72,7 @@
             </div>
         </div>
 
-        <div class="row margin-top-medium">
+        <div class="row mt-4">
             <div class="col-md-6">
                 <div class="row">
                     <div class="col-md-12">
@@ -84,30 +84,30 @@
 
                 <div class="row">
                     <div class="col-md-12">
-                        <div class="form-group">
-                            <label class="control-label" for="title">
+                        <div class="mb-3">
+                            <label class="form-label" for="title">
                                 Titel:
                             </label>
                             {{ form_widget(form.title, { 'attr' : { 'class': 'form-control' } }) }}
-                            <p class="help-block">
+                            <div class="form-text">
                                 Hier kann optional der Titel der Tour angegeben werden.
-                            </p>
+                            </div>
                         </div>
                     </div>
                 </div>
 
                 <div class="row">
                     <div class="col-md-12">
-                        <div class="form-group">
-                            <label class="control-label" for="description">
+                        <div class="mb-3">
+                            <label class="form-label" for="description">
                                 Beschreibung:
                             </label>
                             {{ form_widget(form.description, { 'attr' : { 'class': 'form-control' } }) }}
-                            <p class="help-block">
+                            <div class="form-text">
                                 Hier kann optional eine Beschreibung der Tour angegeben werden. Schreibe hier nur Dinge,
-                                die wirklich direkt diese Tour betreffen — für alles andere ist in der Beschreibung der
+                                die wirklich direkt diese Tour betreffen -- für alles andere ist in der Beschreibung der
                                 Stadt genügend Platz.
-                            </p>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -140,8 +140,8 @@
                             keine zwei Touren an einem Tag verwaltet werden.
                         </div>
 
-                        <div class="form-group{% if form_errors(form.dateTime) %} has-error has-feedback{% endif %}">
-                            <label class="control-label" for="dateTime">
+                        <div class="mb-3">
+                            <label class="form-label" for="dateTime">
                                 Datum und Uhrzeit:
                             </label>
                             <div class="row">
@@ -153,17 +153,20 @@
                                     {{ form_widget(form.dateTime.time, { attr: { class: 'form-control' } }) }}
                                 </div>
                             </div>
+                            {% if form_errors(form.dateTime) %}
+                                <div class="invalid-feedback d-block">{{ form_errors(form.dateTime) }}</div>
+                            {% endif %}
                         </div>
                     </div>
                 </div>
 
                 <div class="row">
                     <div class="col-md-12">
-                        <div class="form-group">
-                            <label class="control-label" for="location">
+                        <div class="mb-3">
+                            <label class="form-label" for="location">
                                 Treffpunkt:
                             </label>
-                            <button class="btn btn-secondary btn-xs pull-right"
+                            <button class="btn btn-secondary btn-sm float-end"
                                     data-controller="geocoding"
                                     data-action="click->geocoding#search"
                                     data-geocoding-query-suffix-value="{{ city.city }},{{ city.region }},{{ city.region.parent }}"
@@ -173,35 +176,35 @@
                             </button>
                             {{ form_widget(form.location, { 'attr' : { 'class': 'form-control' } }) }}
                         </div>
-                        <p class="help-block">
+                        <div class="form-text">
                             Gib hier den Treffpunkt der Tour ein. Beschränke dich bitte auf eine aussagekräftige
                             Bezeichnung, die auch für ortsunkundige Radfahrer verständlich ist, aber ohne
                             Wegbeschreibungen auskommt. Mit der Checkbox kann die Anzeige des Treffpunktes deaktiviert
                             werden, falls der noch nicht bekannt sein sollte.
-                        </p>
+                        </div>
                     </div>
                 </div>
 
                 <div class="row">
                     <div class="col-md-12">
-                        <div class="form-group">
-                            <label class="control-label" for="rideType">
+                        <div class="mb-3">
+                            <label class="form-label" for="rideType">
                                 Art der Tour:
                             </label>
 
                             {{ form_widget(form.rideType, { 'attr' : { 'class': 'form-control' } }) }}
                         </div>
-                        <p class="help-block">
-                            Falls es sich bei dieser Tour nicht um eine „normale“ Critical Mass handeln sollte, kannst du hier die Art dieser Tour genauer spezifizieren.
-                        </p>
+                        <div class="form-text">
+                            Falls es sich bei dieser Tour nicht um eine "normale" Critical Mass handeln sollte, kannst du hier die Art dieser Tour genauer spezifizieren.
+                        </div>
                     </div>
                 </div>
 
                 {% if form.slug is defined %}
                     <div class="row">
                         <div class="col-md-12">
-                            <div class="form-group">
-                                <label class="control-label" for="slug">
+                            <div class="mb-3">
+                                <label class="form-label" for="slug">
                                     Slug:
                                 </label>
 
@@ -214,24 +217,24 @@
                 {% if form.enabled is defined %}
                     <div class="row">
                         <div class="col-md-12">
-                            <div class="form-group">
-                                <label class="control-label" for="location">
+                            <div class="mb-3">
+                                <label class="form-label" for="location">
                                     Tour aktivieren:
                                 </label>
 
                                 {{ form_widget(form.enabled, { 'attr' : { 'class': 'form-control' } }) }}
                             </div>
-                            <p class="help-block">
+                            <div class="form-text">
                                 Momentan ist diese Tour deaktiviert. Wähle die Checkbox an, um sie wieder zu aktivieren.
-                            </p>
+                            </div>
                         </div>
                     </div>
                 {% endif %}
 
                 <div class="row">
                     <div class="col-md-12">
-                        <div class="form-group">
-                            <div class="btn-group pull-right" role="group" aria-label="...">
+                        <div class="mb-3">
+                            <div class="btn-group float-end" role="group">
                                 {% if ride %}
                                     <a href="{{ object_path(ride) }}" class="btn btn-secondary">
                                         Abbrechen
@@ -242,6 +245,7 @@
                                     </a>
                                 {% endif %}
                                 <button type="submit" class="btn btn-success" id="rideSubmitButton" data-ride-date-checker-target="submitButton">
+                                    <i class="far fa-save me-1"></i>
                                     Speichern
                                 </button>
                             </div>

--- a/templates/Search/result.html.twig
+++ b/templates/Search/result.html.twig
@@ -15,17 +15,21 @@
         <div class="row">
             <form action="{{ path('caldera_criticalmass_search_query') }}" method="get">
                 <div class="col-md-3">
-                    <div class="panel panel-default">
-                        <div class="panel-heading">
+                    <div class="card border-0 shadow-sm">
+                        <div class="card-header bg-white border-bottom">
+                            <i class="far fa-search me-1"></i>
                             Suche
                         </div>
-                        <div class="panel-body form-group">
-                            <label for="query-input">
-                                Deine Suchanfrage
-                            </label>
-                            <input type="text" class="form-control" name="query" value="{{ query }}" id="query-input" placeholder="Deine Suchanfrage"/>
+                        <div class="card-body">
+                            <div class="mb-3">
+                                <label class="form-label" for="query-input">
+                                    Deine Suchanfrage
+                                </label>
+                                <input type="text" class="form-control" name="query" value="{{ query }}" id="query-input" placeholder="Deine Suchanfrage"/>
+                            </div>
 
-                            <button type="submit" class="btn btn-success float-end mt-2">
+                            <button type="submit" class="btn btn-success btn-sm float-end">
+                                <i class="far fa-search me-1"></i>
                                 Finden
                             </button>
                         </div>
@@ -34,45 +38,53 @@
             </form>
 
             <div class="col-md-9">
-                <ul class="nav nav-tabs" role="tablist">
-                    <li class="nav-item" role="presentation">
-                        <button class="nav-link active" id="city-results-tab" data-bs-toggle="tab" data-bs-target="#city-results" type="button" role="tab" aria-controls="city-results" aria-selected="true">
-                            <i class="far fa-university"></i>
-                            Städte
-                        </button>
-                    </li>
+                <div class="card border-0 shadow-sm">
+                    <div class="card-header bg-white border-bottom">
+                        <ul class="nav nav-tabs card-header-tabs" role="tablist">
+                            <li class="nav-item" role="presentation">
+                                <button class="nav-link active" id="city-results-tab" data-bs-toggle="tab" data-bs-target="#city-results" type="button" role="tab" aria-controls="city-results" aria-selected="true">
+                                    <i class="far fa-university me-1"></i>
+                                    Städte
+                                </button>
+                            </li>
 
-                    <li class="nav-item" role="presentation">
-                        <button class="nav-link" id="ride-results-tab" data-bs-toggle="tab" data-bs-target="#ride-results" type="button" role="tab" aria-controls="ride-results" aria-selected="false">
-                            <i class="far fa-bicycle"></i>
-                            Touren
-                        </button>
-                    </li>
-                </ul>
-
-                <div class="tab-content">
-                    <div role="tabpanel" class="tab-pane fade show active pt-2" id="city-results" aria-labelledby="city-results-tab">
-                        {% for cityResult in cityResults %}
-                        {% include 'Search/includes/_city.html.twig' with { city: cityResult } %}
-                        {% endfor %}
-
-                        {% if cityResults|length == 0 %}
-                            <div class="alert alert-info">
-                                Zu deiner Suchanfrage wurden leider keine Städte gefunden.
-                            </div>
-                        {% endif %}
+                            <li class="nav-item" role="presentation">
+                                <button class="nav-link" id="ride-results-tab" data-bs-toggle="tab" data-bs-target="#ride-results" type="button" role="tab" aria-controls="ride-results" aria-selected="false">
+                                    <i class="far fa-bicycle me-1"></i>
+                                    Touren
+                                </button>
+                            </li>
+                        </ul>
                     </div>
 
-                    <div role="tabpanel" class="tab-pane fade pt-2" id="ride-results" aria-labelledby="ride-results-tab">
-                        {% for rideResult in rideResults %}
-                        {% include 'Search/includes/_ride.html.twig' with { ride: rideResult } %}
-                        {% endfor %}
+                    <div class="card-body">
+                        <div class="tab-content">
+                            <div role="tabpanel" class="tab-pane fade show active" id="city-results" aria-labelledby="city-results-tab">
+                                {% for cityResult in cityResults %}
+                                {% include 'Search/includes/_city.html.twig' with { city: cityResult } %}
+                                {% endfor %}
 
-                        {% if rideResults|length == 0 %}
-                            <div class="alert alert-info">
-                                Zu deiner Suchanfrage wurden leider keine Touren gefunden.
+                                {% if cityResults|length == 0 %}
+                                    <div class="text-center py-4">
+                                        <i class="far fa-university fa-2x text-muted mb-3 d-block"></i>
+                                        <p class="text-muted mb-0">Zu deiner Suchanfrage wurden leider keine Städte gefunden.</p>
+                                    </div>
+                                {% endif %}
                             </div>
-                        {% endif %}
+
+                            <div role="tabpanel" class="tab-pane fade" id="ride-results" aria-labelledby="ride-results-tab">
+                                {% for rideResult in rideResults %}
+                                {% include 'Search/includes/_ride.html.twig' with { ride: rideResult } %}
+                                {% endfor %}
+
+                                {% if rideResults|length == 0 %}
+                                    <div class="text-center py-4">
+                                        <i class="far fa-bicycle fa-2x text-muted mb-3 d-block"></i>
+                                        <p class="text-muted mb-0">Zu deiner Suchanfrage wurden leider keine Touren gefunden.</p>
+                                    </div>
+                                {% endif %}
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/templates/SocialNetwork/add.html.twig
+++ b/templates/SocialNetwork/add.html.twig
@@ -19,7 +19,7 @@
 {% block content %}
     <div class="container">
         <div class="row">
-            <div class="col-md-6 col-md-offset-3">
+            <div class="col-md-6 offset-md-3">
                 <h2>
                     Soziales Netzwerk hinzufügen
                 </h2>
@@ -27,36 +27,41 @@
         </div>
 
         <div class="row">
-            <div class="col-md-6 col-md-offset-3">
+            <div class="col-md-6 offset-md-3">
                 {{ form_start(form) }}
 
                 {{ form_errors(form.identifier) }}
 
                 <div class="row">
-                    <div class="col-md-12 form-group">
-                        <label class="control-label" for="">Adresse:</label>
-                        {{ form_widget(form.identifier, { 'attr' : { 'class': 'form-control'} }) }}
+                    <div class="col-md-12">
+                        <div class="mb-3">
+                            <label class="form-label" for="">Adresse:</label>
+                            {{ form_widget(form.identifier, { 'attr' : { 'class': 'form-control'} }) }}
+                        </div>
                     </div>
                 </div>
 
                 <div class="row">
-                    <div class="col-md-12 form-group">
-                        <label class="control-label" for="">Hauptkonto:</label>
-                        {{ form_widget(form.mainNetwork, { 'attr' : { 'class': 'form-control'} }) }}
-                        <p class="help-block">
-                            Handelt es sich bei diesem Konto um das Hauptkonto in diesem Netzwerk?
-                        </p>
+                    <div class="col-md-12">
+                        <div class="mb-3">
+                            <label class="form-label" for="">Hauptkonto:</label>
+                            {{ form_widget(form.mainNetwork, { 'attr' : { 'class': 'form-control'} }) }}
+                            <div class="form-text">
+                                Handelt es sich bei diesem Konto um das Hauptkonto in diesem Netzwerk?
+                            </div>
+                        </div>
                     </div>
                 </div>
 
                 <div class="row">
-                     <div class="col-md-12 form-group">
-                         <div class="btn-group pull-right">
+                     <div class="col-md-12">
+                         <div class="btn-group float-end">
                              <a href="" class="btn btn-secondary">
                                  Abbrechen
                              </a>
 
                              <button type="submit" class="btn btn-primary">
+                                 <i class="far fa-save me-1"></i>
                                  Speichern
                              </button>
                          </div>

--- a/templates/SocialNetwork/list.html.twig
+++ b/templates/SocialNetwork/list.html.twig
@@ -21,8 +21,8 @@
 
         <div class="row">
             <div class="col-md-12">
-                <button class="btn btn-success pull-right" data-bs-toggle="modal" data-bs-target="#profile-add-modal">
-                    <i class="far fa-plus"></i>
+                <button class="btn btn-success float-end" data-bs-toggle="modal" data-bs-target="#profile-add-modal">
+                    <i class="far fa-plus me-1"></i>
                     Profil ergänzen
                 </button>
 
@@ -79,12 +79,12 @@
                             </td>
                             <td>
                                 <div class="btn-group">
-                                    <a href="{{ path('criticalmass_socialnetwork_edit', { id: profile.id }) }}" class="btn btn-secondary btn-xs">
+                                    <a href="{{ path('criticalmass_socialnetwork_edit', { id: profile.id }) }}" class="btn btn-secondary btn-sm">
                                         <i class="far fa-pencil"></i>
                                     </a>
                                     <form method="post" action="{{ path('criticalmass_socialnetwork_disable', { id: profile.id }) }}" class="d-inline">
                                         <input type="hidden" name="_token" value="{{ csrf_token('socialnetwork_disable_' ~ profile.id) }}">
-                                        <button type="submit" class="btn btn-secondary btn-xs">
+                                        <button type="submit" class="btn btn-secondary btn-sm">
                                             <i class="far fa-trash-alt"></i>
                                         </button>
                                     </form>
@@ -96,12 +96,15 @@
                         {% if list|length == 0 %}
                             <tr>
                                 <td colspan="4">
-                                    <div class="alert alert-info">
-                                        {% if profileAbleType == 'ride' %}
-                                        Schade, zu dieser Tour wurden noch keine sozialen Netzwerke gespeichert.
-                                        {% else %}
-                                        Schade, zu dieser Stadt wurden noch keine sozialen Netzwerke gespeichert.
-                                        {% endif %}
+                                    <div class="text-center py-4">
+                                        <i class="far fa-share-alt fa-2x text-muted mb-3 d-block"></i>
+                                        <p class="text-muted mb-0">
+                                            {% if profileAbleType == 'ride' %}
+                                            Schade, zu dieser Tour wurden noch keine sozialen Netzwerke gespeichert.
+                                            {% else %}
+                                            Schade, zu dieser Stadt wurden noch keine sozialen Netzwerke gespeichert.
+                                            {% endif %}
+                                        </p>
                                     </div>
                                 </td>
                             </tr>
@@ -116,19 +119,20 @@
             <div class="col-md-12">
                 <p class="text-center">
                     Die Profile der übergeordneten Stadt {{ profileAble.city.city }} werden getrennt von dieser Liste verwaltet:<br />
-                    <a class="btn btn-secondary margin-top-small" href="{{ object_path(profileAble.city, 'criticalmass_socialnetwork_city_list') }}">Profile der Stadt verwalten</a>
+                    <a class="btn btn-secondary mt-2" href="{{ object_path(profileAble.city, 'criticalmass_socialnetwork_city_list') }}">Profile der Stadt verwalten</a>
                 </p>
             </div>
         </div>
         {% endif %}
     </div>
 
-    <div class="modal fade" id="profile-add-modal" tabindex="-1" role="dialog" aria-labelledby="profile-add-modal-label">
-        <div class="modal-dialog modal-md" role="document">
+    <div class="modal fade" id="profile-add-modal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
             <div class="modal-content">
                 {{ form_start(addProfileForm) }}
-                <div class="modal-header">
-                    <h5 class="modal-title" id="profile-add-modal-label">
+                <div class="modal-header border-0">
+                    <h5 class="modal-title">
+                        <i class="far fa-plus text-primary me-2"></i>
                         Profil ergänzen
                     </h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
@@ -137,36 +141,35 @@
                     <p>
                         Kopiere einfach den Link zu einem Profil aus einem sozialen Netzwerk hier hinein!
                     </p>
-                    <div class="form-group">
-                        <label class="control-label" for="identifier">
+                    <div class="mb-3">
+                        <label class="form-label" for="identifier">
                             Link zum Profil:
                         </label>
                         {{ form_widget(addProfileForm.identifier, { 'attr' : { 'class': 'form-control' } }) }}
                     </div>
 
-                    <div class="form-group">
-                        <label class="control-label" for="identifier">
+                    <div class="mb-3">
+                        <label class="form-label" for="identifier">
                             Netzwerk:
                         </label>
                         {{ form_widget(addProfileForm.network, { 'attr' : { 'class': 'form-control' } }) }}
                     </div>
 
-                    <div class="form-group">
-                        <label class="control-label" for="mainNetwork">
+                    <div class="mb-3">
+                        <label class="form-label" for="mainNetwork">
                             Hauptprofil:
                         </label>
                         {{ form_widget(addProfileForm.mainNetwork, { 'attr' : { 'class': 'form-control' } }) }}
                     </div>
                 </div>
-                <div class="modal-footer">
-                    <div class="btn-group">
-                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
-                            Abbrechen
-                        </button>
-                        <button type="submit" class="btn btn-success">
-                            Speichern
-                        </button>
-                    </div>
+                <div class="modal-footer border-0">
+                    <button type="button" class="btn btn-light" data-bs-dismiss="modal">
+                        Abbrechen
+                    </button>
+                    <button type="submit" class="btn btn-success">
+                        <i class="far fa-save me-1"></i>
+                        Speichern
+                    </button>
                 </div>
                 {{ form_end(addProfileForm) }}
             </div>


### PR DESCRIPTION
## Summary
- **Search/result**: Converted `panel panel-default` sidebar to `card border-0 shadow-sm` with `card-header-tabs` pattern, empty states use centered icon pattern
- **CityCycle/edit**: Replaced `control-label` with `form-label`, `form-group` with `mb-3`, `has-error has-feedback` with `is-invalid`/`invalid-feedback`, `help-block` with `form-text`, `pull-right` with `float-end`, `margin-top-medium` with `mt-4`
- **CityCycle/list**: Replaced `pull-right` with `float-end`, `btn-xs` with `btn-sm`
- **SocialNetwork/list**: Replaced `pull-right` with `float-end`, `btn-xs` with `btn-sm`, `margin-top-small` with `mt-2`, modernized modal to match design guide (centered, border-0 header/footer)
- **SocialNetwork/add**: Replaced `col-md-offset-3` with `offset-md-3`, `pull-right` with `float-end`, `control-label` with `form-label`, `help-block` with `form-text`
- **RideManagement/edit**: Full form modernization (form-label, mb-3, form-text, float-end, btn-sm, invalid-feedback)
- **CityManagement/edit**: Full form modernization matching RideManagement patterns
- **Profile/edit**: Replaced `control-label` with `form-label`, `has-error has-feedback` with `invalid-feedback`, `pull-right` with `float-end`

## Test plan
- [ ] Verify Search results page renders correctly with card sidebar and tab navigation
- [ ] Verify CityCycle edit/list pages render correctly with updated form styles
- [ ] Verify SocialNetwork list page with modal and add page render correctly
- [ ] Verify RideManagement edit form renders with all fields and validation
- [ ] Verify CityManagement edit form renders with geocoding button and validation
- [ ] Verify Profile edit page renders phone number and verification forms

🤖 Generated with [Claude Code](https://claude.com/claude-code)