### PR TITLE
Fix social network management routing and template

### DIFF
--- a/src/Controller/SocialNetwork/SocialNetworkManagementController.php
+++ b/src/Controller/SocialNetwork/SocialNetworkManagementController.php
@@ -21,7 +21,7 @@ class SocialNetworkManagementController extends AbstractController
     #[Route(
         '/socialnetwork/{id}/edit',
         name: 'criticalmass_socialnetwork_edit',
-        priority: 60
+        priority: 80
     )]
     public function editAction(
         Request $request,
@@ -87,7 +87,7 @@ class SocialNetworkManagementController extends AbstractController
         '/socialnetwork/{id}/disable',
         name: 'criticalmass_socialnetwork_disable',
         methods: ['POST'],
-        priority: 60
+        priority: 80
     )]
     public function disableAction(
         Request $request,

--- a/templates/SocialNetwork/list.html.twig
+++ b/templates/SocialNetwork/list.html.twig
@@ -66,11 +66,11 @@
                         {% set network = getNetwork(profile.network) %}
 
                         <tr>
-                            <td class="text-center" style="background-color: {{ network.backgroundColor }}; color: {{ network.textColor }};">
-                                <i class="{{ network.icon }}"></i>
+                            <td class="text-center"{% if network %} style="background-color: {{ network.backgroundColor }}; color: {{ network.textColor }};"{% endif %}>
+                                <i class="{{ network ? network.icon : 'far fa-globe' }}"></i>
                             </td>
                             <td>
-                                {{ network.name }}
+                                {{ network ? network.name : profile.network }}
                             </td>
                             <td>
                                 <a href="{{ profile.identifier }}">
@@ -79,12 +79,12 @@
                             </td>
                             <td>
                                 <div class="btn-group">
-                                    <a href="{{ path('criticalmass_socialnetwork_edit', { id: profile.id }) }}" class="btn btn-secondary btn-xs">
+                                    <a href="{{ path('criticalmass_socialnetwork_edit', { id: profile.id }) }}" class="btn btn-secondary btn-sm">
                                         <i class="far fa-pencil"></i>
                                     </a>
                                     <form method="post" action="{{ path('criticalmass_socialnetwork_disable', { id: profile.id }) }}" class="d-inline">
                                         <input type="hidden" name="_token" value="{{ csrf_token('socialnetwork_disable_' ~ profile.id) }}">
-                                        <button type="submit" class="btn btn-secondary btn-xs">
+                                        <button type="submit" class="btn btn-secondary btn-sm">
                                             <i class="far fa-trash-alt"></i>
                                         </button>
                                     </form>


### PR DESCRIPTION
## Summary
- Fix route priority for `/socialnetwork/{id}/edit` and `/socialnetwork/{id}/disable` (60 → 80) to prevent catch-all ride route `/{citySlug}/{rideIdentifier}/...` (priority 70) from intercepting social network URLs
- Add null-safety to `list.html.twig` template: `getNetwork()` returning null for unknown identifiers no longer crashes the entire page (500 error), but shows a fallback globe icon
- Update button size from `btn-xs` to `btn-sm` (Bootstrap 5 compatibility)

## Context
Bug report from Daniel Koch (Kaiserslautern): Social network entries could neither be edited nor deleted. The root cause was a routing priority conflict causing 404 errors.

## Test plan
- [ ] Navigate to `/{citySlug}/socialnetwork/list` for a city with social network profiles
- [ ] Verify the edit button (pencil icon) opens the edit form
- [ ] Verify the delete button (trash icon) disables the profile
- [ ] Verify pages with unknown network identifiers render gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)