### PR TITLE
Fix emoji support in ride descriptions (utf8mb4)

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -11,8 +11,8 @@ doctrine:
         driver: 'pdo_mysql'
         charset: utf8mb4
         default_table_options:
-            charset: utf8
-            collate: utf8_unicode_ci
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
         server_version: 'mariadb-10.9.3'
         url: '%env(resolve:DATABASE_URL)%'
 

--- a/migrations/Version20260225120000.php
+++ b/migrations/Version20260225120000.php
@@ -1,0 +1,96 @@
+<?php declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260225120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Convert database and all tables from utf8 to utf8mb4 to support emoji characters';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER DATABASE DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci');
+
+        $tables = [
+            'alert',
+            'board',
+            'city',
+            'city_activity',
+            'city_blocked',
+            'city_cycle',
+            'cityslug',
+            'frontpage_teaser',
+            'frontpage_teaser_button',
+            'location',
+            'participation',
+            'photo',
+            'post',
+            'promotion',
+            'region',
+            'ride',
+            'ride_estimate',
+            'social_network_feed_item',
+            'social_network_profile',
+            'subride',
+            'thread',
+            'track',
+            'track_candidate',
+            'track_polyline',
+            'user',
+            'weather',
+        ];
+
+        foreach ($tables as $table) {
+            $this->addSql(sprintf(
+                'ALTER TABLE `%s` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci',
+                $table
+            ));
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER DATABASE DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci');
+
+        $tables = [
+            'alert',
+            'board',
+            'city',
+            'city_activity',
+            'city_blocked',
+            'city_cycle',
+            'cityslug',
+            'frontpage_teaser',
+            'frontpage_teaser_button',
+            'location',
+            'participation',
+            'photo',
+            'post',
+            'promotion',
+            'region',
+            'ride',
+            'ride_estimate',
+            'social_network_feed_item',
+            'social_network_profile',
+            'subride',
+            'thread',
+            'track',
+            'track_candidate',
+            'track_polyline',
+            'user',
+            'weather',
+        ];
+
+        foreach ($tables as $table) {
+            $this->addSql(sprintf(
+                'ALTER TABLE `%s` CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci',
+                $table
+            ));
+        }
+    }
+}

--- a/src/Entity/SocialNetworkProfile.php
+++ b/src/Entity/SocialNetworkProfile.php
@@ -8,7 +8,7 @@ use Symfony\Component\Serializer\Annotation\Ignore;
 use Symfony\Component\Serializer\Annotation\SerializedName;
 use Symfony\Component\Validator\Constraints as Assert;
 
-#[ORM\Table(name: 'social_network_profile', options: ['charset' => 'utf8mb4', 'collate' => 'utf8mb4_unicode_ci'])]
+#[ORM\Table(name: 'social_network_profile')]
 #[ORM\Entity(repositoryClass: 'App\Repository\SocialNetworkProfileRepository')]
 class SocialNetworkProfile
 {


### PR DESCRIPTION
## Summary

- Update Doctrine default table options from `utf8`/`utf8_unicode_ci` to `utf8mb4`/`utf8mb4_unicode_ci` to support 4-byte Unicode characters (emoji)
- Add database migration that converts all 26 existing tables and their columns to utf8mb4
- Remove redundant charset override from `SocialNetworkProfile` entity (now matches the default)

Closes #994

## Test plan

- [ ] Run migration on a test database and verify all tables are converted to utf8mb4
- [ ] Insert a ride description containing emoji characters and confirm no 500 error
- [ ] Verify existing data with special characters (umlauts, accents) is preserved after migration
- [ ] Run `vendor/bin/phpstan analyse` — passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)