### PR TITLE
Allow editing social network profile URL

### DIFF
--- a/src/Form/Type/SocialNetworkProfileEditType.php
+++ b/src/Form/Type/SocialNetworkProfileEditType.php
@@ -14,7 +14,6 @@ class SocialNetworkProfileEditType extends SocialNetworkProfileType
         $builder
             ->add('identifier', TextType::class, [
                 'required' => true,
-                'disabled' => true,
             ])
             ->add('mainNetwork', CheckboxType::class, [
                 'required' => false,


### PR DESCRIPTION
## Summary
- Remove `disabled: true` from the `identifier` field in `SocialNetworkProfileEditType`
- Users can now update their social network profile URLs (e.g., when an Instagram handle changes)

## Context
Bug report: Users could not change their social network profile URLs because the identifier field was read-only in the edit form.

## Test plan
- [ ] Navigate to `/socialnetwork/{id}/edit` for an existing profile
- [ ] Verify the identifier (URL) field is editable
- [ ] Change the identifier and submit — verify it saves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)