### PR TITLE
Fix Weather API deserialization group

### DIFF
--- a/src/Controller/Api/WeatherController.php
+++ b/src/Controller/Api/WeatherController.php
@@ -43,7 +43,7 @@ class WeatherController extends BaseController
     public function addWeatherAction(Request $request, Ride $ride): JsonResponse
     {
         /** @var Weather $weather */
-        $weather = $this->deserializeRequest($request, Weather::class);
+        $weather = $this->deserializeRequest($request, Weather::class, ['groups' => ['weather']]);
 
         $weather
             ->setRide($ride)


### PR DESCRIPTION
## Summary
- **Root cause found**: The Weather API endpoint ignored ALL incoming data because of a serialization group mismatch
- `BaseController::deserializeRequest()` defaults to group `api-write`, but `Weather` entity properties use group `weather`
- This caused every field (temperatureEvening, temperatureDay, etc.) to deserialize as `null`, which was then persisted to the database
- Fix: explicitly pass `['groups' => ['weather']]` when deserializing weather data

## Verification
Tested locally with both applications:
- weather-fetcher serializes correctly (all temperature fields present in JSON)
- criticalmass.in with `groups=['api-write']`: all fields → `NULL`
- criticalmass.in with `groups=['weather']`: all fields → correct values

## Test plan
- [ ] Deploy and trigger weather update
- [ ] Verify Weather records now have non-null temperature values
- [ ] Verify ride pages with weather data display temperature correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)