### PR TITLE
Redesign Static page templates to BS5 cards

### DIFF
--- a/templates/Static/critical-maps.html.twig
+++ b/templates/Static/critical-maps.html.twig
@@ -5,22 +5,24 @@
 {% block content %}
     <div class="container">
         <div class="row">
-            <div class="col-md-10 col-md-offset-1">
-                <h1>
-                    Critical Mass Live Tracking
-                </h1>
+            <div class="col-md-10 offset-md-1">
+                <div class="card border-0 shadow-sm mb-4">
+                    <div class="card-body text-center py-5">
+                        <i class="far fa-map-marker-alt fa-3x text-muted mb-3"></i>
+                        <h1 class="h3">
+                            Critical Mass Live Tracking
+                        </h1>
 
-                <p>
-                    Wenn du diese Seite siehst, bist du vermutlich einen veralteten Link gefolgt &mdash; bitte besuche
-                    criticalmass.live für weitere Informationen zum Live-Tracking.
-                </p>
+                        <p class="text-muted mb-4">
+                            Wenn du diese Seite siehst, bist du vermutlich einen veralteten Link gefolgt &mdash; bitte besuche
+                            criticalmass.live für weitere Informationen zum Live-Tracking.
+                        </p>
 
-                <p class="text-center">
-                    <a href="https://criticalmass.live/" class="btn btn-primary">
-                        criticalmass.live
-                    </a>
-                </p>
-
+                        <a href="https://criticalmass.live/" class="btn btn-primary">
+                            <i class="far fa-external-link-alt me-1"></i>criticalmass.live
+                        </a>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/templates/Static/gdpr.html.twig
+++ b/templates/Static/gdpr.html.twig
@@ -19,398 +19,359 @@
                 Hier erfährst du, was mit deinen persönlichen und allgemeinen Daten auf unserer Website passiert.
             </p>
 
-            <p>
-                Seit Anfang an, als criticalmass.in noch ein Studentenprojekt an der <a href="https://fh-wedel.de/">Fachhochschule Wedel</a> war, galt der Grundsatz, keinen Unfug mit persönlichen Daten anzustellen. Daran hat sich bis heute nichts geändert: Wir nutzen so wenig persönliche Daten wie möglich und haben kein Interesse daran, mit deinen Daten Geld zu verdienen. Wenn du ein wenig von Programmierung verstehst, kannst du dich in unserem <a href="https://github.com/calderacc/criticalmass-in">GitHub-Repository</a> selbst davon überzeugen.
-            </p>
-
-            <a name="dein-profil"></a>
-            <h3>
-                Dein Profil
-            </h3>
-
-            <p>
-                Wenn du dich bei criticalmass.in registrierst, speichern wir folgende deiner Daten in unserer Datenbank:
-            </p>
-
-            <ul>
-                <li>
-                    deinen Benutzernamen
-                </li>
-
-                <li>
-                    deine E-Mail-Adresse, sofern du dich nicht über soziale Netzwerke einloggst
-                </li>
-
-                <li>
-                    ein verschlüsseltes Abbild deines Kennwortes, sofern du dich nicht über soziale Netzwerke einloggst
-                </li>
-
-                <li>
-                    den Zeitpunkt deines letzten Logins
-                </li>
-
-                <li>
-                    die Profilfarbe, mit der beispielsweise deine Tracks auf Karten dargestellt werden
-                </li>
-
-                <li>
-                    den Dateinamen deines Profilfotos
-                </li>
-
-                <li>
-                    Benutzer-Kennung und verschlüsseltes Login-Geheimnis, falls du dich über soziale Netzwerke einloggst
-                </li>
-            </ul>
-
-            <p>
-                Du kannst deinen Benutzernamen jederzeit in deinen Profileinstellungen ändern. Wir empfehlen dir die Verwendung eines Pseudonyms, das keine Rückschlüsse auf deine Persönlichkeit zulässt. Wir setzen allerdings die Verwendung eines Benutzernamens voraus, damit andere Nutzer auf criticalmass.in dich erkennen können.
-            </p>
-
-            <p>
-                Selbstverständlich kannst du auch deine E-Mail-Adresse in deinen Kontoeinstellungen ändern. Deine E-Mail-Adresse benötigen wir, um dir im Notfall ein neues Kennwort zusenden zu können.
-            </p>
-
-            <p>
-                Falls du dich nicht über soziale Netzwerke einloggst, kannst du in deinen Profileinstellungen außerdem dein Kennwort und deine E-Mail-Adresse ändern.
-            </p>
-
-            <a name="login-soziale-netzwerke"></a>
-            <h3>
-                Login über soziale Netzwerke
-            </h3>
-
-            <p>
-                Anstatt über Benutzernamen und Kennwort kannst du dich auf criticalmass.in auch über Facebook oder Strava anmelden. Eine solche Registrierung läuft grundsätzlich so ab, dass unter unserem Login-Formular auf den Knopf von einem dieser drei Anbieter klickst. Du wirst daraufhin zur Webseite dieses Anbieters weitergeleitet, wo du gefragt wirst, ob du criticalmass.in den Zugriff auf dein Benutzerkonto gestattest. Wenn du uns diese Genehmigung erteilst, wirst du anschließend auf criticalmass.in zurückgeleitet, wo du entweder in dein bestehendes Benutzerkonto eingeloggt wirst oder ein neues Benutzerkonto mit den Daten aus jenem sozialen Netzwerk erstellt wird.
-            </p>
-
-            <p>
-                Wenn du dein Benutzerkonto bei criticalmass.in löscht, werden selbstverständlich alle Verknüpfungen zu sozialen Netzwerken widerrufen.
-            </p>
-
-            <h4>
-                Login über Facebook
-            </h4>
-
-            <p>
-                Anbieter des Logins über <a href="https://facebook.com/">Facebook</a> ist die Facebook Ireland Limited, 4 Grand Canal Square, Dublin 2, Irland.
-            </p>
-
-            <p>
-                Wenn du dich zu einem Login über Facebook entscheidest, fragen wir die folgenden Daten von Facebook ab und speichern sie in unserer Datenbank:
-            </p>
-
-            <ul>
-                <li>
-                    numerische Kennung deines Benutzerkontos bei Facebook
-                </li>
-                <li>
-                    Vor- und Nachname deines Benutzerkontos bei Facebook
-                </li>
-                <li>
-                    bei Facebook hinterlegte E-Mail-Adresse
-                </li>
-            </ul>
-
-            <h4>
-                Login über Strava
-            </h4>
-
-            <p>
-                Anbieter des Logins über <a href="https://strava.com/">Strava</a> ist die Strava, Inc., 500 3rd Street, Suite 110 , San Francisco, CA 94107.
-            </p>
-
-            <ul>
-                <li>
-                    numerische Kennung deines Benutzerkontos bei Strava
-                </li>
-                <li>
-                    Vor- und Nachname deines Benutzerkontos bei Strava
-                </li>
-                <li>
-                    bei Strava hinterlegte E-Mail-Adresse
-                </li>
-            </ul>
-            <a name="fotos"></a>
-            <h3>
-                Fotos
-            </h3>
-
-            <p>
-                Als angemeldeter Nutzer kannst du Fotos zu Touren hochladen, die auch von nicht angemeldeten Nutzern betrachtet werden können.
-            </p>
-
-            <p>
-                Wenn deine hochgeladenen Fotos GPS-Daten enthalten oder du bereits einen Track zu dieser Tour hochgeladen oder importiert hast, versuchen wir deine Fotos zu verorten und auf der Karte der Tour deinen Aufnahmestandpunkt darzustellen.
-            </p>
-
-            <p>
-                Für Fotos von Critical-Mass-Touren ist <a href="https://www.gesetze-im-internet.de/kunsturhg/__23.html">§ 23 Abs. 1 Nr. 3 KunstUrhG</a> einschlägig, der die Veröffentlichung der „Bilder von Versammlungen, Aufzügen und ähnlichen Vorgängen, an denen die dargestellten Personen teilgenommen haben“ erlaubt.
-            </p>
-
-            <p>
-                Du hast selbstverständlich die Möglichkeit, <a href="{{ path('caldera_criticalmass_photo_user_list') }}">Fotos zu löschen oder zu deaktivieren</a>. Wenn du dein Benutzerkonto löschst, werden auch deine hochgeladenen Fotos entfernt.
-            </p>
-
-            <p>
-                Der Aufruf von Fotos wird zu statistischen Zwecken gespeichert. Wenn du als eingeloggter Nutzer Fotos betrachtest, wird dieser Aufruf mit deinem Benutzerkonto verknüpft, so dass wir dir Fotos vorschlagen können, die du noch nicht gesehen hast.
-            </p>
-
-            <a name="tracks"></a>
-            <h3>
-                Tracks
-            </h3>
-
-            <p>
-                Als Track bezeichnen wir die Aufzeichnung einer Strecke, die ein Teilnehmer während einer Critical-Mass-Tour zurückgelegt hat. Aus technischer Sicht besteht ein Track aus einer Liste von Coordinaten und Zeitstempeln, aus denen ersichtlich ist, zu welchem Zeitpunkt sich ein Nutzer an einem bestimmten Ort aufgehalten hat.
-            </p>
-
-            <p>
-                Wir nutzen Tracks zu statistischen Zwecken. Erfahrungsgemäß ist es für die Teilnehmer einer Tour im Nachhinein immer recht interessant, wohin die Reise ging, außerdem lassen sich aus Tracks einerseits Statistiken über die Länge und Dauer einer Tour generieren, andererseits so genannte Heatmaps erstellen.
-            </p>
-            
-            <p>
-                Du kannst Tracks entweder manuell als GPX-Datei hochladen oder über das soziale Fahrrad-Netzwerk Strava importieren. Wenn du dich für einen Importvorgang über Strava entscheidest, erteilst du uns die einmalige Erlaubnis, auf die von dir dort gespeicherten Touren zuzugreifen. Wir fragen über eine technische Schnittstelle zunächst jene Touren ab, die am Tag einer Critical Mass stattgefunden haben. Diese Touren präsentieren wir dir als Liste, von denen du eine einzelne Tour zum Importieren auswählen kannst. Wir laden anschließend von Strava nur die Positions- und Zeitdaten herunter, etwaige Gesundheitsdaten wie beispielsweise deine Herzfrequenz, oder zusätzliche Daten wie deine Trittfrequenz fragen wir nicht an.
-            </p>
-
-            <p>
-                <a href="{{ path('caldera_criticalmass_track_list') }}">Selbstverständlich kannst du deine Tracks anschließend verwalten</a>. Dir stehen verschiedene Werkzeuge zur Verfügung, mit denen du deinen Track unsichtbar schalten kannst, um ihn von anderen Nutzern und aus den Heatmaps zu verbergen, oder mit denen du deinen Track kürzen kannst, um etwa die An- und Abfahrt zu einer Critical Mass herauszuschneiden. Natürlich kannst du deine Track auch komplett aus unserer Webseite löschen. Die damit verknüpften statistischen Daten werden dann ebenfalls entfernt.
-            </p>
-
-            <a name="staedte-touren-zubringertouren"></a>
-            <h3>
-                Städte, Touren und Zubringertouren
-            </h3>
-
-            <p>
-                criticalmass.in funktioniert gewissermaßen wie Wikipedia: Jeder angemeldete Nutzer kann Städte, Touren und Zubringertouren erstellen und editieren.
-            </p>
-
-            <p>
-                Wenn du eine Stadt, eine Tour oder eine Zubringertour erstellst oder editierst, wird der Zeitpunkt dieser Aktion zusammen mit deinem aktuellen Benutzernamen in einer Historie gespeichert und außerdem auf der Startseite in der Zeitleiste dargestellt. Mit dieser Historie sind wir in der Lage, Änderungen aufgrund von Vandalismus nachzuvollziehen und zurückzudrehen.
-            </p>
-
-            <p>
-                Beachte bitte, dass dein Benutzername aus technischen Gründen in der Historie gespeichert bleibt, wenn du dein Benutzerkonto löscht oder dein Benutzernamen änderst.
-            </p>
-
-            <p>
-                Der Aufruf der Seite einer Stadt oder einer Tour wird zu statistischen Zwecken erhoben, um besonders beliebte oder wenig bekannte Städte und Touren ermitteln zu können. Falls du im eingeloggten Zustand diese Seiten aufrufst, wird der Zugriff mit deinem Benutzerkonto verknüpft, damit wir dir anzeigen können, ob du die Seite einer Stadt bereits aufgerufen oder eine neu erstellte Tour bereits kennst.
-            </p>
-
-            <a name="teilnahmen"></a>
-            <h3>
-                Teilnahmen an Touren
-            </h3>
-
-            <p>
-                Du hast die Möglichkeit, die Teilnahme an einer Critical-Mass-Tour auf criticalmass.in zu bestätigen, indem du auf der Seite der jeweiligen Tour auf „Teilnehmen“ klickst. Diese Funktion dient lediglich statistischen Zwecken: Einerseits können wir anzeigen, wie viele Radfahrer an einer Tour teilnehmen wollen, andererseits können wir dir <a href="{{ path('criticalmass_user_participation_list') }}">eine detaillierte Statistik anzeigen</a>, wie oft, in welchen Städten und in welchen Monaten du bei einer Critical Mass mitgefahren bist.
-            </p>
-
-            <p>
-                Hin und wieder werden wir dich aufgrund der Liste deiner Teilnahmen fragen, ob du fehlende Daten oder Beschreibungen zu Städten oder Touren, die du besucht hast, zu ergänzen.
-            </p>
-
-            <p>
-                Du kannst deine Teilnahmen <a href="{{ path('criticalmass_user_participation_list') }}">jederzeit wiederrufen oder den Datensatz komplett löschen</a>.
-            </p>
-
-            <a name="statistiken"></a>
-            <h3>
-                Statistiken
-            </h3>
-
-            <p>
-                Zu jeder Tour sammeln wir statistische Daten: Die Länge der zurückgelegten Strecke, die Dauer der Tour und die ungefähre Anzahl an Teilnehmern.
-            </p>
-
-            <p>
-                Jeder bei criticalmass.in angemeldete Nutzer kann Schätzungen zur Teilnehmerzahl abgeben. Diese Schätzungen werden zusammengerechnet und ein Mittelwert gebildet, der zu einer Tour abgespeichert wird. Beachte, dass deine Schätzungen erhalten bleiben, wenn du dein Benutzerkonto löschst, da es sich nicht um personenbezogene Daten handelt.
-            </p>
-
-            <p>
-                Es besteht außerdem die Möglichkeit, Schätzungen anonym über unsere Api-Schnittstelle von unserem <a href="https://wp-demo.criticalmass.in">Wordpress-Plguin</a> einzugeben.
-            </p>
-
-            <p>
-                Wenn du einen Track hochlädst oder importierst, wird automatisch die Länge der Strecke und die Dauer als statistischer Wert erhoben. Diese Werte werden jedoch wieder entfernt, wenn du deinen Track deaktivierst, löschst oder dein Benutzerkonto entfernst.
-            </p>
-
-            <a name="diskussionsforum"></a>
-            <h3>
-                Diskussionsforum und Kommentare
-            </h3>
-
-            <p>
-                Auf criticalmass.in kannst du Fotos und Touren kommentieren sowie im Diskussionsforum Beiträge schreiben.
-            </p>
-
-            <p>
-                Wenn du einen Kommentar oder Beitrag schreibst, wird deine Nachricht mit deinem Benutzerkonto verknüpft. Neben deinem Benutzernamen und deinem Profilfoto wird außerdem der Zeitpunkt dargestellt, zu dem du den Kommentar geschrieben hast.
-            </p>
-
-            <p>
-                Du hast zusätzlich die Möglichkeit, deinen Standort ermitteln und mit deinem Kommentar verknüpfen zu lassen. Dadurch kann dein Kommentar beispielsweise auf der Karte einer Tour dargestellt werden. Die Standortermittlung wird nur ausgeführt, wenn du die entsprechende Checkbox anklickst. Natürlich kannst du deinen Standort anschließend von deinem Kommentar entfernen lassen.
-            </p>
-
-            <p>
-                Beachte bitte, dass Kommentare und Forenbeiträge erhalten bleiben, wenn du dein Benutzerkonto löscht, da ansonsten die Diskussionen nicht mehr nachvollziehbar wären. Sie werden dann ohne deinen Benutzernamen und ohne dein Profilfoto als Kommentar eines anonymen Nutzers dargestellt.
-            </p>
-
-            <p>
-                Wenn du einen Kommentar oder Forenbeitrag schreibst, wird dieser Text außerdem zusammen mit deinem Benutzernamen und deinem Profilfoto auf der Zeitleiste auf unserer Startseite dargestellt.
-            </p>
-
-            <p>
-                Der Aufruf eines Diskussionsstranges wird zu statistischen Zwecken mitgezählt. Wenn du im eingeloggten Zustand einen Strang aufrufst, wird dieser Aufruf mit deinem Benutzerkonto verknüpft, damit wir dir anzeigen können, welche Stränge und Foren noch ungelesene Beiträge enthalten.
-            </p>
-
-            <a name="landkarten"></a>
-            <h3>
-                Landkarten
-            </h3>
-
-            <p>
-                Wir setzen das freie JavaScript-Framework <a href="https://leafletjs.com/">Leaflet</a> ein, um Landkarten auf unseren Webseiten anzuzeigen. Die grundlegenden Daten stammen vom Internetprojekt Open Street Map, das mit tausenden freiwilligen Helfern rund um den Globus freie Landkarten erstellt und dem Netz zur Verfügung stellt. Diese Kartendarten werden von verschiedenen Anbietern aufbereitet und unterscheiden sich vor allem hinsichtlich der Farbgebung und der abgebildeten Details. So gibt es Karten, auf denen Radwege besonders hervorgehoben sind, während sich andere Karten auf Eisenbahn- oder gar Stromtrassen konzentrieren.
-            </p>
-
-            <p>
-                Die Darstellung einer Karte in deinem Browser erfolgt mit quadratischen Bilddateien, auf denen jeweils ein Aussschnitt der Karte dargestellt wird. Nebeneinandergelegt ergeben diese einzelnen Kacheln eine Landkarte — wenn du in der Karte nach Osten navigierst, werden aus dem Internet weitere Kacheln nachgeladen und an der rechten Seite der Darstellung angehängt.
-            </p>
-
-            <p>
-                Wir nutzen bei criticalmass.in die Kacheldarstellung, die du beispielsweise von Wikipedia kennst. Sie wird von <a href="https://maps.wikimedia.org/">Wikimedia Maps</a> zur Verfügung gestellt.
-            </p>
-
-            <p>
-                Theoretisch kann der Anbieter dieser Kacheln, in unserem Fall Wikimedia Maps, deine Betrachtung der Karte verfolgen. Aus einer Statistik, welche Kacheln in welcher Zoom-Stufe an welchen Nutzer ausgeliefert werden, ließe sich beispielsweise ermitteln, für welche Städte oder Gebiete sich diese Nutzer interessieren, bis hin zu konkreten Mutmaßungen, wo sich beispielsweise die Wohnung eines Nutzers befindet.
-            </p>
-
-            <p>
-                Um deine Privatsphäre zu schützen, leiten wir alle Kacheldaten über unseren Kachel-Proxy-Server <code>tiles.caldera.cc</code> um. Weder Wikimedia Maps noch Open Street Map werden darüber informiert, welche Gebiete der Karte du dir angesehen hast. Selbstverständlich erhebt unser Kachel-Proxy-Server keine weiteren Logdateien über deine Zugriffe.
-            </p>
-
-            <a name="verschluesselung"></a>
-            <h3>
-                Verschlüsselung
-            </h3>
-
-            <p>
-                Selbstverständlich werden deine Daten zwischen deinem Browser und criticalmass.in ausschließlich verschlüsselt übertragen. Du kannst die Sicherheit dieser Verschlüsselung beispielsweise bei <a href="https://www.ssllabs.com/ssltest/analyze.html?d=criticalmass.in&latest">SSL Labs</a> überprüfen.
-            </p>
-
-            <p>
-                Wenn du dich mit deiner E-Mail-Adresse und einem Kennwort bei criticalmass.in registrierst, wird dein Kennwort nach dem <a href="https://de.wikipedia.org/wiki/Bcrypt">bcrypt</a>-Verfahren verschlüsselt in unserer Datenbank abgelegt. Wenn du dich anschließend einloggst, wird das eingegebene Kennwort ebenfalls nach diesem Verfahren verschlüsselt und mit dem Wert aus der Datenbank verglichen.
-            </p>
-
-            <p>
-                Technisch gesehen ist bcrypt keine Verschlüsselungs-, sondern eine Hashfunktion, was bedeutet, dass einmal gehashte Werte nie wieder in ihren Ursprungswert zurückgeführt werden können.
-            </p>
-
-            <a name="cookies"></a>
-            <h3>
-                Cookies
-            </h3>
-
-            <p>
-                Als Webseite mit Login-Funktionalität kommen wir leider um Cookies nicht drumherum. Du kennst den Spruch sicherlich: Wir setzen Cookies ein, um die Funktionalität unserer Webseite zu gewährleisten. In den Cookies werden keine persönlichen Informationen abgelegt, sie denen lediglich dazu, dich beim Besuch von criticalmass.in erkennen und einloggen zu können.
-            </p>
-
-            <a name="tracking"></a>
-            <h3>
-                Tracking
-            </h3>
-
-            <p>
-                Zugriffe auf criticalmass.in werden von der Software <a href="https://matomo.org">Matomo</a>, ehemals Piwik, gemessen. Wir setzen Matomo ein, um ein ungefähres Bild des Interesses der Nutzer an unserer Webseite zu bekommen. Die Zugriffe werden anonymisiert erhoben, unser Server <code>piwik.caldera.cc</code> führt darüberhinaus keine zusätzlichen Logfiles.
-            </p>
-
-            <p>
-                Du kannst dem Tracking entweder über die <a href="https://de.wikipedia.org/wiki/Do_Not_Track_(Software)">„Do not Track“-Einstellungen deines Browsers</a> oder über folgende Checkbox widersprechen:
-            </p>
-
-            <iframe style="border: 0; height: 200px; width: 100%;" src="https://piwik.caldera.cc/index.php?module=CoreAdminHome&action=optOut&language=de&backgroundColor=ffffff&fontColor=000000&fontSize=16px&fontFamily=%22Helvetica%20Neue%22%2C%20Helvetica%2C%20Arial%2C%20sans-serif"></iframe>
+            <div class="card border-0 shadow-sm mb-4">
+                <div class="card-body">
+                    <p>
+                        Seit Anfang an, als criticalmass.in noch ein Studentenprojekt an der <a href="https://fh-wedel.de/">Fachhochschule Wedel</a> war, galt der Grundsatz, keinen Unfug mit persönlichen Daten anzustellen. Daran hat sich bis heute nichts geändert: Wir nutzen so wenig persönliche Daten wie möglich und haben kein Interesse daran, mit deinen Daten Geld zu verdienen. Wenn du ein wenig von Programmierung verstehst, kannst du dich in unserem <a href="https://github.com/calderacc/criticalmass-in">GitHub-Repository</a> selbst davon überzeugen.
+                    </p>
+
+                    <h3 id="dein-profil">
+                        <i class="far fa-user me-2 text-muted"></i>Dein Profil
+                    </h3>
+
+                    <p>
+                        Wenn du dich bei criticalmass.in registrierst, speichern wir folgende deiner Daten in unserer Datenbank:
+                    </p>
+
+                    <ul>
+                        <li>
+                            deinen Benutzernamen
+                        </li>
+
+                        <li>
+                            deine E-Mail-Adresse, sofern du dich nicht über soziale Netzwerke einloggst
+                        </li>
+
+                        <li>
+                            ein verschlüsseltes Abbild deines Kennwortes, sofern du dich nicht über soziale Netzwerke einloggst
+                        </li>
+
+                        <li>
+                            den Zeitpunkt deines letzten Logins
+                        </li>
+
+                        <li>
+                            die Profilfarbe, mit der beispielsweise deine Tracks auf Karten dargestellt werden
+                        </li>
+
+                        <li>
+                            den Dateinamen deines Profilfotos
+                        </li>
+
+                        <li>
+                            Benutzer-Kennung und verschlüsseltes Login-Geheimnis, falls du dich über soziale Netzwerke einloggst
+                        </li>
+                    </ul>
+
+                    <p>
+                        Du kannst deinen Benutzernamen jederzeit in deinen Profileinstellungen ändern. Wir empfehlen dir die Verwendung eines Pseudonyms, das keine Rückschlüsse auf deine Persönlichkeit zulässt. Wir setzen allerdings die Verwendung eines Benutzernamens voraus, damit andere Nutzer auf criticalmass.in dich erkennen können.
+                    </p>
+
+                    <p>
+                        Selbstverständlich kannst du auch deine E-Mail-Adresse in deinen Kontoeinstellungen ändern. Deine E-Mail-Adresse benötigen wir, um dir im Notfall ein neues Kennwort zusenden zu können.
+                    </p>
+
+                    <p>
+                        Falls du dich nicht über soziale Netzwerke einloggst, kannst du in deinen Profileinstellungen außerdem dein Kennwort und deine E-Mail-Adresse ändern.
+                    </p>
+
+                    <h3 id="login-soziale-netzwerke">
+                        <i class="far fa-share-alt me-2 text-muted"></i>Login über soziale Netzwerke
+                    </h3>
+
+                    <p>
+                        Anstatt über Benutzernamen und Kennwort kannst du dich auf criticalmass.in auch über Facebook oder Strava anmelden. Eine solche Registrierung läuft grundsätzlich so ab, dass unter unserem Login-Formular auf den Knopf von einem dieser drei Anbieter klickst. Du wirst daraufhin zur Webseite dieses Anbieters weitergeleitet, wo du gefragt wirst, ob du criticalmass.in den Zugriff auf dein Benutzerkonto gestattest. Wenn du uns diese Genehmigung erteilst, wirst du anschließend auf criticalmass.in zurückgeleitet, wo du entweder in dein bestehendes Benutzerkonto eingeloggt wirst oder ein neues Benutzerkonto mit den Daten aus jenem sozialen Netzwerk erstellt wird.
+                    </p>
+
+                    <p>
+                        Wenn du dein Benutzerkonto bei criticalmass.in löscht, werden selbstverständlich alle Verknüpfungen zu sozialen Netzwerken widerrufen.
+                    </p>
+
+                    <h4>
+                        Login über Facebook
+                    </h4>
+
+                    <p>
+                        Anbieter des Logins über <a href="https://facebook.com/">Facebook</a> ist die Facebook Ireland Limited, 4 Grand Canal Square, Dublin 2, Irland.
+                    </p>
+
+                    <p>
+                        Wenn du dich zu einem Login über Facebook entscheidest, fragen wir die folgenden Daten von Facebook ab und speichern sie in unserer Datenbank:
+                    </p>
+
+                    <ul>
+                        <li>
+                            numerische Kennung deines Benutzerkontos bei Facebook
+                        </li>
+                        <li>
+                            Vor- und Nachname deines Benutzerkontos bei Facebook
+                        </li>
+                        <li>
+                            bei Facebook hinterlegte E-Mail-Adresse
+                        </li>
+                    </ul>
+
+                    <h4>
+                        Login über Strava
+                    </h4>
+
+                    <p>
+                        Anbieter des Logins über <a href="https://strava.com/">Strava</a> ist die Strava, Inc., 500 3rd Street, Suite 110 , San Francisco, CA 94107.
+                    </p>
+
+                    <ul>
+                        <li>
+                            numerische Kennung deines Benutzerkontos bei Strava
+                        </li>
+                        <li>
+                            Vor- und Nachname deines Benutzerkontos bei Strava
+                        </li>
+                        <li>
+                            bei Strava hinterlegte E-Mail-Adresse
+                        </li>
+                    </ul>
+
+                    <h3 id="fotos">
+                        <i class="far fa-images me-2 text-muted"></i>Fotos
+                    </h3>
+
+                    <p>
+                        Als angemeldeter Nutzer kannst du Fotos zu Touren hochladen, die auch von nicht angemeldeten Nutzern betrachtet werden können.
+                    </p>
+
+                    <p>
+                        Wenn deine hochgeladenen Fotos GPS-Daten enthalten oder du bereits einen Track zu dieser Tour hochgeladen oder importiert hast, versuchen wir deine Fotos zu verorten und auf der Karte der Tour deinen Aufnahmestandpunkt darzustellen.
+                    </p>
+
+                    <p>
+                        Für Fotos von Critical-Mass-Touren ist <a href="https://www.gesetze-im-internet.de/kunsturhg/__23.html">§ 23 Abs. 1 Nr. 3 KunstUrhG</a> einschlägig, der die Veröffentlichung der „Bilder von Versammlungen, Aufzügen und ähnlichen Vorgängen, an denen die dargestellten Personen teilgenommen haben" erlaubt.
+                    </p>
+
+                    <p>
+                        Du hast selbstverständlich die Möglichkeit, <a href="{{ path('caldera_criticalmass_photo_user_list') }}">Fotos zu löschen oder zu deaktivieren</a>. Wenn du dein Benutzerkonto löschst, werden auch deine hochgeladenen Fotos entfernt.
+                    </p>
+
+                    <p>
+                        Der Aufruf von Fotos wird zu statistischen Zwecken gespeichert. Wenn du als eingeloggter Nutzer Fotos betrachtest, wird dieser Aufruf mit deinem Benutzerkonto verknüpft, so dass wir dir Fotos vorschlagen können, die du noch nicht gesehen hast.
+                    </p>
+
+                    <h3 id="tracks">
+                        <i class="far fa-route me-2 text-muted"></i>Tracks
+                    </h3>
+
+                    <p>
+                        Als Track bezeichnen wir die Aufzeichnung einer Strecke, die ein Teilnehmer während einer Critical-Mass-Tour zurückgelegt hat. Aus technischer Sicht besteht ein Track aus einer Liste von Coordinaten und Zeitstempeln, aus denen ersichtlich ist, zu welchem Zeitpunkt sich ein Nutzer an einem bestimmten Ort aufgehalten hat.
+                    </p>
+
+                    <p>
+                        Wir nutzen Tracks zu statistischen Zwecken. Erfahrungsgemäß ist es für die Teilnehmer einer Tour im Nachhinein immer recht interessant, wohin die Reise ging, außerdem lassen sich aus Tracks einerseits Statistiken über die Länge und Dauer einer Tour generieren, andererseits so genannte Heatmaps erstellen.
+                    </p>
+
+                    <p>
+                        Du kannst Tracks entweder manuell als GPX-Datei hochladen oder über das soziale Fahrrad-Netzwerk Strava importieren. Wenn du dich für einen Importvorgang über Strava entscheidest, erteilst du uns die einmalige Erlaubnis, auf die von dir dort gespeicherten Touren zuzugreifen. Wir fragen über eine technische Schnittstelle zunächst jene Touren ab, die am Tag einer Critical Mass stattgefunden haben. Diese Touren präsentieren wir dir als Liste, von denen du eine einzelne Tour zum Importieren auswählen kannst. Wir laden anschließend von Strava nur die Positions- und Zeitdaten herunter, etwaige Gesundheitsdaten wie beispielsweise deine Herzfrequenz, oder zusätzliche Daten wie deine Trittfrequenz fragen wir nicht an.
+                    </p>
+
+                    <p>
+                        <a href="{{ path('caldera_criticalmass_track_list') }}">Selbstverständlich kannst du deine Tracks anschließend verwalten</a>. Dir stehen verschiedene Werkzeuge zur Verfügung, mit denen du deinen Track unsichtbar schalten kannst, um ihn von anderen Nutzern und aus den Heatmaps zu verbergen, oder mit denen du deinen Track kürzen kannst, um etwa die An- und Abfahrt zu einer Critical Mass herauszuschneiden. Natürlich kannst du deine Track auch komplett aus unserer Webseite löschen. Die damit verknüpften statistischen Daten werden dann ebenfalls entfernt.
+                    </p>
+
+                    <h3 id="staedte-touren-zubringertouren">
+                        <i class="far fa-map-marker-alt me-2 text-muted"></i>Städte, Touren und Zubringertouren
+                    </h3>
+
+                    <p>
+                        criticalmass.in funktioniert gewissermaßen wie Wikipedia: Jeder angemeldete Nutzer kann Städte, Touren und Zubringertouren erstellen und editieren.
+                    </p>
+
+                    <p>
+                        Wenn du eine Stadt, eine Tour oder eine Zubringertour erstellst oder editierst, wird der Zeitpunkt dieser Aktion zusammen mit deinem aktuellen Benutzernamen in einer Historie gespeichert und außerdem auf der Startseite in der Zeitleiste dargestellt. Mit dieser Historie sind wir in der Lage, Änderungen aufgrund von Vandalismus nachzuvollziehen und zurückzudrehen.
+                    </p>
+
+                    <p>
+                        Beachte bitte, dass dein Benutzername aus technischen Gründen in der Historie gespeichert bleibt, wenn du dein Benutzerkonto löscht oder dein Benutzernamen änderst.
+                    </p>
+
+                    <p>
+                        Der Aufruf der Seite einer Stadt oder einer Tour wird zu statistischen Zwecken erhoben, um besonders beliebte oder wenig bekannte Städte und Touren ermitteln zu können. Falls du im eingeloggten Zustand diese Seiten aufrufst, wird der Zugriff mit deinem Benutzerkonto verknüpft, damit wir dir anzeigen können, ob du die Seite einer Stadt bereits aufgerufen oder eine neu erstellte Tour bereits kennst.
+                    </p>
+
+                    <h3 id="teilnahmen">
+                        <i class="far fa-calendar-plus me-2 text-muted"></i>Teilnahmen an Touren
+                    </h3>
+
+                    <p>
+                        Du hast die Möglichkeit, die Teilnahme an einer Critical-Mass-Tour auf criticalmass.in zu bestätigen, indem du auf der Seite der jeweiligen Tour auf „Teilnehmen" klickst. Diese Funktion dient lediglich statistischen Zwecken: Einerseits können wir anzeigen, wie viele Radfahrer an einer Tour teilnehmen wollen, andererseits können wir dir <a href="{{ path('criticalmass_user_participation_list') }}">eine detaillierte Statistik anzeigen</a>, wie oft, in welchen Städten und in welchen Monaten du bei einer Critical Mass mitgefahren bist.
+                    </p>
+
+                    <p>
+                        Hin und wieder werden wir dich aufgrund der Liste deiner Teilnahmen fragen, ob du fehlende Daten oder Beschreibungen zu Städten oder Touren, die du besucht hast, zu ergänzen.
+                    </p>
+
+                    <p>
+                        Du kannst deine Teilnahmen <a href="{{ path('criticalmass_user_participation_list') }}">jederzeit wiederrufen oder den Datensatz komplett löschen</a>.
+                    </p>
+
+                    <h3 id="statistiken">
+                        <i class="far fa-chart-bar me-2 text-muted"></i>Statistiken
+                    </h3>
+
+                    <p>
+                        Zu jeder Tour sammeln wir statistische Daten: Die Länge der zurückgelegten Strecke, die Dauer der Tour und die ungefähre Anzahl an Teilnehmern.
+                    </p>
+
+                    <p>
+                        Jeder bei criticalmass.in angemeldete Nutzer kann Schätzungen zur Teilnehmerzahl abgeben. Diese Schätzungen werden zusammengerechnet und ein Mittelwert gebildet, der zu einer Tour abgespeichert wird. Beachte, dass deine Schätzungen erhalten bleiben, wenn du dein Benutzerkonto löschst, da es sich nicht um personenbezogene Daten handelt.
+                    </p>
+
+                    <p>
+                        Es besteht außerdem die Möglichkeit, Schätzungen anonym über unsere Api-Schnittstelle von unserem <a href="https://wp-demo.criticalmass.in">Wordpress-Plguin</a> einzugeben.
+                    </p>
+
+                    <p>
+                        Wenn du einen Track hochlädst oder importierst, wird automatisch die Länge der Strecke und die Dauer als statistischer Wert erhoben. Diese Werte werden jedoch wieder entfernt, wenn du deinen Track deaktivierst, löschst oder dein Benutzerkonto entfernst.
+                    </p>
+
+                    <h3 id="diskussionsforum">
+                        <i class="far fa-comments me-2 text-muted"></i>Diskussionsforum und Kommentare
+                    </h3>
+
+                    <p>
+                        Auf criticalmass.in kannst du Fotos und Touren kommentieren sowie im Diskussionsforum Beiträge schreiben.
+                    </p>
+
+                    <p>
+                        Wenn du einen Kommentar oder Beitrag schreibst, wird deine Nachricht mit deinem Benutzerkonto verknüpft. Neben deinem Benutzernamen und deinem Profilfoto wird außerdem der Zeitpunkt dargestellt, zu dem du den Kommentar geschrieben hast.
+                    </p>
+
+                    <p>
+                        Du hast zusätzlich die Möglichkeit, deinen Standort ermitteln und mit deinem Kommentar verknüpfen zu lassen. Dadurch kann dein Kommentar beispielsweise auf der Karte einer Tour dargestellt werden. Die Standortermittlung wird nur ausgeführt, wenn du die entsprechende Checkbox anklickst. Natürlich kannst du deinen Standort anschließend von deinem Kommentar entfernen lassen.
+                    </p>
+
+                    <p>
+                        Beachte bitte, dass Kommentare und Forenbeiträge erhalten bleiben, wenn du dein Benutzerkonto löscht, da ansonsten die Diskussionen nicht mehr nachvollziehbar wären. Sie werden dann ohne deinen Benutzernamen und ohne dein Profilfoto als Kommentar eines anonymen Nutzers dargestellt.
+                    </p>
+
+                    <p>
+                        Wenn du einen Kommentar oder Forenbeitrag schreibst, wird dieser Text außerdem zusammen mit deinem Benutzernamen und deinem Profilfoto auf der Zeitleiste auf unserer Startseite dargestellt.
+                    </p>
+
+                    <p>
+                        Der Aufruf eines Diskussionsstranges wird zu statistischen Zwecken mitgezählt. Wenn du im eingeloggten Zustand einen Strang aufrufst, wird dieser Aufruf mit deinem Benutzerkonto verknüpft, damit wir dir anzeigen können, welche Stränge und Foren noch ungelesene Beiträge enthalten.
+                    </p>
+
+                    <h3 id="landkarten">
+                        <i class="far fa-map me-2 text-muted"></i>Landkarten
+                    </h3>
+
+                    <p>
+                        Wir setzen das freie JavaScript-Framework <a href="https://leafletjs.com/">Leaflet</a> ein, um Landkarten auf unseren Webseiten anzuzeigen. Die grundlegenden Daten stammen vom Internetprojekt Open Street Map, das mit tausenden freiwilligen Helfern rund um den Globus freie Landkarten erstellt und dem Netz zur Verfügung stellt. Diese Kartendarten werden von verschiedenen Anbietern aufbereitet und unterscheiden sich vor allem hinsichtlich der Farbgebung und der abgebildeten Details. So gibt es Karten, auf denen Radwege besonders hervorgehoben sind, während sich andere Karten auf Eisenbahn- oder gar Stromtrassen konzentrieren.
+                    </p>
+
+                    <p>
+                        Die Darstellung einer Karte in deinem Browser erfolgt mit quadratischen Bilddateien, auf denen jeweils ein Aussschnitt der Karte dargestellt wird. Nebeneinandergelegt ergeben diese einzelnen Kacheln eine Landkarte — wenn du in der Karte nach Osten navigierst, werden aus dem Internet weitere Kacheln nachgeladen und an der rechten Seite der Darstellung angehängt.
+                    </p>
+
+                    <p>
+                        Wir nutzen bei criticalmass.in die Kacheldarstellung, die du beispielsweise von Wikipedia kennst. Sie wird von <a href="https://maps.wikimedia.org/">Wikimedia Maps</a> zur Verfügung gestellt.
+                    </p>
+
+                    <p>
+                        Theoretisch kann der Anbieter dieser Kacheln, in unserem Fall Wikimedia Maps, deine Betrachtung der Karte verfolgen. Aus einer Statistik, welche Kacheln in welcher Zoom-Stufe an welchen Nutzer ausgeliefert werden, ließe sich beispielsweise ermitteln, für welche Städte oder Gebiete sich diese Nutzer interessieren, bis hin zu konkreten Mutmaßungen, wo sich beispielsweise die Wohnung eines Nutzers befindet.
+                    </p>
+
+                    <p>
+                        Um deine Privatsphäre zu schützen, leiten wir alle Kacheldaten über unseren Kachel-Proxy-Server <code>tiles.caldera.cc</code> um. Weder Wikimedia Maps noch Open Street Map werden darüber informiert, welche Gebiete der Karte du dir angesehen hast. Selbstverständlich erhebt unser Kachel-Proxy-Server keine weiteren Logdateien über deine Zugriffe.
+                    </p>
+
+                    <h3 id="verschluesselung">
+                        <i class="far fa-lock me-2 text-muted"></i>Verschlüsselung
+                    </h3>
+
+                    <p>
+                        Selbstverständlich werden deine Daten zwischen deinem Browser und criticalmass.in ausschließlich verschlüsselt übertragen. Du kannst die Sicherheit dieser Verschlüsselung beispielsweise bei <a href="https://www.ssllabs.com/ssltest/analyze.html?d=criticalmass.in&latest">SSL Labs</a> überprüfen.
+                    </p>
+
+                    <p>
+                        Wenn du dich mit deiner E-Mail-Adresse und einem Kennwort bei criticalmass.in registrierst, wird dein Kennwort nach dem <a href="https://de.wikipedia.org/wiki/Bcrypt">bcrypt</a>-Verfahren verschlüsselt in unserer Datenbank abgelegt. Wenn du dich anschließend einloggst, wird das eingegebene Kennwort ebenfalls nach diesem Verfahren verschlüsselt und mit dem Wert aus der Datenbank verglichen.
+                    </p>
+
+                    <p>
+                        Technisch gesehen ist bcrypt keine Verschlüsselungs-, sondern eine Hashfunktion, was bedeutet, dass einmal gehashte Werte nie wieder in ihren Ursprungswert zurückgeführt werden können.
+                    </p>
+
+                    <h3 id="cookies">
+                        <i class="far fa-cookie-bite me-2 text-muted"></i>Cookies
+                    </h3>
+
+                    <p>
+                        Als Webseite mit Login-Funktionalität kommen wir leider um Cookies nicht drumherum. Du kennst den Spruch sicherlich: Wir setzen Cookies ein, um die Funktionalität unserer Webseite zu gewährleisten. In den Cookies werden keine persönlichen Informationen abgelegt, sie denen lediglich dazu, dich beim Besuch von criticalmass.in erkennen und einloggen zu können.
+                    </p>
+
+                    <h3 id="tracking">
+                        <i class="far fa-chart-line me-2 text-muted"></i>Tracking
+                    </h3>
+
+                    <p>
+                        Zugriffe auf criticalmass.in werden von der Software <a href="https://matomo.org">Matomo</a>, ehemals Piwik, gemessen. Wir setzen Matomo ein, um ein ungefähres Bild des Interesses der Nutzer an unserer Webseite zu bekommen. Die Zugriffe werden anonymisiert erhoben, unser Server <code>piwik.caldera.cc</code> führt darüberhinaus keine zusätzlichen Logfiles.
+                    </p>
+
+                    <p>
+                        Du kannst dem Tracking entweder über die <a href="https://de.wikipedia.org/wiki/Do_Not_Track_(Software)">„Do not Track"-Einstellungen deines Browsers</a> oder über folgende Checkbox widersprechen:
+                    </p>
+
+                    <iframe style="border: 0; height: 200px; width: 100%;" src="https://piwik.caldera.cc/index.php?module=CoreAdminHome&action=optOut&language=de&backgroundColor=ffffff&fontColor=000000&fontSize=16px&fontFamily=%22Helvetica%20Neue%22%2C%20Helvetica%2C%20Arial%2C%20sans-serif"></iframe>
+                </div>
+            </div>
         </div>
 
         <div class="col-md-4">
-            <ul class="nav nav-pills nav-stacked">
-                <li role="presentation">
-                    <a href="#dein-profil">
-                        Dein Profil
-                    </a>
-                </li>
-
-                <li role="presentation">
-                    <a href="#login-soziale-netzwerke">
-                        Login über soziale Netzwerke
-                    </a>
-                </li>
-
-                <li role="presentation">
-                    <a href="#fotos">
-                        Fotos
-                    </a>
-                </li>
-
-                <li role="presentation">
-                    <a href="#tracks">
-                        Tracks
-                    </a>
-                </li>
-
-                <li role="presentation">
-                    <a href="#staedte-touren-zubringertouren">
-                        Städte, Touren und Zubringertouren
-                    </a>
-                </li>
-
-                <li role="presentation">
-                    <a href="#teilnahmen">
-                        Teilnahmen an Touren
-                    </a>
-                </li>
-
-                <li role="presentation">
-                    <a href="#statistiken">
-                        Statistiken
-                    </a>
-                </li>
-
-                <li role="presentation">
-                    <a href="#diskussionsforum">
-                        Diskussionsforum
-                    </a>
-                </li>
-
-                <li role="presentation">
-                    <a href="#landkarten">
-                        Landkarten
-                    </a>
-                </li>
-
-                <li role="presentation">
-                    <a href="#werbung">
-                        Werbung
-                    </a>
-                </li>
-
-                <li role="presentation">
-                    <a href="#verschluesselung">
-                        Verschlüsselung
-                    </a>
-                </li>
-
-                <li role="presentation">
-                    <a href="#cookies">
-                        Cookies
-                    </a>
-                </li>
-
-                <li role="presentation">
-                    <a href="#tracking">
-                        Tracking
-                    </a>
-                </li>
-            </ul>
+            <div class="card border-0 shadow-sm mb-4">
+                <div class="card-header bg-white">
+                    <h5 class="mb-0 h6">
+                        <i class="far fa-list me-2"></i>Inhalt
+                    </h5>
+                </div>
+                <div class="card-body p-0">
+                    <nav class="nav nav-pills flex-column">
+                        <a class="nav-link" href="#dein-profil">
+                            <i class="far fa-user me-2 text-muted"></i>Dein Profil
+                        </a>
+                        <a class="nav-link" href="#login-soziale-netzwerke">
+                            <i class="far fa-share-alt me-2 text-muted"></i>Login über soziale Netzwerke
+                        </a>
+                        <a class="nav-link" href="#fotos">
+                            <i class="far fa-images me-2 text-muted"></i>Fotos
+                        </a>
+                        <a class="nav-link" href="#tracks">
+                            <i class="far fa-route me-2 text-muted"></i>Tracks
+                        </a>
+                        <a class="nav-link" href="#staedte-touren-zubringertouren">
+                            <i class="far fa-map-marker-alt me-2 text-muted"></i>Städte, Touren und Zubringertouren
+                        </a>
+                        <a class="nav-link" href="#teilnahmen">
+                            <i class="far fa-calendar-plus me-2 text-muted"></i>Teilnahmen an Touren
+                        </a>
+                        <a class="nav-link" href="#statistiken">
+                            <i class="far fa-chart-bar me-2 text-muted"></i>Statistiken
+                        </a>
+                        <a class="nav-link" href="#diskussionsforum">
+                            <i class="far fa-comments me-2 text-muted"></i>Diskussionsforum
+                        </a>
+                        <a class="nav-link" href="#landkarten">
+                            <i class="far fa-map me-2 text-muted"></i>Landkarten
+                        </a>
+                        <a class="nav-link" href="#verschluesselung">
+                            <i class="far fa-lock me-2 text-muted"></i>Verschlüsselung
+                        </a>
+                        <a class="nav-link" href="#cookies">
+                            <i class="far fa-cookie-bite me-2 text-muted"></i>Cookies
+                        </a>
+                        <a class="nav-link" href="#tracking">
+                            <i class="far fa-chart-line me-2 text-muted"></i>Tracking
+                        </a>
+                    </nav>
+                </div>
+            </div>
         </div>
     </div>
 </div>

--- a/templates/Static/glympse.html.twig
+++ b/templates/Static/glympse.html.twig
@@ -5,22 +5,24 @@
 {% block content %}
     <div class="container">
         <div class="row">
-            <div class="col-md-10 col-md-offset-1">
-                <h1>
-                    Critical Mass Live Tracking
-                </h1>
+            <div class="col-md-10 offset-md-1">
+                <div class="card border-0 shadow-sm mb-4">
+                    <div class="card-body text-center py-5">
+                        <i class="far fa-map-marker-alt fa-3x text-muted mb-3"></i>
+                        <h1 class="h3">
+                            Critical Mass Live Tracking
+                        </h1>
 
-                <p>
-                    Wenn du diese Seite siehst, bist du vermutlich einen veralteten Link gefolgt &mdash; bitte besuche
-                    criticalmass.live für weitere Informationen zum Live-Tracking.
-                </p>
+                        <p class="text-muted mb-4">
+                            Wenn du diese Seite siehst, bist du vermutlich einen veralteten Link gefolgt &mdash; bitte besuche
+                            criticalmass.live für weitere Informationen zum Live-Tracking.
+                        </p>
 
-                <p class="text-center">
-                    <a href="https://criticalmass.live/" class="btn btn-primary">
-                        criticalmass.live
-                    </a>
-                </p>
-
+                        <a href="https://criticalmass.live/" class="btn btn-primary">
+                            <i class="far fa-external-link-alt me-1"></i>criticalmass.live
+                        </a>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/templates/Static/impress.html.twig
+++ b/templates/Static/impress.html.twig
@@ -10,7 +10,7 @@
 {% block content %}
     <div class="container">
         <div class="row">
-            <div class="col-md-10 col-md-offset-1">
+            <div class="col-md-10 offset-md-1">
                 <h2>
                     Impressum
                 </h2>
@@ -18,14 +18,14 @@
         </div>
 
         <div class="row">
-            <div class="col-md-5 col-md-offset-1">
-                <div class="panel panel-default">
-                    <div class="panel-heading">
-                        <h3 class="panel-title">
-                            Verantwortlichkeit für lokale Critical-Mass-Gruppen
+            <div class="col-md-5 offset-md-1">
+                <div class="card border-0 shadow-sm mb-4">
+                    <div class="card-header bg-white">
+                        <h3 class="mb-0 h6">
+                            <i class="far fa-building me-2"></i>Verantwortlichkeit für lokale Critical-Mass-Gruppen
                         </h3>
                     </div>
-                    <div class="panel-body">
+                    <div class="card-body">
                         <p>
                             Die Website criticalmass.in ist ein rein informatorisches Projekt.
                         </p>
@@ -38,36 +38,36 @@
                             Alle Einträge zu Städten, Touren oder Gruppen dienen ausschließlich der Übersicht und werden größtenteils von Nutzer*innen selbst gepflegt.
                         </p>
 
-                        <p>
+                        <p class="mb-0">
                             Für Inhalte, Fotos, Videos oder Beiträge einzelner Städte oder deren Social-Media-Kanäle sind wir nicht verantwortlich und haben keinen administrativen Zugriff.
                         </p>
                     </div>
                 </div>
 
-                <div class="panel panel-default">
-                    <div class="panel-heading">
-                        <h3 class="panel-title">
-                            Externe Inhalte und Links
+                <div class="card border-0 shadow-sm mb-4">
+                    <div class="card-header bg-white">
+                        <h3 class="mb-0 h6">
+                            <i class="far fa-external-link-alt me-2"></i>Externe Inhalte und Links
                         </h3>
                     </div>
-                    <div class="panel-body">
+                    <div class="card-body">
                         <p>
                             Die auf criticalmass.in verlinkten Websites, Social-Media-Kanäle und externen Inhalte werden weder betrieben noch kontrolliert. Für deren Inhalte sind ausschließlich die jeweiligen Betreiber verantwortlich.
                         </p>
 
-                        <p>
+                        <p class="mb-0">
                             Wir machen uns fremde Inhalte nicht zu eigen und haben keinen Einfluss auf deren Veröffentlichung, Löschung oder rechtlichen Status.
                         </p>
                     </div>
                 </div>
 
-                <div class="panel panel-default">
-                    <div class="panel-heading">
-                        <h3 class="panel-title">
-                            Keine Verantwortlichkeit für Inhalte verlinkter Social-Media-Seiten
+                <div class="card border-0 shadow-sm mb-4">
+                    <div class="card-header bg-white">
+                        <h3 class="mb-0 h6">
+                            <i class="far fa-share-alt me-2"></i>Keine Verantwortlichkeit für Inhalte verlinkter Social-Media-Seiten
                         </h3>
                     </div>
-                    <div class="panel-body">
+                    <div class="card-body">
                         <p>
                             Bitte beachten Sie, dass wir in keiner Form Betreiber oder Verantwortlicher externern Social-Media-Angebote von Critical-Mass-Radtouren sind sind.
                         </p>
@@ -76,19 +76,19 @@
                             Wir haben keinen Zugriff auf dort veröffentlichte Inhalte und können diese nicht entfernen, nicht bearbeiten und nicht moderieren.
                         </p>
 
-                        <p>
+                        <p class="mb-0">
                             Bitte wenden Sie sich bei rechtlichen Anliegen direkt an die jeweiligen Seitenbetreiber der lokalen Gruppe.
                         </p>
                     </div>
                 </div>
 
-                <div class="panel panel-default">
-                    <div class="panel-heading">
-                        <h3 class="panel-title">
-                            Impressum
+                <div class="card border-0 shadow-sm mb-4">
+                    <div class="card-header bg-white">
+                        <h3 class="mb-0 h6">
+                            <i class="far fa-id-card me-2"></i>Impressum
                         </h3>
                     </div>
-                    <div class="panel-body">
+                    <div class="card-body">
                         <p>
                             Angaben nach § 5 TMG:
                         </p>
@@ -107,7 +107,7 @@
                             E-Mail: <a href="mailto:maltehuebner@gmx.org">maltehuebner@gmx.org</a>
                         </p>
 
-                        <p>
+                        <p class="mb-0">
                             <strong>
                                 Bitte beachte, dass diese Kontaktdaten nicht für Support- oder Presseanfragen vorgesehen sind.
                             </strong>
@@ -117,13 +117,13 @@
             </div>
 
             <div class="col-md-5">
-                <div class="panel panel-default">
-                    <div class="panel-heading">
-                        <h3 class="panel-title">
-                            Kontakt
+                <div class="card border-0 shadow-sm mb-4">
+                    <div class="card-header bg-white">
+                        <h3 class="mb-0 h6">
+                            <i class="far fa-envelope me-2"></i>Kontakt
                         </h3>
                     </div>
-                    <div class="panel-body">
+                    <div class="card-body">
                         <h4>
                             Supportanfragen
                         </h4>
@@ -145,14 +145,14 @@
                         </h4>
 
                         <p>
-                            Wir bekommen häufig lange E-Mails mit Erfahrungsberichten und Verbesserungsvorschlägen zu allen möglichen Critical-Mass-Touren — leider können wir damit gar nichts anfangen, weil wir nicht dabei waren und überhaupt keinen Einfluss auf den Ablauf der Touren haben. Damit deine Berichte das entsprechende Publikum finden, suchst du am besten deine Stadt aus der <a href="{{ path('caldera_criticalmass_city_list') }}">Städteliste</a> heraus und schreibst deine Erfahrungen entweder als Kommentar unter die jeweilige Tour oder nutzt die Verlinkungen zu sozialen Netzwerken, um dort mit anderen Teilnehmern über die Tour zu diskutieren. Natürlich kannst du auch gerne das <a href="{{ path('caldera_criticalmass_board_overview') }}">Diskussionsforum auf criticalmass.in</a> nutzen.
+                            Wir bekommen häufig lange E-Mails mit Erfahrungsberichten und Verbesserungsvorschlägen zu allen möglichen Critical-Mass-Touren — leider können wir damit gar nichts anfangen, weil wir nicht dabei waren und überhaupt keinen Einfluss auf den Ablauf der Touren haben. Damit deine Berichte das entsprechende Publikum finden, suchst du am besten deine Stadt aus der <a href="{{ path('caldera_criticalmass_city_list') }}">Städteliste</a> heraus und schreibst deine Erfahrungen entweder als Kommentar unter die jeweilige Tour oder nutzt die Verlinkungen zu sozialen Netzwerken, um dort mit anderen Teilnehmern über die Tour zu diskutieren. Natürlich kannst du auch gerne das <a href="{{ path('caldera_criticalmass_board_overview') }}">Diskussionsforum auf criticalmass.in</a> nutzen.
                         </p>
 
                         <h4>
                             Presseanfragen
                         </h4>
 
-                        <p>
+                        <p class="mb-0">
                             Wir können leider nur allgemeine Fragen zur Critical Mass beantworten. Über Details zur Critical Mass in einzelnen Städten oder weiteren Fahrrad-Aktionen wie das Aufstellen von Ghostbikes, Fahrradreparaturwerkstätten oder Fahrradtouren können wir keine Auskunft geben. Bitte suche in der <a href="{{ path('caldera_criticalmass_city_list') }}">Städteliste</a> die jeweilige Stadt heraus und versuche über die Verlinkungen zu sozialen Netzwerken einen Ansprechpartner zu finden.
                         </p>
                     </div>

--- a/templates/Static/privacy.html.twig
+++ b/templates/Static/privacy.html.twig
@@ -10,7 +10,7 @@
 {% block content %}
 <div class="container">
     <div class="row">
-        <div class="col-md-10 col-md-offset-1">
+        <div class="col-md-10 offset-md-1">
             <h2>
                 Datenschutzerklärung
             </h2>
@@ -18,311 +18,314 @@
     </div>
 
     <div class="row">
-        <div class="col-md-10 col-md-offset-1">
-            <p>
-                Diese Datenschutzerklärung klärt Sie über die Art, den Umfang und Zweck der Verarbeitung von personenbezogenen Daten (nachfolgend kurz „Daten“) innerhalb unseres Onlineangebotes und der mit ihm verbundenen Webseiten, Funktionen und Inhalte sowie externen Onlinepräsenzen, wie z.B. unser Social Media Profile auf. (nachfolgend gemeinsam bezeichnet als „Onlineangebot“). Im Hinblick auf die verwendeten Begrifflichkeiten, wie z.B. „Verarbeitung“ oder „Verantwortlicher“ verweisen wir auf die Definitionen im Art. 4 der Datenschutzgrundverordnung (DSGVO).
-            </p>
-
-            <h3>
-                Verantwortlicher
-            </h3>
-
-            <p>
-                Malte Hübner
-                <br />
-                Goethestraße 48
-                <br />
-                21335 Lüneburg
-            </p>
-
-            <p>
-                Telefon: 0151 172 77 032
-                <br/>
-                E-Mail: <a href="mailto:maltehuebner@gmx.org">maltehuebner@gmx.org</a>
-            </p>
-
-            <h3>
-                Arten der verarbeiteten Daten
-            </h3>
-
-            <ul>
-                <li>
-                    Bestandsdaten (z.B., Namen, Adressen).
-                </li>
-                <li>
-                    Kontaktdaten (z.B., E-Mail, Telefonnummern).
-                </li>
-                <li>
-                    Inhaltsdaten (z.B., Texteingaben, Fotografien, Videos).
-                </li>
-                <li>
-                    Nutzungsdaten (z.B., besuchte Webseiten, Interesse an Inhalten, Zugriffszeiten).
-                </li>
-                <li>
-                    Meta-/Kommunikationsdaten (z.B., Geräte-Informationen, IP-Adressen).
-                </li>
-            </ul>
-
-            <h3>
-                Kategorien betroffener Personen
-            </h3>
-
-            <p>
-                Besucher und Nutzer des Onlineangebotes (Nachfolgend bezeichnen wir die betroffenen Personen zusammenfassend auch als „Nutzer“).
-            </p>
-
-            <h3>
-                Zweck der Verarbeitung
-            </h3>
-
-            <ul>
-                <li>
-                    Zurverfügungstellung des Onlineangebotes, seiner Funktionen und  Inhalte.
-                </li>
-                <li>
-                    Beantwortung von Kontaktanfragen und Kommunikation mit Nutzern.
-                </li>
-                <li>
-                    Sicherheitsmaßnahmen.
-                </li>
-                <li>
-                    Reichweitenmessung/Marketing
-                </li>
-            </ul>
-
-            <h3>
-                Verwendete Begrifflichkeiten
-            </h3>
-
-            <p>
-                „Personenbezogene Daten“ sind alle Informationen, die sich auf eine identifizierte oder identifizierbare natürliche Person (im Folgenden „betroffene Person“) beziehen; als identifizierbar wird eine natürliche Person angesehen, die direkt oder indirekt, insbesondere mittels Zuordnung zu einer Kennung wie einem Namen, zu einer Kennnummer, zu Standortdaten, zu einer Online-Kennung (z.B. Cookie) oder zu einem oder mehreren besonderen Merkmalen identifiziert werden kann, die Ausdruck der physischen, physiologischen, genetischen, psychischen, wirtschaftlichen, kulturellen oder sozialen Identität dieser natürlichen Person sind.
-            </p>
-
-            <p>
-                „Verarbeitung“ ist jeder mit oder ohne Hilfe automatisierter Verfahren ausgeführten Vorgang oder jede solche Vorgangsreihe im Zusammenhang mit personenbezogenen Daten. Der Begriff reicht weit und umfasst praktisch jeden Umgang mit Daten.
-            </p>
-
-            <p>
-                Als „Verantwortlicher“ wird die natürliche oder juristische Person, Behörde, Einrichtung oder andere Stelle, die allein oder gemeinsam mit anderen über die Zwecke und Mittel der Verarbeitung von personenbezogenen Daten entscheidet, bezeichnet.
-            </p>
-
-            <h3>
-                Maßgebliche Rechtsgrundlagen
-            </h3>
-
-            <p>
-                Nach Maßgabe des Art. 13 DSGVO teilen wir Ihnen die Rechtsgrundlagen unserer Datenverarbeitungen mit. Sofern die Rechtsgrundlage in der Datenschutzerklärung nicht genannt wird, gilt Folgendes: Die Rechtsgrundlage für die Einholung von Einwilligungen ist Art. 6 Abs. 1 lit. a und Art. 7 DSGVO, die Rechtsgrundlage für die Verarbeitung zur Erfüllung unserer Leistungen und Durchführung vertraglicher Maßnahmen sowie Beantwortung von Anfragen ist Art. 6 Abs. 1 lit. b DSGVO, die Rechtsgrundlage für die Verarbeitung zur Erfüllung unserer rechtlichen Verpflichtungen ist Art. 6 Abs. 1 lit. c DSGVO, und die Rechtsgrundlage für die Verarbeitung zur Wahrung unserer berechtigten Interessen ist Art. 6 Abs. 1 lit. f DSGVO. Für den Fall, dass lebenswichtige Interessen der betroffenen Person oder einer anderen natürlichen Person eine Verarbeitung personenbezogener Daten erforderlich machen, dient Art. 6 Abs. 1 lit. d DSGVO als Rechtsgrundlage.
-            </p>
-
-            <h3>
-                Zusammenarbeit mit Auftragsverarbeitern und Dritten
-            </h3>
-
-            <p>
-                Sofern wir im Rahmen unserer Verarbeitung Daten gegenüber anderen Personen und Unternehmen (Auftragsverarbeitern oder Dritten) offenbaren, sie an diese übermitteln oder ihnen sonst Zugriff auf die Daten gewähren, erfolgt dies nur auf Grundlage einer gesetzlichen Erlaubnis (z.B. wenn eine Übermittlung der Daten an Dritte, wie an Zahlungsdienstleister, gem. Art. 6 Abs. 1 lit. b DSGVO zur Vertragserfüllung erforderlich ist), Sie eingewilligt haben, eine rechtliche Verpflichtung dies vorsieht oder auf Grundlage unserer berechtigten Interessen (z.B. beim Einsatz von Beauftragten, Webhostern, etc.).
-            </p>
-
-            <p>
-                Sofern wir Dritte mit der Verarbeitung von Daten auf Grundlage eines sog. „Auftragsverarbeitungsvertrages“ beauftragen, geschieht dies auf Grundlage des Art. 28 DSGVO.
-            </p>
-
-            <h3>
-                Übermittlungen in Drittländer
-            </h3>
-
-            <p>
-                Sofern wir Daten in einem Drittland (d.h. außerhalb der Europäischen Union (EU) oder des Europäischen Wirtschaftsraums (EWR)) verarbeiten oder dies im Rahmen der Inanspruchnahme von Diensten Dritter oder Offenlegung, bzw. Übermittlung von Daten an Dritte geschieht, erfolgt dies nur, wenn es zur Erfüllung unserer (vor)vertraglichen Pflichten, auf Grundlage Ihrer Einwilligung, aufgrund einer rechtlichen Verpflichtung oder auf Grundlage unserer berechtigten Interessen geschieht. Vorbehaltlich gesetzlicher oder vertraglicher Erlaubnisse, verarbeiten oder lassen wir die Daten in einem Drittland nur beim Vorliegen der besonderen Voraussetzungen der Art. 44 ff. DSGVO verarbeiten. D.h. die Verarbeitung erfolgt z.B. auf Grundlage besonderer Garantien, wie der offiziell anerkannten Feststellung eines der EU entsprechenden Datenschutzniveaus (z.B. für die USA durch das „Privacy Shield“) oder Beachtung offiziell anerkannter spezieller vertraglicher Verpflichtungen (so genannte „Standardvertragsklauseln“).
-            </p>
-
-            <h3>
-                Rechte der betroffenen Personen
-            </h3>
-
-            <p>
-                Sie haben das Recht, eine Bestätigung darüber zu verlangen, ob betreffende Daten verarbeitet werden und auf Auskunft über diese Daten sowie auf weitere Informationen und Kopie der Daten entsprechend Art. 15 DSGVO.
-            </p>
-
-            <p>
-                Sie haben entsprechend. Art. 16 DSGVO das Recht, die Vervollständigung der Sie betreffenden Daten oder die Berichtigung der Sie betreffenden unrichtigen Daten zu verlangen.
-            </p>
-
-            <p>
-                Sie haben nach Maßgabe des Art. 17 DSGVO das Recht zu verlangen, dass betreffende Daten unverzüglich gelöscht werden, bzw. alternativ nach Maßgabe des Art. 18 DSGVO eine Einschränkung der Verarbeitung der Daten zu verlangen.
-            </p>
-
-            <p>
-                Sie haben das Recht zu verlangen, dass die Sie betreffenden Daten, die Sie uns bereitgestellt haben nach Maßgabe des Art. 20 DSGVO zu erhalten und deren Übermittlung an andere Verantwortliche zu fordern.
-            </p>
-
-            <p>
-                Sie haben ferner gem. Art. 77 DSGVO das Recht, eine Beschwerde bei der zuständigen Aufsichtsbehörde einzureichen.
-            </p>
-
-            <h3>
-                Widerrufsrecht
-            </h3>
-
-            <p>
-                Sie haben das Recht, erteilte Einwilligungen gem. Art. 7 Abs. 3 DSGVO mit Wirkung für die Zukunft zu widerrufen.
-            </p>
-
-            <h3>
-                Widerspruchsrecht
-            </h3>
-
-            <p>
-                Sie können der künftigen Verarbeitung der Sie betreffenden Daten nach Maßgabe des Art. 21 DSGVO jederzeit widersprechen. Der Widerspruch kann insbesondere gegen die Verarbeitung für Zwecke der Direktwerbung erfolgen.
-            </p>
-
-            <h3>
-                Cookies und Widerspruchsrecht bei Direktwerbung
-            </h3>
-
-            <p>
-                Als „Cookies“ werden kleine Dateien bezeichnet, die auf Rechnern der Nutzer gespeichert werden. Innerhalb der Cookies können unterschiedliche Angaben gespeichert werden. Ein Cookie dient primär dazu, die Angaben zu einem Nutzer (bzw. dem Gerät auf dem das Cookie gespeichert ist) während oder auch nach seinem Besuch innerhalb eines Onlineangebotes zu speichern. Als temporäre Cookies, bzw. „Session-Cookies“ oder „transiente Cookies“, werden Cookies bezeichnet, die gelöscht werden, nachdem ein Nutzer ein Onlineangebot verlässt und seinen Browser schließt. In einem solchen Cookie kann z.B. der Inhalt eines Warenkorbs in einem Onlineshop oder ein Login-Staus gespeichert werden. Als „permanent“ oder „persistent“ werden Cookies bezeichnet, die auch nach dem Schließen des Browsers gespeichert bleiben. So kann z.B. der Login-Status gespeichert werden, wenn die Nutzer diese nach mehreren Tagen aufsuchen. Ebenso können in einem solchen Cookie die Interessen der Nutzer gespeichert werden, die für Reichweitenmessung oder Marketingzwecke verwendet werden. Als „Third-Party-Cookie“ werden Cookies bezeichnet, die von anderen Anbietern als dem Verantwortlichen, der das Onlineangebot betreibt, angeboten werden (andernfalls, wenn es nur dessen Cookies sind spricht man von „First-Party Cookies“).
-            </p>
-
-            <p>
-                Wir können temporäre und permanente Cookies einsetzen und klären hierüber im Rahmen unserer Datenschutzerklärung auf.
-            </p>
-
-            <p>
-                Falls die Nutzer nicht möchten, dass Cookies auf ihrem Rechner gespeichert werden, werden sie gebeten die entsprechende Option in den Systemeinstellungen ihres Browsers zu deaktivieren. Gespeicherte Cookies können in den Systemeinstellungen des Browsers gelöscht werden. Der Ausschluss von Cookies kann zu Funktionseinschränkungen dieses Onlineangebotes führen.
-            </p>
-
-            <p>
-                Ein genereller Widerspruch gegen den Einsatz der zu Zwecken des Onlinemarketing eingesetzten Cookies kann bei einer Vielzahl der Dienste, vor allem im Fall des Trackings, über die US-amerikanische Seite <a href="http://www.aboutads.info/choices/">http://www.aboutads.info/choices/</a> oder die EU-Seite <a href="http://www.youronlinechoices.com/">http://www.youronlinechoices.com/</a> erklärt werden. Des Weiteren kann die Speicherung von Cookies mittels deren Abschaltung in den Einstellungen des Browsers erreicht werden. Bitte beachten Sie, dass dann gegebenenfalls nicht alle Funktionen dieses Onlineangebotes genutzt werden können.
-            </p>
-
-            <h3>
-                Löschung von Daten
-            </h3>
-
-            <p>
-                Die von uns verarbeiteten Daten werden nach Maßgabe der Art. 17 und 18 DSGVO gelöscht oder in ihrer Verarbeitung eingeschränkt. Sofern nicht im Rahmen dieser Datenschutzerklärung ausdrücklich angegeben, werden die bei uns gespeicherten Daten gelöscht, sobald sie für ihre Zweckbestimmung nicht mehr erforderlich sind und der Löschung keine gesetzlichen Aufbewahrungspflichten entgegenstehen. Sofern die Daten nicht gelöscht werden, weil sie für andere und gesetzlich zulässige Zwecke erforderlich sind, wird deren Verarbeitung eingeschränkt. D.h. die Daten werden gesperrt und nicht für andere Zwecke verarbeitet. Das gilt z.B. für Daten, die aus handels- oder steuerrechtlichen Gründen aufbewahrt werden müssen.
-            </p>
-
-            <p>
-                Nach gesetzlichen Vorgaben in Deutschland erfolgt die Aufbewahrung insbesondere für 6 Jahre gemäß § 257 Abs. 1 HGB (Handelsbücher, Inventare, Eröffnungsbilanzen, Jahresabschlüsse, Handelsbriefe, Buchungsbelege, etc.) sowie für 10 Jahre gemäß § 147 Abs. 1 AO (Bücher, Aufzeichnungen, Lageberichte, Buchungsbelege, Handels- und Geschäftsbriefe, Für Besteuerung relevante Unterlagen, etc.).
-            </p>
-
-            <p>
-                Nach gesetzlichen Vorgaben in Österreich erfolgt die Aufbewahrung insbesondere für 7 J gemäß § 132 Abs. 1 BAO (Buchhaltungsunterlagen, Belege/Rechnungen, Konten, Belege, Geschäftspapiere, Aufstellung der Einnahmen und Ausgaben, etc.), für 22 Jahre im Zusammenhang mit Grundstücken und für 10 Jahre bei Unterlagen im Zusammenhang mit elektronisch erbrachten Leistungen, Telekommunikations-, Rundfunk- und Fernsehleistungen, die an Nichtunternehmer in EU-Mitgliedstaaten erbracht werden und für die der Mini-One-Stop-Shop (MOSS) in Anspruch genommen wird.
-            </p>
-
-            <h3>
-                Hosting
-            </h3>
-
-            <p>
-                Die von uns in Anspruch genommenen Hosting-Leistungen dienen der Zurverfügungstellung der folgenden Leistungen: Infrastruktur- und Plattformdienstleistungen, Rechenkapazität, Speicherplatz und Datenbankdienste, Sicherheitsleistungen sowie technische Wartungsleistungen, die wir zum Zwecke des Betriebs dieses Onlineangebotes einsetzen.
-            </p>
-
-            <p>
-                Hierbei verarbeiten wir, bzw. unser Hostinganbieter Bestandsdaten, Kontaktdaten, Inhaltsdaten, Vertragsdaten, Nutzungsdaten, Meta- und Kommunikationsdaten von Kunden, Interessenten und Besuchern dieses Onlineangebotes auf Grundlage unserer berechtigten Interessen an einer effizienten und sicheren Zurverfügungstellung dieses Onlineangebotes gem. Art. 6 Abs. 1 lit. f DSGVO i.V.m. Art. 28 DSGVO (Abschluss Auftragsverarbeitungsvertrag).
-            </p>
-
-            <h3>
-                Erhebung von Zugriffsdaten und Logfiles
-            </h3>
-
-            <p>
-                Wir, bzw. unser Hostinganbieter, erhebt auf Grundlage unserer berechtigten Interessen im Sinne des Art. 6 Abs. 1 lit. f. DSGVO Daten über jeden Zugriff auf den Server, auf dem sich dieser Dienst befindet (sogenannte Serverlogfiles). Zu den Zugriffsdaten gehören Name der abgerufenen Webseite, Datei, Datum und Uhrzeit des Abrufs, übertragene Datenmenge, Meldung über erfolgreichen Abruf, Browsertyp nebst Version, das Betriebssystem des Nutzers, Referrer URL (die zuvor besuchte Seite), IP-Adresse und der anfragende Provider.
-            </p>
-
-            <p>
-                Logfile-Informationen werden aus Sicherheitsgründen (z.B. zur Aufklärung von Missbrauchs- oder Betrugshandlungen) für die Dauer von maximal 7 Tagen gespeichert und danach gelöscht. Daten, deren weitere Aufbewahrung zu Beweiszwecken erforderlich ist, sind bis zur endgültigen Klärung des jeweiligen Vorfalls von der Löschung ausgenommen.
-            </p>
-
-            <h3>
-                Registrierfunktion
-            </h3>
-
-            <p>
-                Nutzer können optional ein Nutzerkonto anlegen. Im Rahmen der Registrierung werden die erforderlichen Pflichtangaben den Nutzern mitgeteilt. Die im Rahmen der Registrierung eingegebenen Daten werden für die Zwecke der Nutzung des Angebotes verwendet. Die Nutzer können über angebots- oder registrierungsrelevante Informationen, wie Änderungen des Angebotsumfangs oder technische Umstände per E-Mail informiert werden. Wenn Nutzer ihr Nutzerkonto gekündigt haben, werden deren Daten im Hinblick auf das Nutzerkonto gelöscht, vorbehaltlich deren Aufbewahrung ist aus handels- oder steuerrechtlichen Gründen entspr. Art. 6 Abs. 1 lit. c DSGVO notwendig. Es obliegt den Nutzern, ihre Daten bei erfolgter Kündigung vor dem Vertragsende zu sichern. Wir sind berechtigt, sämtliche während der Vertragsdauer gespeicherten Daten des Nutzers unwiederbringlich zu löschen.
-            </p>
-
-            <p>
-                Im Rahmen der Inanspruchnahme unserer Regsitrierungs- und Anmeldefunktionen sowie der Nutzung der Nutzerkontos, speichern wird die IP-Adresse und den Zeitpunkt der jeweiligen Nutzerhandlung. Die Speicherung erfolgt auf Grundlage unserer berechtigten Interessen, als auch der Nutzer an Schutz vor Missbrauch und sonstiger unbefugter Nutzung. Eine Weitergabe dieser Daten an Dritte erfolgt grundsätzlich nicht, außer sie ist zur Verfolgung unserer Ansprüche erforderlich oder es besteht hierzu besteht eine gesetzliche Verpflichtung gem. Art. 6 Abs. 1 lit. c DSGVO. Die IP-Adressen werden spätestens nach 7 Tagen anonymisiert oder gelöscht.
-            </p>
-
-            <h3>
-                Kontaktaufnahme
-            </h3>
-
-            <p>
-                Bei der Kontaktaufnahme mit uns (z.B. per Kontaktformular, E-Mail, Telefon oder via sozialer Medien) werden die Angaben des Nutzers zur Bearbeitung der Kontaktanfrage und deren Abwicklung gem. Art. 6 Abs. 1 lit. b) DSGVO verarbeitet. Die Angaben der Nutzer können in einem Customer-Relationship-Management System ("CRM System") oder vergleichbarer Anfragenorganisation gespeichert werden.
-            </p>
-
-            <p>
-                Wir löschen die Anfragen, sofern diese nicht mehr erforderlich sind. Wir überprüfen die Erforderlichkeit alle zwei Jahre; Ferner gelten die gesetzlichen Archivierungspflichten.
-            </p>
-
-            <h3>
-                Kommentare und Beiträge
-            </h3>
-
-            <p>
-                Wenn Nutzer Kommentare oder sonstige Beiträge hinterlassen, werden ihre IP-Adressen auf Grundlage unserer berechtigten Interessen im Sinne des Art. 6 Abs. 1 lit. f. DSGVO für 7 Tage gespeichert. Das erfolgt zu unserer Sicherheit, falls jemand in Kommentaren und Beiträgen widerrechtliche Inhalte hinterlässt (Beleidigungen, verbotene politische Propaganda, etc.). In diesem Fall können wir selbst für den Kommentar oder Beitrag belangt werden und sind daher an der Identität des Verfassers interessiert.
-            </p>
-
-            <h3>
-                Kommentarabonnements
-            </h3>
-
-            <p>
-                Die Nachfolgekommentare können durch Nutzer mit deren Einwilligung gem. Art. 6 Abs. 1 lit. a DSGVO abonniert werden. Die Nutzer erhalten eine Bestätigungsemail, um zu überprüfen, ob sie der Inhaber der eingegebenen Emailadresse sind. Nutzer können laufende Kommentarabonnements jederzeit abbestellen. Die Bestätigungsemail wird Hinweise zu den Widerrufsmöglichkeiten enthalten.
-            </p>
-
-            <h3>
-                Newsletter
-            </h3>
-
-            <p>
-                Mit den nachfolgenden Hinweisen informieren wir Sie über die Inhalte unseres Newsletters sowie das Anmelde-, Versand- und das statistische Auswertungsverfahren sowie Ihre Widerspruchsrechte auf. Indem Sie unseren Newsletter abonnieren, erklären Sie sich mit dem Empfang und den beschriebenen Verfahren einverstanden.
-            </p>
-
-
-            <p>
-                Inhalt des Newsletters: Wir versenden Newsletter, E-Mails und weitere elektronische Benachrichtigungen mit werblichen Informationen (nachfolgend „Newsletter“) nur mit der Einwilligung der Empfänger oder einer gesetzlichen Erlaubnis. Sofern im Rahmen einer Anmeldung zum Newsletter dessen Inhalte konkret umschrieben werden, sind sie für die Einwilligung der Nutzer maßgeblich. Im Übrigen enthalten unsere Newsletter Informationen zu unseren Leistungen und uns.
-            </p>
-
-            <p>
-                Double-Opt-In und Protokollierung: Die Anmeldung zu unserem Newsletter erfolgt in einem sog. Double-Opt-In-Verfahren. D.h. Sie erhalten nach der Anmeldung eine E-Mail, in der Sie um die Bestätigung Ihrer Anmeldung gebeten werden. Diese Bestätigung ist notwendig, damit sich niemand mit fremden E-Mailadressen anmelden kann. Die Anmeldungen zum Newsletter werden protokolliert, um den Anmeldeprozess entsprechend den rechtlichen Anforderungen nachweisen zu können. Hierzu gehört die Speicherung des Anmelde- und des Bestätigungszeitpunkts, als auch der IP-Adresse. Ebenso werden die Änderungen Ihrer bei dem Versanddienstleister gespeicherten Daten protokolliert.
-            </p>
-
-            <p>
-                Anmeldedaten: Um sich für den Newsletter anzumelden, reicht es aus, wenn Sie Ihre E-Mailadresse angeben. Optional bitten wir Sie einen Namen, zwecks persönlicher Ansprache im Newsletters anzugeben.
-            </p>
-
-            <p>
-                Deutschland: Der Versand des Newsletters und die mit ihm verbundene Erfolgsmessung erfolgt auf Grundlage
-                einer Einwilligung der Empfänger gem. Art. 6 Abs. 1 lit. a, Art. 7 DSGVO i.V.m § 7 Abs. 2 Nr. 3 UWG bzw.
-                auf Grundlage der gesetzlichen Erlaubnis gem. § 7 Abs. 3 UWG.
-            </p>
-
-            <p>
-                Die Protokollierung des Anmeldeverfahrens erfolgt auf Grundlage unserer berechtigten Interessen gem.
-                Art. 6 Abs. 1 lit. f DSGVO. Unser Interesse richtet sich auf den Einsatz eines nutzerfreundlichen sowie
-                sicheren Newslettersystems, das sowohl unseren geschäftlichen Interessen dient, als auch den Erwartungen
-                der Nutzer entspricht und uns ferner den Nachweis von Einwilligungen erlaubt.
-            </p>
-
-            <p>
-                Sie können den Empfang unseres Newsletters jederzeit kündigen, d.h. Ihre Einwilligungen widerrufen.
-                Einen Link zur Kündigung des Newsletters finden Sie am Ende eines jeden Newsletters. Wir können die
-                ausgetragenen E-Mailadressen bis zu drei Jahren auf Grundlage unserer berechtigten Interessen speichern
-                bevor wir sie für Zwecke des Newsletterversandes löschen, um eine ehemals gegebene Einwilligung
-                nachweisen zu können. Die Verarbeitung dieser Daten wird auf den Zweck einer möglichen Abwehr von
-                Ansprüchen beschränkt. Ein individueller Löschungsantrag ist jederzeit möglich, sofern zugleich das
-                ehemalige Bestehen einer Einwilligung bestätigt wird.
-            </p>
-
-            <p>
-                <a href="https://datenschutz-generator.de">
-                    Erstellt mit Datenschutz-Generator.de von RA Dr. Thomas Schwenke
-                </a>
-            </p>
+        <div class="col-md-10 offset-md-1">
+            <div class="card border-0 shadow-sm mb-4">
+                <div class="card-body">
+                    <p>
+                        Diese Datenschutzerklärung klärt Sie über die Art, den Umfang und Zweck der Verarbeitung von personenbezogenen Daten (nachfolgend kurz „Daten") innerhalb unseres Onlineangebotes und der mit ihm verbundenen Webseiten, Funktionen und Inhalte sowie externen Onlinepräsenzen, wie z.B. unser Social Media Profile auf. (nachfolgend gemeinsam bezeichnet als „Onlineangebot"). Im Hinblick auf die verwendeten Begrifflichkeiten, wie z.B. „Verarbeitung" oder „Verantwortlicher" verweisen wir auf die Definitionen im Art. 4 der Datenschutzgrundverordnung (DSGVO).
+                    </p>
+
+                    <h3>
+                        Verantwortlicher
+                    </h3>
+
+                    <p>
+                        Malte Hübner
+                        <br />
+                        Goethestraße 48
+                        <br />
+                        21335 Lüneburg
+                    </p>
+
+                    <p>
+                        Telefon: 0151 172 77 032
+                        <br/>
+                        E-Mail: <a href="mailto:maltehuebner@gmx.org">maltehuebner@gmx.org</a>
+                    </p>
+
+                    <h3>
+                        Arten der verarbeiteten Daten
+                    </h3>
+
+                    <ul>
+                        <li>
+                            Bestandsdaten (z.B., Namen, Adressen).
+                        </li>
+                        <li>
+                            Kontaktdaten (z.B., E-Mail, Telefonnummern).
+                        </li>
+                        <li>
+                            Inhaltsdaten (z.B., Texteingaben, Fotografien, Videos).
+                        </li>
+                        <li>
+                            Nutzungsdaten (z.B., besuchte Webseiten, Interesse an Inhalten, Zugriffszeiten).
+                        </li>
+                        <li>
+                            Meta-/Kommunikationsdaten (z.B., Geräte-Informationen, IP-Adressen).
+                        </li>
+                    </ul>
+
+                    <h3>
+                        Kategorien betroffener Personen
+                    </h3>
+
+                    <p>
+                        Besucher und Nutzer des Onlineangebotes (Nachfolgend bezeichnen wir die betroffenen Personen zusammenfassend auch als „Nutzer").
+                    </p>
+
+                    <h3>
+                        Zweck der Verarbeitung
+                    </h3>
+
+                    <ul>
+                        <li>
+                            Zurverfügungstellung des Onlineangebotes, seiner Funktionen und  Inhalte.
+                        </li>
+                        <li>
+                            Beantwortung von Kontaktanfragen und Kommunikation mit Nutzern.
+                        </li>
+                        <li>
+                            Sicherheitsmaßnahmen.
+                        </li>
+                        <li>
+                            Reichweitenmessung/Marketing
+                        </li>
+                    </ul>
+
+                    <h3>
+                        Verwendete Begrifflichkeiten
+                    </h3>
+
+                    <p>
+                        „Personenbezogene Daten" sind alle Informationen, die sich auf eine identifizierte oder identifizierbare natürliche Person (im Folgenden „betroffene Person") beziehen; als identifizierbar wird eine natürliche Person angesehen, die direkt oder indirekt, insbesondere mittels Zuordnung zu einer Kennung wie einem Namen, zu einer Kennnummer, zu Standortdaten, zu einer Online-Kennung (z.B. Cookie) oder zu einem oder mehreren besonderen Merkmalen identifiziert werden kann, die Ausdruck der physischen, physiologischen, genetischen, psychischen, wirtschaftlichen, kulturellen oder sozialen Identität dieser natürlichen Person sind.
+                    </p>
+
+                    <p>
+                        „Verarbeitung" ist jeder mit oder ohne Hilfe automatisierter Verfahren ausgeführten Vorgang oder jede solche Vorgangsreihe im Zusammenhang mit personenbezogenen Daten. Der Begriff reicht weit und umfasst praktisch jeden Umgang mit Daten.
+                    </p>
+
+                    <p>
+                        Als „Verantwortlicher" wird die natürliche oder juristische Person, Behörde, Einrichtung oder andere Stelle, die allein oder gemeinsam mit anderen über die Zwecke und Mittel der Verarbeitung von personenbezogenen Daten entscheidet, bezeichnet.
+                    </p>
+
+                    <h3>
+                        Maßgebliche Rechtsgrundlagen
+                    </h3>
+
+                    <p>
+                        Nach Maßgabe des Art. 13 DSGVO teilen wir Ihnen die Rechtsgrundlagen unserer Datenverarbeitungen mit. Sofern die Rechtsgrundlage in der Datenschutzerklärung nicht genannt wird, gilt Folgendes: Die Rechtsgrundlage für die Einholung von Einwilligungen ist Art. 6 Abs. 1 lit. a und Art. 7 DSGVO, die Rechtsgrundlage für die Verarbeitung zur Erfüllung unserer Leistungen und Durchführung vertraglicher Maßnahmen sowie Beantwortung von Anfragen ist Art. 6 Abs. 1 lit. b DSGVO, die Rechtsgrundlage für die Verarbeitung zur Erfüllung unserer rechtlichen Verpflichtungen ist Art. 6 Abs. 1 lit. c DSGVO, und die Rechtsgrundlage für die Verarbeitung zur Wahrung unserer berechtigten Interessen ist Art. 6 Abs. 1 lit. f DSGVO. Für den Fall, dass lebenswichtige Interessen der betroffenen Person oder einer anderen natürlichen Person eine Verarbeitung personenbezogener Daten erforderlich machen, dient Art. 6 Abs. 1 lit. d DSGVO als Rechtsgrundlage.
+                    </p>
+
+                    <h3>
+                        Zusammenarbeit mit Auftragsverarbeitern und Dritten
+                    </h3>
+
+                    <p>
+                        Sofern wir im Rahmen unserer Verarbeitung Daten gegenüber anderen Personen und Unternehmen (Auftragsverarbeitern oder Dritten) offenbaren, sie an diese übermitteln oder ihnen sonst Zugriff auf die Daten gewähren, erfolgt dies nur auf Grundlage einer gesetzlichen Erlaubnis (z.B. wenn eine Übermittlung der Daten an Dritte, wie an Zahlungsdienstleister, gem. Art. 6 Abs. 1 lit. b DSGVO zur Vertragserfüllung erforderlich ist), Sie eingewilligt haben, eine rechtliche Verpflichtung dies vorsieht oder auf Grundlage unserer berechtigten Interessen (z.B. beim Einsatz von Beauftragten, Webhostern, etc.).
+                    </p>
+
+                    <p>
+                        Sofern wir Dritte mit der Verarbeitung von Daten auf Grundlage eines sog. „Auftragsverarbeitungsvertrages" beauftragen, geschieht dies auf Grundlage des Art. 28 DSGVO.
+                    </p>
+
+                    <h3>
+                        Übermittlungen in Drittländer
+                    </h3>
+
+                    <p>
+                        Sofern wir Daten in einem Drittland (d.h. außerhalb der Europäischen Union (EU) oder des Europäischen Wirtschaftsraums (EWR)) verarbeiten oder dies im Rahmen der Inanspruchnahme von Diensten Dritter oder Offenlegung, bzw. Übermittlung von Daten an Dritte geschieht, erfolgt dies nur, wenn es zur Erfüllung unserer (vor)vertraglichen Pflichten, auf Grundlage Ihrer Einwilligung, aufgrund einer rechtlichen Verpflichtung oder auf Grundlage unserer berechtigten Interessen geschieht. Vorbehaltlich gesetzlicher oder vertraglicher Erlaubnisse, verarbeiten oder lassen wir die Daten in einem Drittland nur beim Vorliegen der besonderen Voraussetzungen der Art. 44 ff. DSGVO verarbeiten. D.h. die Verarbeitung erfolgt z.B. auf Grundlage besonderer Garantien, wie der offiziell anerkannten Feststellung eines der EU entsprechenden Datenschutzniveaus (z.B. für die USA durch das „Privacy Shield") oder Beachtung offiziell anerkannter spezieller vertraglicher Verpflichtungen (so genannte „Standardvertragsklauseln").
+                    </p>
+
+                    <h3>
+                        Rechte der betroffenen Personen
+                    </h3>
+
+                    <p>
+                        Sie haben das Recht, eine Bestätigung darüber zu verlangen, ob betreffende Daten verarbeitet werden und auf Auskunft über diese Daten sowie auf weitere Informationen und Kopie der Daten entsprechend Art. 15 DSGVO.
+                    </p>
+
+                    <p>
+                        Sie haben entsprechend. Art. 16 DSGVO das Recht, die Vervollständigung der Sie betreffenden Daten oder die Berichtigung der Sie betreffenden unrichtigen Daten zu verlangen.
+                    </p>
+
+                    <p>
+                        Sie haben nach Maßgabe des Art. 17 DSGVO das Recht zu verlangen, dass betreffende Daten unverzüglich gelöscht werden, bzw. alternativ nach Maßgabe des Art. 18 DSGVO eine Einschränkung der Verarbeitung der Daten zu verlangen.
+                    </p>
+
+                    <p>
+                        Sie haben das Recht zu verlangen, dass die Sie betreffenden Daten, die Sie uns bereitgestellt haben nach Maßgabe des Art. 20 DSGVO zu erhalten und deren Übermittlung an andere Verantwortliche zu fordern.
+                    </p>
+
+                    <p>
+                        Sie haben ferner gem. Art. 77 DSGVO das Recht, eine Beschwerde bei der zuständigen Aufsichtsbehörde einzureichen.
+                    </p>
+
+                    <h3>
+                        Widerrufsrecht
+                    </h3>
+
+                    <p>
+                        Sie haben das Recht, erteilte Einwilligungen gem. Art. 7 Abs. 3 DSGVO mit Wirkung für die Zukunft zu widerrufen.
+                    </p>
+
+                    <h3>
+                        Widerspruchsrecht
+                    </h3>
+
+                    <p>
+                        Sie können der künftigen Verarbeitung der Sie betreffenden Daten nach Maßgabe des Art. 21 DSGVO jederzeit widersprechen. Der Widerspruch kann insbesondere gegen die Verarbeitung für Zwecke der Direktwerbung erfolgen.
+                    </p>
+
+                    <h3>
+                        Cookies und Widerspruchsrecht bei Direktwerbung
+                    </h3>
+
+                    <p>
+                        Als „Cookies" werden kleine Dateien bezeichnet, die auf Rechnern der Nutzer gespeichert werden. Innerhalb der Cookies können unterschiedliche Angaben gespeichert werden. Ein Cookie dient primär dazu, die Angaben zu einem Nutzer (bzw. dem Gerät auf dem das Cookie gespeichert ist) während oder auch nach seinem Besuch innerhalb eines Onlineangebotes zu speichern. Als temporäre Cookies, bzw. „Session-Cookies" oder „transiente Cookies", werden Cookies bezeichnet, die gelöscht werden, nachdem ein Nutzer ein Onlineangebot verlässt und seinen Browser schließt. In einem solchen Cookie kann z.B. der Inhalt eines Warenkorbs in einem Onlineshop oder ein Login-Staus gespeichert werden. Als „permanent" oder „persistent" werden Cookies bezeichnet, die auch nach dem Schließen des Browsers gespeichert bleiben. So kann z.B. der Login-Status gespeichert werden, wenn die Nutzer diese nach mehreren Tagen aufsuchen. Ebenso können in einem solchen Cookie die Interessen der Nutzer gespeichert werden, die für Reichweitenmessung oder Marketingzwecke verwendet werden. Als „Third-Party-Cookie" werden Cookies bezeichnet, die von anderen Anbietern als dem Verantwortlichen, der das Onlineangebot betreibt, angeboten werden (andernfalls, wenn es nur dessen Cookies sind spricht man von „First-Party Cookies").
+                    </p>
+
+                    <p>
+                        Wir können temporäre und permanente Cookies einsetzen und klären hierüber im Rahmen unserer Datenschutzerklärung auf.
+                    </p>
+
+                    <p>
+                        Falls die Nutzer nicht möchten, dass Cookies auf ihrem Rechner gespeichert werden, werden sie gebeten die entsprechende Option in den Systemeinstellungen ihres Browsers zu deaktivieren. Gespeicherte Cookies können in den Systemeinstellungen des Browsers gelöscht werden. Der Ausschluss von Cookies kann zu Funktionseinschränkungen dieses Onlineangebotes führen.
+                    </p>
+
+                    <p>
+                        Ein genereller Widerspruch gegen den Einsatz der zu Zwecken des Onlinemarketing eingesetzten Cookies kann bei einer Vielzahl der Dienste, vor allem im Fall des Trackings, über die US-amerikanische Seite <a href="http://www.aboutads.info/choices/">http://www.aboutads.info/choices/</a> oder die EU-Seite <a href="http://www.youronlinechoices.com/">http://www.youronlinechoices.com/</a> erklärt werden. Des Weiteren kann die Speicherung von Cookies mittels deren Abschaltung in den Einstellungen des Browsers erreicht werden. Bitte beachten Sie, dass dann gegebenenfalls nicht alle Funktionen dieses Onlineangebotes genutzt werden können.
+                    </p>
+
+                    <h3>
+                        Löschung von Daten
+                    </h3>
+
+                    <p>
+                        Die von uns verarbeiteten Daten werden nach Maßgabe der Art. 17 und 18 DSGVO gelöscht oder in ihrer Verarbeitung eingeschränkt. Sofern nicht im Rahmen dieser Datenschutzerklärung ausdrücklich angegeben, werden die bei uns gespeicherten Daten gelöscht, sobald sie für ihre Zweckbestimmung nicht mehr erforderlich sind und der Löschung keine gesetzlichen Aufbewahrungspflichten entgegenstehen. Sofern die Daten nicht gelöscht werden, weil sie für andere und gesetzlich zulässige Zwecke erforderlich sind, wird deren Verarbeitung eingeschränkt. D.h. die Daten werden gesperrt und nicht für andere Zwecke verarbeitet. Das gilt z.B. für Daten, die aus handels- oder steuerrechtlichen Gründen aufbewahrt werden müssen.
+                    </p>
+
+                    <p>
+                        Nach gesetzlichen Vorgaben in Deutschland erfolgt die Aufbewahrung insbesondere für 6 Jahre gemäß § 257 Abs. 1 HGB (Handelsbücher, Inventare, Eröffnungsbilanzen, Jahresabschlüsse, Handelsbriefe, Buchungsbelege, etc.) sowie für 10 Jahre gemäß § 147 Abs. 1 AO (Bücher, Aufzeichnungen, Lageberichte, Buchungsbelege, Handels- und Geschäftsbriefe, Für Besteuerung relevante Unterlagen, etc.).
+                    </p>
+
+                    <p>
+                        Nach gesetzlichen Vorgaben in Österreich erfolgt die Aufbewahrung insbesondere für 7 J gemäß § 132 Abs. 1 BAO (Buchhaltungsunterlagen, Belege/Rechnungen, Konten, Belege, Geschäftspapiere, Aufstellung der Einnahmen und Ausgaben, etc.), für 22 Jahre im Zusammenhang mit Grundstücken und für 10 Jahre bei Unterlagen im Zusammenhang mit elektronisch erbrachten Leistungen, Telekommunikations-, Rundfunk- und Fernsehleistungen, die an Nichtunternehmer in EU-Mitgliedstaaten erbracht werden und für die der Mini-One-Stop-Shop (MOSS) in Anspruch genommen wird.
+                    </p>
+
+                    <h3>
+                        Hosting
+                    </h3>
+
+                    <p>
+                        Die von uns in Anspruch genommenen Hosting-Leistungen dienen der Zurverfügungstellung der folgenden Leistungen: Infrastruktur- und Plattformdienstleistungen, Rechenkapazität, Speicherplatz und Datenbankdienste, Sicherheitsleistungen sowie technische Wartungsleistungen, die wir zum Zwecke des Betriebs dieses Onlineangebotes einsetzen.
+                    </p>
+
+                    <p>
+                        Hierbei verarbeiten wir, bzw. unser Hostinganbieter Bestandsdaten, Kontaktdaten, Inhaltsdaten, Vertragsdaten, Nutzungsdaten, Meta- und Kommunikationsdaten von Kunden, Interessenten und Besuchern dieses Onlineangebotes auf Grundlage unserer berechtigten Interessen an einer effizienten und sicheren Zurverfügungstellung dieses Onlineangebotes gem. Art. 6 Abs. 1 lit. f DSGVO i.V.m. Art. 28 DSGVO (Abschluss Auftragsverarbeitungsvertrag).
+                    </p>
+
+                    <h3>
+                        Erhebung von Zugriffsdaten und Logfiles
+                    </h3>
+
+                    <p>
+                        Wir, bzw. unser Hostinganbieter, erhebt auf Grundlage unserer berechtigten Interessen im Sinne des Art. 6 Abs. 1 lit. f. DSGVO Daten über jeden Zugriff auf den Server, auf dem sich dieser Dienst befindet (sogenannte Serverlogfiles). Zu den Zugriffsdaten gehören Name der abgerufenen Webseite, Datei, Datum und Uhrzeit des Abrufs, übertragene Datenmenge, Meldung über erfolgreichen Abruf, Browsertyp nebst Version, das Betriebssystem des Nutzers, Referrer URL (die zuvor besuchte Seite), IP-Adresse und der anfragende Provider.
+                    </p>
+
+                    <p>
+                        Logfile-Informationen werden aus Sicherheitsgründen (z.B. zur Aufklärung von Missbrauchs- oder Betrugshandlungen) für die Dauer von maximal 7 Tagen gespeichert und danach gelöscht. Daten, deren weitere Aufbewahrung zu Beweiszwecken erforderlich ist, sind bis zur endgültigen Klärung des jeweiligen Vorfalls von der Löschung ausgenommen.
+                    </p>
+
+                    <h3>
+                        Registrierfunktion
+                    </h3>
+
+                    <p>
+                        Nutzer können optional ein Nutzerkonto anlegen. Im Rahmen der Registrierung werden die erforderlichen Pflichtangaben den Nutzern mitgeteilt. Die im Rahmen der Registrierung eingegebenen Daten werden für die Zwecke der Nutzung des Angebotes verwendet. Die Nutzer können über angebots- oder registrierungsrelevante Informationen, wie Änderungen des Angebotsumfangs oder technische Umstände per E-Mail informiert werden. Wenn Nutzer ihr Nutzerkonto gekündigt haben, werden deren Daten im Hinblick auf das Nutzerkonto gelöscht, vorbehaltlich deren Aufbewahrung ist aus handels- oder steuerrechtlichen Gründen entspr. Art. 6 Abs. 1 lit. c DSGVO notwendig. Es obliegt den Nutzern, ihre Daten bei erfolgter Kündigung vor dem Vertragsende zu sichern. Wir sind berechtigt, sämtliche während der Vertragsdauer gespeicherten Daten des Nutzers unwiederbringlich zu löschen.
+                    </p>
+
+                    <p>
+                        Im Rahmen der Inanspruchnahme unserer Regsitrierungs- und Anmeldefunktionen sowie der Nutzung der Nutzerkontos, speichern wird die IP-Adresse und den Zeitpunkt der jeweiligen Nutzerhandlung. Die Speicherung erfolgt auf Grundlage unserer berechtigten Interessen, als auch der Nutzer an Schutz vor Missbrauch und sonstiger unbefugter Nutzung. Eine Weitergabe dieser Daten an Dritte erfolgt grundsätzlich nicht, außer sie ist zur Verfolgung unserer Ansprüche erforderlich oder es besteht hierzu besteht eine gesetzliche Verpflichtung gem. Art. 6 Abs. 1 lit. c DSGVO. Die IP-Adressen werden spätestens nach 7 Tagen anonymisiert oder gelöscht.
+                    </p>
+
+                    <h3>
+                        Kontaktaufnahme
+                    </h3>
+
+                    <p>
+                        Bei der Kontaktaufnahme mit uns (z.B. per Kontaktformular, E-Mail, Telefon oder via sozialer Medien) werden die Angaben des Nutzers zur Bearbeitung der Kontaktanfrage und deren Abwicklung gem. Art. 6 Abs. 1 lit. b) DSGVO verarbeitet. Die Angaben der Nutzer können in einem Customer-Relationship-Management System ("CRM System") oder vergleichbarer Anfragenorganisation gespeichert werden.
+                    </p>
+
+                    <p>
+                        Wir löschen die Anfragen, sofern diese nicht mehr erforderlich sind. Wir überprüfen die Erforderlichkeit alle zwei Jahre; Ferner gelten die gesetzlichen Archivierungspflichten.
+                    </p>
+
+                    <h3>
+                        Kommentare und Beiträge
+                    </h3>
+
+                    <p>
+                        Wenn Nutzer Kommentare oder sonstige Beiträge hinterlassen, werden ihre IP-Adressen auf Grundlage unserer berechtigten Interessen im Sinne des Art. 6 Abs. 1 lit. f. DSGVO für 7 Tage gespeichert. Das erfolgt zu unserer Sicherheit, falls jemand in Kommentaren und Beiträgen widerrechtliche Inhalte hinterlässt (Beleidigungen, verbotene politische Propaganda, etc.). In diesem Fall können wir selbst für den Kommentar oder Beitrag belangt werden und sind daher an der Identität des Verfassers interessiert.
+                    </p>
+
+                    <h3>
+                        Kommentarabonnements
+                    </h3>
+
+                    <p>
+                        Die Nachfolgekommentare können durch Nutzer mit deren Einwilligung gem. Art. 6 Abs. 1 lit. a DSGVO abonniert werden. Die Nutzer erhalten eine Bestätigungsemail, um zu überprüfen, ob sie der Inhaber der eingegebenen Emailadresse sind. Nutzer können laufende Kommentarabonnements jederzeit abbestellen. Die Bestätigungsemail wird Hinweise zu den Widerrufsmöglichkeiten enthalten.
+                    </p>
+
+                    <h3>
+                        Newsletter
+                    </h3>
+
+                    <p>
+                        Mit den nachfolgenden Hinweisen informieren wir Sie über die Inhalte unseres Newsletters sowie das Anmelde-, Versand- und das statistische Auswertungsverfahren sowie Ihre Widerspruchsrechte auf. Indem Sie unseren Newsletter abonnieren, erklären Sie sich mit dem Empfang und den beschriebenen Verfahren einverstanden.
+                    </p>
+
+                    <p>
+                        Inhalt des Newsletters: Wir versenden Newsletter, E-Mails und weitere elektronische Benachrichtigungen mit werblichen Informationen (nachfolgend „Newsletter") nur mit der Einwilligung der Empfänger oder einer gesetzlichen Erlaubnis. Sofern im Rahmen einer Anmeldung zum Newsletter dessen Inhalte konkret umschrieben werden, sind sie für die Einwilligung der Nutzer maßgeblich. Im Übrigen enthalten unsere Newsletter Informationen zu unseren Leistungen und uns.
+                    </p>
+
+                    <p>
+                        Double-Opt-In und Protokollierung: Die Anmeldung zu unserem Newsletter erfolgt in einem sog. Double-Opt-In-Verfahren. D.h. Sie erhalten nach der Anmeldung eine E-Mail, in der Sie um die Bestätigung Ihrer Anmeldung gebeten werden. Diese Bestätigung ist notwendig, damit sich niemand mit fremden E-Mailadressen anmelden kann. Die Anmeldungen zum Newsletter werden protokolliert, um den Anmeldeprozess entsprechend den rechtlichen Anforderungen nachweisen zu können. Hierzu gehört die Speicherung des Anmelde- und des Bestätigungszeitpunkts, als auch der IP-Adresse. Ebenso werden die Änderungen Ihrer bei dem Versanddienstleister gespeicherten Daten protokolliert.
+                    </p>
+
+                    <p>
+                        Anmeldedaten: Um sich für den Newsletter anzumelden, reicht es aus, wenn Sie Ihre E-Mailadresse angeben. Optional bitten wir Sie einen Namen, zwecks persönlicher Ansprache im Newsletters anzugeben.
+                    </p>
+
+                    <p>
+                        Deutschland: Der Versand des Newsletters und die mit ihm verbundene Erfolgsmessung erfolgt auf Grundlage
+                        einer Einwilligung der Empfänger gem. Art. 6 Abs. 1 lit. a, Art. 7 DSGVO i.V.m § 7 Abs. 2 Nr. 3 UWG bzw.
+                        auf Grundlage der gesetzlichen Erlaubnis gem. § 7 Abs. 3 UWG.
+                    </p>
+
+                    <p>
+                        Die Protokollierung des Anmeldeverfahrens erfolgt auf Grundlage unserer berechtigten Interessen gem.
+                        Art. 6 Abs. 1 lit. f DSGVO. Unser Interesse richtet sich auf den Einsatz eines nutzerfreundlichen sowie
+                        sicheren Newslettersystems, das sowohl unseren geschäftlichen Interessen dient, als auch den Erwartungen
+                        der Nutzer entspricht und uns ferner den Nachweis von Einwilligungen erlaubt.
+                    </p>
+
+                    <p>
+                        Sie können den Empfang unseres Newsletters jederzeit kündigen, d.h. Ihre Einwilligungen widerrufen.
+                        Einen Link zur Kündigung des Newsletters finden Sie am Ende eines jeden Newsletters. Wir können die
+                        ausgetragenen E-Mailadressen bis zu drei Jahren auf Grundlage unserer berechtigten Interessen speichern
+                        bevor wir sie für Zwecke des Newsletterversandes löschen, um eine ehemals gegebene Einwilligung
+                        nachweisen zu können. Die Verarbeitung dieser Daten wird auf den Zweck einer möglichen Abwehr von
+                        Ansprüchen beschränkt. Ein individueller Löschungsantrag ist jederzeit möglich, sofern zugleich das
+                        ehemalige Bestehen einer Einwilligung bestätigt wird.
+                    </p>
+
+                    <p class="mb-0">
+                        <a href="https://datenschutz-generator.de">
+                            Erstellt mit Datenschutz-Generator.de von RA Dr. Thomas Schwenke
+                        </a>
+                    </p>
+                </div>
+            </div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- Replace all BS3 `panel panel-default` with modern `card border-0 shadow-sm` pattern across 5 Static templates
- Fix BS3 `col-md-offset-1` to BS5 `offset-md-1` in all templates
- Replace BS3 `nav nav-pills nav-stacked` with BS5 `nav nav-pills flex-column` in gdpr.html.twig
- Replace deprecated `<a name>` anchors with `id` attributes on heading elements
- Add Font Awesome 5 `far` icons to card headers and navigation links
- Apply empty state pattern to glympse and critical-maps redirect pages

## Test plan
- [ ] Verify impress page renders correctly with new card layout
- [ ] Verify privacy page content displays within card wrapper
- [ ] Verify gdpr page sidebar navigation links work with id-based anchors
- [ ] Verify glympse and critical-maps redirect pages display centered card layout
- [ ] Check responsive behavior on mobile viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)