### PR TITLE
Fix duration display: remove seconds, use non-breaking spaces

### DIFF
--- a/src/Twig/Extension/DurationTwigExtension.php
+++ b/src/Twig/Extension/DurationTwigExtension.php
@@ -2,7 +2,6 @@
 
 namespace App\Twig\Extension;
 
-use Khill\Duration\Duration;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -23,7 +22,19 @@ class DurationTwigExtension extends AbstractExtension
             return null;
         }
 
-        return (new Duration())->humanize($duration);
+        $totalSeconds = (int) $duration;
+        $hours = intdiv($totalSeconds, 3600);
+        $minutes = intdiv($totalSeconds % 3600, 60);
+
+        $parts = [];
+        if ($hours > 0) {
+            $parts[] = $hours . "\u{00A0}" . 'h';
+        }
+        if ($minutes > 0 || $hours === 0) {
+            $parts[] = $minutes . "\u{00A0}" . 'min';
+        }
+
+        return implode(' ', $parts);
     }
 
     public function getName(): string

--- a/tests/Twig/DurationTwigExtensionTest.php
+++ b/tests/Twig/DurationTwigExtensionTest.php
@@ -24,12 +24,34 @@ class DurationTwigExtensionTest extends TestCase
         $this->assertNull($this->extension->duration(''));
     }
 
-    public function testHumanizesDuration(): void
+    public function testHoursAndMinutes(): void
     {
-        $result = $this->extension->duration('3600');
+        $this->assertEquals("1\u{00A0}h 30\u{00A0}min", $this->extension->duration('5400'));
+    }
 
-        $this->assertIsString($result);
-        $this->assertNotEmpty($result);
+    public function testExactHours(): void
+    {
+        $this->assertEquals("1\u{00A0}h", $this->extension->duration('3600'));
+    }
+
+    public function testMinutesOnly(): void
+    {
+        $this->assertEquals("45\u{00A0}min", $this->extension->duration('2700'));
+    }
+
+    public function testSecondsIgnored(): void
+    {
+        $this->assertEquals("1\u{00A0}h 1\u{00A0}min", $this->extension->duration('3661'));
+    }
+
+    public function testLessThanOneMinute(): void
+    {
+        $this->assertEquals("0\u{00A0}min", $this->extension->duration('30'));
+    }
+
+    public function testMultipleHours(): void
+    {
+        $this->assertEquals("2\u{00A0}h 15\u{00A0}min", $this->extension->duration('8100'));
     }
 
     public function testGetName(): void


### PR DESCRIPTION
## Summary
- Replace `khill/php-duration` with custom formatting in `DurationTwigExtension`
- Omit seconds from duration display (e.g. `1h 1m 1s` → `1 h 1 min`)
- Add non-breaking spaces (`\u00A0`) between numbers and units to prevent line breaks
- Show `0 min` for durations under 60 seconds

## Test plan
- [x] PHPUnit tests pass (`vendor/bin/phpunit tests/Twig/DurationTwigExtensionTest.php`)
- [x] PHPStan passes
- [ ] Verify duration display in templates (ride details, track info)

🤖 Generated with [Claude Code](https://claude.com/claude-code)