### PR TITLE
Fix crash when GPX file is missing on disk

### DIFF
--- a/src/Command/Track/TrackGeneratePolylinesCommand.php
+++ b/src/Command/Track/TrackGeneratePolylinesCommand.php
@@ -104,7 +104,7 @@ class TrackGeneratePolylinesCommand extends Command
 
                 $processed++;
                 $io->writeln('<info>OK</info>');
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 $io->writeln(sprintf('<error>Error: %s</error>', $e->getMessage()));
                 $skipped++;
             }

--- a/src/Criticalmass/Geo/GpxService/GpxService.php
+++ b/src/Criticalmass/Geo/GpxService/GpxService.php
@@ -44,6 +44,10 @@ class GpxService implements GpxServiceInterface
     {
         $gpxFile = $this->loadFromTrack($track);
 
+        if (empty($gpxFile->tracks)) {
+            return [];
+        }
+
         return $gpxFile->tracks[0]->getPoints();
     }
 
@@ -276,6 +280,11 @@ class GpxService implements GpxServiceInterface
     public function shiftTimeAndSave(Track $track, \DateInterval $interval): void
     {
         $gpxFile = $this->loadFromTrack($track);
+
+        if (empty($gpxFile->tracks)) {
+            return;
+        }
+
         $gpxTrack = $gpxFile->tracks[0];
 
         foreach ($gpxTrack->segments as $segment) {


### PR DESCRIPTION
## Summary

- Fix `GpxService::getPoints()` crashing with "Call to a member function getPoints() on null" when a track references a GPX file that no longer exists on disk
- Add empty check on `$gpxFile->tracks` before accessing index 0, returning `[]` gracefully
- Apply same guard to `shiftTimeAndSave()` which has the same unsafe `tracks[0]` access
- Change `catch (\Exception $e)` to `catch (\Throwable $e)` in `TrackGeneratePolylinesCommand` so PHP `\Error` is also caught, allowing the command to continue processing remaining tracks

## Test plan

- [ ] Run `bin/console criticalmass:track:generate-polylines --all` — should skip tracks with missing GPX files with an error message instead of crashing
- [ ] Run `bin/console criticalmass:track:generate-polylines --track-id=<valid>` — should still work normally
- [ ] PHPStan passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)