### PR TITLE
Fix track_polyline column names to camelCase

### DIFF
--- a/migrations/Version20260211120000.php
+++ b/migrations/Version20260211120000.php
@@ -14,7 +14,7 @@ final class Version20260211120000 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql('CREATE TABLE track_polyline (id INT AUTO_INCREMENT NOT NULL, track_id INT NOT NULL, resolution SMALLINT NOT NULL, polyline LONGTEXT NOT NULL, num_points INT NOT NULL, created_at DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\', INDEX IDX_TRACK_POLYLINE_TRACK (track_id), UNIQUE INDEX UNIQ_TRACK_RESOLUTION (track_id, resolution), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE track_polyline (id INT AUTO_INCREMENT NOT NULL, track_id INT NOT NULL, resolution SMALLINT NOT NULL, polyline LONGTEXT NOT NULL, numPoints INT NOT NULL, createdAt DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\', INDEX IDX_TRACK_POLYLINE_TRACK (track_id), UNIQUE INDEX UNIQ_TRACK_RESOLUTION (track_id, resolution), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
         $this->addSql('ALTER TABLE track_polyline ADD CONSTRAINT FK_TRACK_POLYLINE_TRACK_ID FOREIGN KEY (track_id) REFERENCES track (id) ON DELETE CASCADE');
         $this->addSql('ALTER TABLE track DROP polyline, DROP reducedPolyline');
     }

--- a/migrations/Version20260224160000.php
+++ b/migrations/Version20260224160000.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260224160000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Rename track_polyline columns from snake_case to camelCase to match Doctrine naming strategy';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE track_polyline CHANGE num_points numPoints INT NOT NULL, CHANGE created_at createdAt DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE track_polyline CHANGE numPoints num_points INT NOT NULL, CHANGE createdAt created_at DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\'');
+    }
+}


### PR DESCRIPTION
## Summary
- Fix `track_polyline` table column names: `num_points` → `numPoints`, `created_at` → `createdAt`
- The original migration (Version20260211120000) created columns in snake_case, but Doctrine's default naming strategy expects camelCase
- Updated original migration for fresh installs
- Added new migration (Version20260224160000) to rename columns on servers where the original already ran

## Test plan
- [ ] Run `doctrine:migrations:migrate` on server — renames columns
- [ ] Run `criticalmass:track:generate-polylines --all` — no more `Unknown column numPoints` error
- [ ] Run `vendor/bin/phpstan analyse` — no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)