### PR TITLE
Redesign city header with full-width image overlay

### DIFF
--- a/config/packages/liip_imagine.yaml
+++ b/config/packages/liip_imagine.yaml
@@ -72,7 +72,7 @@ liip_imagine:
             data_loader: city_image_flysystem_loader
             quality: 60
             filters:
-                thumbnail: { size: [1140, 250], mode: inset }
+                thumbnail: { size: [1400, 400], mode: inset }
 
         ride_image_wide:
             data_loader: ride_image_flysystem_loader

--- a/templates/City/show.html.twig
+++ b/templates/City/show.html.twig
@@ -14,157 +14,36 @@
 
         {{ include('City/Includes/_tabs.html.twig', { tab: 'city' }) }}
 
-        {# Hero Section #}
-        <div class="card mb-4 border-0 shadow-sm overflow-hidden">
-            <div class="row g-0">
-                {% if city.imageName %}
-                    {# Visueller Bereich mit Bild - 7 Spalten #}
-                    <div class="col-lg-7">
-                        <div class="position-relative h-100" style="min-height: 300px;">
-                            <img src="{{ vich_uploader_asset(city, 'imageFile')|imagine_filter('city_image_wide') }}"
-                                 alt="{{ city.title }}"
-                                 class="w-100 h-100 object-fit-cover">
-                        </div>
-                    </div>
+        {% if city.imageName %}
+            {# Header mit Bild, Titel und Optionen als Overlay #}
+            <div class="card border-0 shadow-sm mb-4 overflow-hidden">
+                <div class="position-relative">
+                    <img src="{{ vich_uploader_asset(city, 'imageFile')|imagine_filter('city_image_wide') }}"
+                         alt="{{ city.title }}"
+                         class="w-100"
+                         style="height: 400px; object-fit: cover;">
 
-                    {# Info-Bereich - 5 Spalten #}
-                    <div class="col-lg-5">
-                        <div class="card-body d-flex flex-column h-100">
-                            <div class="mb-3">
-                                <h1 class="h3 mb-1" itemprop="name">{{ city.title }}</h1>
+                    <div class="position-absolute bottom-0 start-0 end-0 p-4"
+                         style="background: linear-gradient(transparent, rgba(0, 0, 0, 0.7));">
+                        <div class="d-flex justify-content-between align-items-end">
+                            <div>
+                                <h1 class="h2 text-white mb-0" itemprop="name">{{ city.title }}</h1>
                                 {% if city.punchline %}
-                                    <p class="text-muted mb-0">{{ city.punchline }}</p>
+                                    <p class="text-white-50 mb-0">{{ city.punchline }}</p>
                                 {% endif %}
                             </div>
 
-                            {# Quick Info #}
-                            {% if currentRide %}
-                                <div class="row g-3 mb-3">
-                                    <div class="col-6">
-                                        <div class="d-flex align-items-center">
-                                            <div class="bg-primary bg-opacity-10 rounded-circle d-flex align-items-center justify-content-center me-2"
-                                                 style="width: 36px; height: 36px; min-width: 36px;">
-                                                <i class="far fa-calendar-alt text-primary"></i>
-                                            </div>
-                                            <div>
-                                                <small class="text-muted d-block">Nächste Tour</small>
-                                                <strong>{{ currentRide.dateTime|date('d.m.Y', currentRide.city.timezone) }}</strong>
-                                            </div>
-                                        </div>
-                                    </div>
-
-                                    <div class="col-6">
-                                        <div class="d-flex align-items-center">
-                                            <div class="bg-success bg-opacity-10 rounded-circle d-flex align-items-center justify-content-center me-2"
-                                                 style="width: 36px; height: 36px; min-width: 36px;">
-                                                <i class="far fa-clock text-success"></i>
-                                            </div>
-                                            <div>
-                                                <small class="text-muted d-block">Uhrzeit</small>
-                                                <strong>{{ currentRide.dateTime|date('H:i', currentRide.city.timezone) }} Uhr</strong>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            {% endif %}
-
-                            {# Social Media Links inline #}
-                            {% if socialNetworkProfiles|length > 0 %}
-                                <div class="mb-3">
-                                    <span class="text-muted me-2">
-                                        <i class="far fa-share-alt me-1"></i>Links:
-                                    </span>
-                                    {% for profile in socialNetworkProfiles %}
-                                        {% set network = getNetwork(profile.network) %}
-                                        {% if network %}
-                                            <a href="{{ profile.identifier }}"
-                                               class="btn btn-sm me-1 mb-1"
-                                               style="background-color: {{ network.backgroundColor }}; color: {{ network.textColor }};"
-                                               target="_blank"
-                                               rel="noopener">
-                                                <i class="{{ network.icon }}"></i>
-                                            </a>
-                                        {% endif %}
-                                    {% endfor %}
-                                </div>
-                            {% endif %}
-
-                            {# Aktions-Buttons am unteren Rand #}
-                            <div class="mt-auto">
+                            <div class="d-flex gap-2">
                                 {% if currentRide %}
-                                    <div class="btn-group w-100 mb-2" role="group">
-                                        <a href="{{ object_path(currentRide) }}" class="btn btn-primary btn-sm">
-                                            <i class="far fa-bicycle me-1"></i>
-                                            <span class="d-none d-sm-inline">Tour anzeigen</span>
-                                        </a>
-                                        <a href="{{ object_path(city, 'caldera_criticalmass_city_listrides') }}" class="btn btn-outline-primary btn-sm">
-                                            <i class="far fa-list me-1"></i>
-                                            <span class="d-none d-sm-inline">Alle Touren</span>
-                                        </a>
-                                    </div>
+                                    <a href="{{ object_path(currentRide) }}" class="btn btn-primary btn-sm">
+                                        <i class="far fa-bicycle me-1"></i>Tour anzeigen
+                                    </a>
                                 {% endif %}
 
                                 {% if app.user %}
                                     <div class="dropdown">
-                                        <button type="button" class="btn btn-outline-success btn-sm w-100 dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                            <i class="far fa-cogs me-1"></i>
-                                            Optionen
-                                        </button>
-                                        <ul class="dropdown-menu dropdown-menu-end w-100">
-                                            <li>
-                                                <a class="dropdown-item" href="{{ object_path(city, 'caldera_criticalmass_city_edit') }}">
-                                                    <i class="far fa-cogs me-2"></i>Stadt editieren
-                                                </a>
-                                            </li>
-                                            <li>
-                                                <a class="dropdown-item" href="{{ object_path(city, 'caldera_criticalmass_ride_add') }}">
-                                                    <i class="far fa-plus me-2"></i>Tour hinzufügen
-                                                </a>
-                                            </li>
-                                            <li>
-                                                <a class="dropdown-item" href="{{ object_path(city, 'caldera_criticalmass_citycycle_list') }}">
-                                                    <i class="far fa-calendar me-2"></i>Turnus verwalten
-                                                </a>
-                                            </li>
-                                            <li>
-                                                <a class="dropdown-item" href="{{ object_path(city, 'criticalmass_socialnetwork_city_list') }}">
-                                                    <i class="far fa-at me-2"></i>Soziale Netzwerke verwalten
-                                                </a>
-                                            </li>
-                                        </ul>
-                                    </div>
-                                {% else %}
-                                    <button type="button"
-                                            class="btn btn-outline-success btn-sm w-100"
-                                            data-controller="hint-modal"
-                                            data-modal-hint-title="{{ 'hint_modal.city.options_button.title'|trans }}"
-                                            data-modal-hint-text="{{ 'hint_modal.city.options_button.text'|trans({'%city%': city.city}) }}"
-                                            data-modal-hint-size="md">
-                                        <i class="far fa-cogs me-1"></i>
-                                        Optionen
-                                    </button>
-                                {% endif %}
-                            </div>
-                        </div>
-                    </div>
-                {% else %}
-                    {# Kein Bild vorhanden - volle Breite #}
-                    <div class="col-12">
-                        <div class="card-body">
-                            <div class="d-flex justify-content-between align-items-start mb-3">
-                                <div>
-                                    <h1 class="h3 mb-1" itemprop="name">{{ city.title }}</h1>
-                                    {% if city.punchline %}
-                                        <p class="text-muted mb-0">{{ city.punchline }}</p>
-                                    {% endif %}
-                                </div>
-
-                                {# Options Button #}
-                                {% if app.user %}
-                                    <div class="dropdown">
-                                        <button type="button" class="btn btn-outline-success btn-sm dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                            <i class="far fa-cogs me-1"></i>
-                                            Optionen
+                                        <button type="button" class="btn btn-light btn-sm dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                            <i class="far fa-cogs me-1"></i>Optionen
                                         </button>
                                         <ul class="dropdown-menu dropdown-menu-end">
                                             <li>
@@ -191,24 +70,84 @@
                                     </div>
                                 {% else %}
                                     <button type="button"
-                                            class="btn btn-outline-success btn-sm"
+                                            class="btn btn-light btn-sm"
                                             data-controller="hint-modal"
                                             data-modal-hint-title="{{ 'hint_modal.city.options_button.title'|trans }}"
                                             data-modal-hint-text="{{ 'hint_modal.city.options_button.text'|trans({'%city%': city.city}) }}"
                                             data-modal-hint-size="md">
-                                        <i class="far fa-cogs me-1"></i>
-                                        Optionen
+                                        <i class="far fa-cogs me-1"></i>Optionen
                                     </button>
                                 {% endif %}
                             </div>
                         </div>
                     </div>
-                {% endif %}
+                </div>
             </div>
-        </div>
+        {% else %}
+            {# Kein Header-Bild: Info-Leiste als Card #}
+            <div class="card border-0 shadow-sm mb-4">
+                <div class="card-body">
+                    <div class="d-flex flex-wrap justify-content-between align-items-start gap-3">
+                        <div>
+                            <h1 class="h3 mb-1" itemprop="name">{{ city.title }}</h1>
+                            {% if city.punchline %}
+                                <p class="text-muted mb-0">{{ city.punchline }}</p>
+                            {% endif %}
+                        </div>
+
+                        <div class="d-flex gap-2">
+                            {% if currentRide %}
+                                <a href="{{ object_path(currentRide) }}" class="btn btn-primary btn-sm">
+                                    <i class="far fa-bicycle me-1"></i>Tour anzeigen
+                                </a>
+                            {% endif %}
+
+                            {% if app.user %}
+                                <div class="dropdown">
+                                    <button type="button" class="btn btn-outline-success btn-sm dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                        <i class="far fa-cogs me-1"></i>Optionen
+                                    </button>
+                                    <ul class="dropdown-menu dropdown-menu-end">
+                                        <li>
+                                            <a class="dropdown-item" href="{{ object_path(city, 'caldera_criticalmass_city_edit') }}">
+                                                <i class="far fa-cogs me-2"></i>Stadt editieren
+                                            </a>
+                                        </li>
+                                        <li>
+                                            <a class="dropdown-item" href="{{ object_path(city, 'caldera_criticalmass_ride_add') }}">
+                                                <i class="far fa-plus me-2"></i>Tour hinzufügen
+                                            </a>
+                                        </li>
+                                        <li>
+                                            <a class="dropdown-item" href="{{ object_path(city, 'caldera_criticalmass_citycycle_list') }}">
+                                                <i class="far fa-calendar me-2"></i>Turnus verwalten
+                                            </a>
+                                        </li>
+                                        <li>
+                                            <a class="dropdown-item" href="{{ object_path(city, 'criticalmass_socialnetwork_city_list') }}">
+                                                <i class="far fa-at me-2"></i>Soziale Netzwerke verwalten
+                                            </a>
+                                        </li>
+                                    </ul>
+                                </div>
+                            {% else %}
+                                <button type="button"
+                                        class="btn btn-outline-success btn-sm"
+                                        data-controller="hint-modal"
+                                        data-modal-hint-title="{{ 'hint_modal.city.options_button.title'|trans }}"
+                                        data-modal-hint-text="{{ 'hint_modal.city.options_button.text'|trans({'%city%': city.city}) }}"
+                                        data-modal-hint-size="md">
+                                    <i class="far fa-cogs me-1"></i>Optionen
+                                </button>
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        {% endif %}
 
         <div class="row">
-            {# Hauptinhalt - 9 Spalten #}
+            {# Hauptinhalt #}
             <div class="col-lg-8">
                 {# Beschreibung #}
                 {% if city.longDescription %}
@@ -270,7 +209,7 @@
                 {% endif %}
             </div>
 
-            {# Sidebar - 4 Spalten #}
+            {# Sidebar #}
             <div class="col-lg-4">
                 {% include 'City/Includes/_nextTour.html.twig' with { 'city': city, 'currentRide': currentRide } %}
 


### PR DESCRIPTION
## Summary
- Header-Bild wird über die volle Inhaltsbreite angezeigt (400px Höhe)
- Stadtname und Optionen-Button als Overlay auf dem Bild mit dunklem Gradient
- Fallback auf kompakte Info-Leiste wenn kein Bild gesetzt ist
- `city_image_wide` Filter von 1140x250 auf 1400x400 vergrößert

## Test plan
- [ ] Stadt mit Header-Bild aufrufen — Bild sollte volle Breite einnehmen, Titel unten links, Optionen unten rechts
- [ ] Stadt ohne Header-Bild aufrufen — kompakte Info-Leiste mit Titel und Optionen
- [ ] Optionen-Dropdown auf dem Bild testen (eingeloggt)
- [ ] Optionen-Button ohne Login testen (Hint-Modal)
- [ ] Responsive Verhalten prüfen (Mobile/Tablet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)