### PR TITLE
Fix TypeError on null city in RideValueResolver

### DIFF
--- a/src/ValueResolver/RideValueResolver.php
+++ b/src/ValueResolver/RideValueResolver.php
@@ -72,6 +72,10 @@ class RideValueResolver implements ValueResolverInterface
 
         $city = $citySlug->getCity();
 
+        if (!$city) {
+            return null;
+        }
+
         $rideRepository = $this->registry->getRepository(Ride::class);
 
         if (count($matches) === 0) {


### PR DESCRIPTION
## Summary
- Fix `TypeError: findCityRideByDate(): Argument #1 ($city) must be of type City, null given` in `RideValueResolver`
- `CitySlug::getCity()` returns `?City` — a slug can exist without an associated city
- Added null check for `$city` before passing it to repository methods

## Test plan
- [ ] Request a ride URL with a valid city slug whose city was deleted — should return 404 instead of 500
- [ ] Request a ride URL with a valid city slug and date — should still resolve the ride correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)