### PR TITLE
Fix nullable column/property type mismatches across entities

### DIFF
--- a/src/Entity/BlockedCity.php
+++ b/src/Entity/BlockedCity.php
@@ -27,10 +27,10 @@ class BlockedCity
     protected ?string $description = null;
 
     #[ORM\Column(type: 'boolean', nullable: true)]
-    protected bool $photosLink = false;
+    protected ?bool $photosLink = false;
 
     #[ORM\Column(type: 'boolean', nullable: true)]
-    protected bool $rideListLink = false;
+    protected ?bool $rideListLink = false;
 
     public function getId(): ?int
     {
@@ -82,7 +82,7 @@ class BlockedCity
 
     public function getPhotosLink(): bool
     {
-        return $this->photosLink;
+        return $this->photosLink ?? false;
     }
 
     public function setRideListLink(bool $rideListLink): BlockedCity
@@ -94,7 +94,7 @@ class BlockedCity
 
     public function getRideListLink(): bool
     {
-        return $this->rideListLink;
+        return $this->rideListLink ?? false;
     }
 
     public function setCity(?City $city = null): BlockedCity

--- a/src/Entity/City.php
+++ b/src/Entity/City.php
@@ -77,18 +77,18 @@ class City implements BoardInterface, PhotoInterface, RouteableInterface, Audita
     #[DataQuery\Sortable]
     #[ORM\Column(type: 'float', nullable: true)]
     #[Groups(['ride-list', 'ride-details'])]
-    protected float $latitude = 0.0;
+    protected ?float $latitude = 0.0;
 
     #[DataQuery\Queryable]
     #[DataQuery\Sortable]
     #[ORM\Column(type: 'float', nullable: true)]
     #[Groups(['ride-list', 'ride-details'])]
-    protected float $longitude = 0.0;
+    protected ?float $longitude = 0.0;
 
     #[DataQuery\DefaultBooleanValue(value: true)]
     #[ORM\Column(type: 'boolean', nullable: true)]
     #[Ignore]
-    protected bool $enabled = true;
+    protected ?bool $enabled = true;
 
     #[ORM\OneToMany(targetEntity: 'Ride', mappedBy: 'city')]
     #[Ignore]
@@ -396,12 +396,12 @@ class City implements BoardInterface, PhotoInterface, RouteableInterface, Audita
 
     public function getEnabled(): bool
     {
-        return $this->enabled;
+        return $this->enabled ?? true;
     }
 
     public function isEnabled(): bool
     {
-        return $this->enabled;
+        return $this->enabled ?? true;
     }
 
     public function setCityPopulation(int $cityPopulation): City

--- a/src/Entity/FrontpageTeaser.php
+++ b/src/Entity/FrontpageTeaser.php
@@ -46,7 +46,7 @@ class FrontpageTeaser implements PhotoInterface
     protected ?string $imageMimeType = null;
 
     #[ORM\Column(type: 'smallint', nullable: true)]
-    protected int $position = 0;
+    protected ?int $position = 0;
 
     #[ORM\Column(type: 'datetime', nullable: false)]
     protected \DateTime $createdAt;
@@ -184,7 +184,7 @@ class FrontpageTeaser implements PhotoInterface
 
     public function getPosition(): int
     {
-        return $this->position;
+        return $this->position ?? 0;
     }
 
     public function setCreatedAt(\DateTime $createdAt): FrontpageTeaser

--- a/src/Entity/FrontpageTeaserButton.php
+++ b/src/Entity/FrontpageTeaserButton.php
@@ -31,7 +31,7 @@ class FrontpageTeaserButton
     protected ?string $class = null;
 
     #[ORM\Column(type: 'smallint', nullable: true)]
-    protected int $position = 0;
+    protected ?int $position = 0;
 
     #[ORM\Column(type: 'datetime', nullable: false)]
     protected \DateTime $createdAt;
@@ -118,7 +118,7 @@ class FrontpageTeaserButton
 
     public function getPosition(): int
     {
-        return $this->position;
+        return $this->position ?? 0;
     }
 
     public function setCreatedAt(\DateTime $createdAt): FrontpageTeaserButton

--- a/src/Entity/Participation.php
+++ b/src/Entity/Participation.php
@@ -22,16 +22,16 @@ class Participation
     protected ?User $user = null;
 
     #[ORM\Column(type: 'datetime', nullable: true)]
-    protected \DateTime $dateTime;
+    protected ?\DateTime $dateTime = null;
 
     #[ORM\Column(type: 'boolean', nullable: true)]
-    protected bool $goingYes = true;
+    protected ?bool $goingYes = true;
 
     #[ORM\Column(type: 'boolean', nullable: true)]
-    protected bool $goingMaybe = true;
+    protected ?bool $goingMaybe = true;
 
     #[ORM\Column(type: 'boolean', nullable: true)]
-    protected bool $goingNo = true;
+    protected ?bool $goingNo = true;
 
     public function __construct()
     {
@@ -57,7 +57,7 @@ class Participation
 
     public function getGoingYes(): bool
     {
-        return $this->goingYes;
+        return $this->goingYes ?? true;
     }
 
     public function setGoingYes(bool $goingYes): Participation
@@ -69,7 +69,7 @@ class Participation
 
     public function getGoingMaybe(): bool
     {
-        return $this->goingMaybe;
+        return $this->goingMaybe ?? true;
     }
 
     public function setGoingMaybe(bool $goingMaybe): Participation
@@ -81,7 +81,7 @@ class Participation
 
     public function getGoingNo(): bool
     {
-        return $this->goingNo;
+        return $this->goingNo ?? true;
     }
 
     public function setGoingNo(bool $goingNo): Participation

--- a/src/Entity/Post.php
+++ b/src/Entity/Post.php
@@ -84,7 +84,7 @@ class Post
     #[DataQuery\DefaultBooleanValue(alias: 'isEnabled', value: true)]
     #[ORM\Column(type: 'boolean', nullable: true)]
     #[Ignore]
-    protected bool $enabled = true;
+    protected ?bool $enabled = true;
 
     public function __construct()
     {
@@ -148,7 +148,7 @@ class Post
 
     public function getEnabled(): bool
     {
-        return $this->enabled;
+        return $this->enabled ?? true;
     }
 
     public function setEnabled(bool $enabled): Post

--- a/src/Entity/Ride.php
+++ b/src/Entity/Ride.php
@@ -97,7 +97,7 @@ class Ride implements ParticipateableInterface, PhotoInterface, RouteableInterfa
     #[DataQuery\DateTimeQueryable(format: 'strict_date', pattern: 'Y-m-d')]
     #[ORM\Column(type: 'datetime', nullable: true)]
     #[Groups(['ride-list', 'ride-details', 'api-write'])]
-    protected \DateTime $dateTime;
+    protected ?\DateTime $dateTime = null;
 
     #[DataQuery\Sortable]
     #[DataQuery\Queryable]
@@ -149,7 +149,7 @@ class Ride implements ParticipateableInterface, PhotoInterface, RouteableInterfa
 
     #[ORM\Column(type: 'datetime', nullable: true)]
     #[Ignore]
-    protected \DateTime $createdAt;
+    protected ?\DateTime $createdAt = null;
 
     #[ORM\Column(type: 'datetime', nullable: true)]
     #[Ignore]
@@ -157,15 +157,15 @@ class Ride implements ParticipateableInterface, PhotoInterface, RouteableInterfa
 
     #[ORM\Column(type: 'integer', nullable: true)]
     #[Groups(['ride-list', 'ride-details'])]
-    protected int $participationsNumberYes = 0;
+    protected ?int $participationsNumberYes = 0;
 
     #[ORM\Column(type: 'integer', nullable: true)]
     #[Groups(['ride-list', 'ride-details'])]
-    protected int $participationsNumberMaybe = 0;
+    protected ?int $participationsNumberMaybe = 0;
 
     #[ORM\Column(type: 'integer', nullable: true)]
     #[Groups(['ride-list', 'ride-details'])]
-    protected int $participationsNumberNo = 0;
+    protected ?int $participationsNumberNo = 0;
 
     #[ORM\OneToMany(targetEntity: 'Participation', mappedBy: 'ride', fetch: 'LAZY')]
     #[Ignore]
@@ -182,7 +182,7 @@ class Ride implements ParticipateableInterface, PhotoInterface, RouteableInterfa
 
     #[ORM\Column(type: 'boolean', nullable: true)]
     #[Ignore]
-    protected bool $restrictedPhotoAccess = false;
+    protected ?bool $restrictedPhotoAccess = false;
 
     #[ORM\OneToMany(targetEntity: 'Weather', mappedBy: 'ride', fetch: 'LAZY')]
     #[ORM\OrderBy(['creationDateTime' => 'DESC'])]
@@ -421,10 +421,12 @@ class Ride implements ParticipateableInterface, PhotoInterface, RouteableInterfa
 
     public function __toString(): string
     {
+        $dateStr = $this->dateTime ? $this->dateTime->format('Y-m-d') : 'unknown';
+
         if ($this->city) {
-            return $this->city->getTitle() . " - " . $this->getDateTime()->format('Y-m-d');
+            return $this->city->getTitle() . " - " . $dateStr;
         } else {
-            return $this->getDateTime()->format('Y-m-d');
+            return $dateStr;
         }
     }
 
@@ -441,13 +443,13 @@ class Ride implements ParticipateableInterface, PhotoInterface, RouteableInterfa
     }
 
     /** @deprecated */
-    public function getDate(): \DateTime
+    public function getDate(): ?\DateTime
     {
         return $this->dateTime;
     }
 
     /** @deprecated */
-    public function getTime(): \DateTime
+    public function getTime(): ?\DateTime
     {
         return $this->dateTime;
     }
@@ -598,7 +600,7 @@ class Ride implements ParticipateableInterface, PhotoInterface, RouteableInterfa
         return $this->getEstimatedDistance() / $this->getEstimatedDuration();
     }
 
-    public function getCreatedAt(): \DateTime
+    public function getCreatedAt(): ?\DateTime
     {
         return $this->createdAt;
     }
@@ -631,7 +633,7 @@ class Ride implements ParticipateableInterface, PhotoInterface, RouteableInterfa
 
     public function getParticipationsNumberYes(): int
     {
-        return $this->participationsNumberYes;
+        return $this->participationsNumberYes ?? 0;
     }
 
     public function setParticipationsNumberMaybe(int $participationsNumberMaybe): ParticipateableInterface
@@ -643,7 +645,7 @@ class Ride implements ParticipateableInterface, PhotoInterface, RouteableInterfa
 
     public function getParticipationsNumberMaybe(): int
     {
-        return $this->participationsNumberMaybe;
+        return $this->participationsNumberMaybe ?? 0;
     }
 
     public function setParticipationsNumberNo(int $participationsNumberNo): ParticipateableInterface
@@ -655,7 +657,7 @@ class Ride implements ParticipateableInterface, PhotoInterface, RouteableInterfa
 
     public function getParticipationsNumberNo(): int
     {
-        return $this->participationsNumberNo;
+        return $this->participationsNumberNo ?? 0;
     }
 
     #[DataQuery\Queryable]
@@ -701,7 +703,7 @@ class Ride implements ParticipateableInterface, PhotoInterface, RouteableInterfa
     /** @deprecated */
     public function getRestrictedPhotoAccess(): bool
     {
-        return $this->restrictedPhotoAccess;
+        return $this->restrictedPhotoAccess ?? false;
     }
 
     /** @deprecated */

--- a/src/Entity/RideEstimate.php
+++ b/src/Entity/RideEstimate.php
@@ -46,10 +46,10 @@ class RideEstimate
     protected ?float $estimatedDuration = null;
 
     #[ORM\Column(type: 'datetime', nullable: true)]
-    protected \DateTime $dateTime;
+    protected ?\DateTime $dateTime = null;
 
     #[ORM\Column(type: 'datetime', nullable: true)]
-    protected \DateTime $createdAt;
+    protected ?\DateTime $createdAt = null;
 
     #[ORM\Column(type: 'string', length: 255, nullable: true)]
     protected ?string $source = null;

--- a/src/Entity/Thread.php
+++ b/src/Entity/Thread.php
@@ -36,7 +36,7 @@ class Thread implements RouteableInterface, PostableInterface
     protected ?string $slug = null;
 
     #[ORM\Column(type: 'integer', nullable: true)]
-    protected int $postNumber = 0;
+    protected ?int $postNumber = 0;
 
     #[ORM\OneToOne(targetEntity: 'Post')]
     #[ORM\JoinColumn(name: 'firstpost_id', referencedColumnName: 'id', unique: true)]
@@ -47,7 +47,7 @@ class Thread implements RouteableInterface, PostableInterface
     protected ?Post $lastPost = null;
 
     #[ORM\Column(type: 'boolean', nullable: true)]
-    protected bool $enabled = true;
+    protected ?bool $enabled = true;
 
     public function __construct()
     {
@@ -79,7 +79,7 @@ class Thread implements RouteableInterface, PostableInterface
 
     public function getEnabled(): bool
     {
-        return $this->enabled;
+        return $this->enabled ?? true;
     }
 
     public function setCity(?City $city = null): Thread
@@ -139,7 +139,7 @@ class Thread implements RouteableInterface, PostableInterface
 
     public function getPostNumber(): int
     {
-        return $this->postNumber;
+        return $this->postNumber ?? 0;
     }
 
     public function incPostNumber(): Thread

--- a/src/Entity/Track.php
+++ b/src/Entity/Track.php
@@ -99,12 +99,12 @@ class Track extends GeoTrack implements RouteableInterface, TrackInterface, Uplo
     #[DataQuery\DefaultBooleanValue(value: true)]
     #[ORM\Column(type: 'boolean', nullable: true)]
     #[Ignore]
-    protected bool $enabled = true;
+    protected ?bool $enabled = true;
 
     #[DataQuery\DefaultBooleanValue(value: false)]
     #[ORM\Column(type: 'boolean', nullable: true)]
     #[Ignore]
-    protected bool $deleted = false;
+    protected ?bool $deleted = false;
 
     /**
      * @deprecated
@@ -225,7 +225,7 @@ class Track extends GeoTrack implements RouteableInterface, TrackInterface, Uplo
 
     public function getEnabled(): bool
     {
-        return $this->enabled;
+        return $this->enabled ?? true;
     }
 
     public function setEnabled(bool $enabled): Track
@@ -237,7 +237,7 @@ class Track extends GeoTrack implements RouteableInterface, TrackInterface, Uplo
 
     public function getDeleted(): bool
     {
-        return $this->deleted;
+        return $this->deleted ?? false;
     }
 
     public function setDeleted(bool $deleted): Track

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -48,23 +48,23 @@ class User implements SocialNetworkProfileAble, RouteableInterface, PhotoInterfa
 
     #[ORM\Column(type: 'smallint', nullable: true)]
     #[Groups(['timelapse'])]
-    protected int $colorRed = 0;
+    protected ?int $colorRed = 0;
 
     #[ORM\Column(type: 'smallint', nullable: true)]
     #[Groups(['timelapse'])]
-    protected int $colorGreen = 0;
+    protected ?int $colorGreen = 0;
 
     #[ORM\Column(type: 'smallint', nullable: true)]
     #[Groups(['timelapse'])]
-    protected int $colorBlue = 0;
+    protected ?int $colorBlue = 0;
 
     #[ORM\Column(type: 'boolean', nullable: true, options: ['default' => 0])]
     #[Ignore]
-    protected bool $blurGalleries = false;
+    protected ?bool $blurGalleries = false;
 
     #[ORM\Column(type: 'boolean', nullable: true, options: ['default' => 0])]
     #[Ignore]
-    protected bool $enabled = false;
+    protected ?bool $enabled = false;
 
     #[ORM\OneToMany(targetEntity: 'Participation', mappedBy: 'user')]
     #[Ignore]
@@ -213,7 +213,7 @@ class User implements SocialNetworkProfileAble, RouteableInterface, PhotoInterfa
 
     public function getColorRed(): int
     {
-        return $this->colorRed;
+        return $this->colorRed ?? 0;
     }
 
     public function setColorRed(int $colorRed): User
@@ -225,7 +225,7 @@ class User implements SocialNetworkProfileAble, RouteableInterface, PhotoInterfa
 
     public function getColorGreen(): int
     {
-        return $this->colorGreen;
+        return $this->colorGreen ?? 0;
     }
 
     public function setColorGreen(int $colorGreen): User
@@ -237,7 +237,7 @@ class User implements SocialNetworkProfileAble, RouteableInterface, PhotoInterfa
 
     public function getColorBlue(): int
     {
-        return $this->colorBlue;
+        return $this->colorBlue ?? 0;
     }
 
     public function setColorBlue(int $colorBlue): User
@@ -404,7 +404,7 @@ class User implements SocialNetworkProfileAble, RouteableInterface, PhotoInterfa
 
     public function getBlurGalleries(): bool
     {
-        return $this->blurGalleries;
+        return $this->blurGalleries ?? false;
     }
 
     public function isOauthAccount(): bool
@@ -610,7 +610,7 @@ class User implements SocialNetworkProfileAble, RouteableInterface, PhotoInterfa
 
     public function isEnabled(): bool
     {
-        return $this->enabled;
+        return $this->enabled ?? false;
     }
 
     public function setEnabled(bool $enabled): self


### PR DESCRIPTION
## Summary
- Fix nullable DB columns (`nullable: true`) with non-nullable PHP property types across 11 entity files
- Prevents "Typed property must not be accessed before initialization" errors when DB value is NULL
- Affected entities: Ride, Track, User, City, Thread, Post, RideEstimate, Participation, FrontpageTeaser, FrontpageTeaserButton, BlockedCity
- Added null-coalescing (`?? default`) in getters with non-nullable return types

## Test plan
- [ ] PHPStan passes (verified locally)
- [ ] PHPUnit tests pass
- [ ] Pages that load Ride entities (city show, photo gallery, ride pages) no longer crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)