### PR TITLE
Fix GPX multi-segment track validation

### DIFF
--- a/src/Criticalmass/UploadValidator/TrackValidator.php
+++ b/src/Criticalmass/UploadValidator/TrackValidator.php
@@ -43,7 +43,6 @@ class TrackValidator implements UploadValidatorInterface
 
     protected function checkForXmlContent(): void
     {
-        //echo "checkForXmlContent";
         try {
             $this->simpleXml = new \SimpleXMLElement($this->rawFileContent, LIBXML_NONET | LIBXML_NOENT);
         } catch (Exception $e) {
@@ -53,7 +52,6 @@ class TrackValidator implements UploadValidatorInterface
 
     protected function checkForBasicGpxStructure(): void
     {
-        //echo "checkForBasicGpxStructure";
         try {
             $this->simpleXml->trk->trkseg->trkpt[0];
         } catch (Exception $e) {
@@ -76,32 +74,34 @@ class TrackValidator implements UploadValidatorInterface
 
     protected function checkForLatitudeLongitude(): void
     {
-        //echo "checkForLatitudeLongitude";
-        foreach ($this->simpleXml->trk->trkseg->trkpt as $point) {
-            /* @TODO This is really bullshit, but php refuses to get is_float or stuff like this working. Replace preg_match with a faster solution! */
-            if (
-                !$point['lat'] ||
-                !$point['lon'] ||
-                !preg_match('/^([-]?)([0-9]{1,3})\.([0-9]*)$/', (string) $point['lat']) ||
-                !preg_match('/^([-]?)([0-9]{1,3})\.([0-9]*)$/', (string) $point['lon'])
-            ) {
-                throw new NoLatitudeLongitudeException();
+        foreach ($this->simpleXml->trk->trkseg as $trkseg) {
+            foreach ($trkseg->trkpt as $point) {
+                /* @TODO This is really bullshit, but php refuses to get is_float or stuff like this working. Replace preg_match with a faster solution! */
+                if (
+                    !$point['lat'] ||
+                    !$point['lon'] ||
+                    !preg_match('/^([-]?)([0-9]{1,3})\.([0-9]*)$/', (string) $point['lat']) ||
+                    !preg_match('/^([-]?)([0-9]{1,3})\.([0-9]*)$/', (string) $point['lon'])
+                ) {
+                    throw new NoLatitudeLongitudeException();
+                }
             }
         }
     }
 
     protected function checkForDateTime(): void
     {
-        //echo "checkForDateTime";
-        foreach ($this->simpleXml->trk->trkseg->trkpt as $point) {
-            if (!$point->time) {
-                throw new NoDateTimeException();
-            }
+        foreach ($this->simpleXml->trk->trkseg as $trkseg) {
+            foreach ($trkseg->trkpt as $point) {
+                if (!$point->time) {
+                    throw new NoDateTimeException();
+                }
 
-            try {
-                $dateTime = new \DateTime((string) $point->time);
-            } catch (Exception $e) {
-                throw new NoDateTimeException();
+                try {
+                    $dateTime = new \DateTime((string) $point->time);
+                } catch (Exception $e) {
+                    throw new NoDateTimeException();
+                }
             }
         }
     }

--- a/tests/Criticalmass/UploadValidator/TrackValidatorTest.php
+++ b/tests/Criticalmass/UploadValidator/TrackValidatorTest.php
@@ -1,0 +1,101 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Criticalmass\UploadValidator;
+
+use App\Criticalmass\UploadValidator\TrackValidator;
+use App\Criticalmass\UploadValidator\UploadValidatorException\TrackValidatorException\NoDateTimeException;
+use App\Criticalmass\UploadValidator\UploadValidatorException\TrackValidatorException\NoLatitudeLongitudeException;
+use App\Criticalmass\UploadValidator\UploadValidatorException\TrackValidatorException\NotEnoughCoordsException;
+use PHPUnit\Framework\TestCase;
+
+class TrackValidatorTest extends TestCase
+{
+    private function createValidatorWithGpx(string $gpxContent): TrackValidator
+    {
+        $reflection = new \ReflectionClass(TrackValidator::class);
+        $validator = $reflection->newInstanceWithoutConstructor();
+
+        $simpleXmlProperty = $reflection->getProperty('simpleXml');
+        $simpleXmlProperty->setValue($validator, new \SimpleXMLElement($gpxContent));
+
+        $rawFileContentProperty = $reflection->getProperty('rawFileContent');
+        $rawFileContentProperty->setValue($validator, $gpxContent);
+
+        return $validator;
+    }
+
+    private function generateTrkpt(int $count, float $startLat = 53.0, float $startLon = 10.0): string
+    {
+        $points = '';
+        for ($i = 0; $i < $count; $i++) {
+            $lat = $startLat + ($i * 0.001);
+            $lon = $startLon + ($i * 0.001);
+            $time = (new \DateTime('2024-01-01 12:00:00'))->modify("+{$i} seconds")->format('Y-m-d\TH:i:s\Z');
+            $points .= sprintf('<trkpt lat="%.6f" lon="%.6f"><time>%s</time></trkpt>', $lat, $lon, $time);
+        }
+
+        return $points;
+    }
+
+    private function buildGpx(string $trackContent): string
+    {
+        return '<?xml version="1.0" encoding="UTF-8"?><gpx version="1.1"><trk>' . $trackContent . '</trk></gpx>';
+    }
+
+    public function testValidateSingleSegment(): void
+    {
+        $gpx = $this->buildGpx('<trkseg>' . $this->generateTrkpt(60) . '</trkseg>');
+        $validator = $this->createValidatorWithGpx($gpx);
+
+        $this->assertTrue($validator->validate());
+    }
+
+    public function testValidateMultipleSegments(): void
+    {
+        $gpx = $this->buildGpx(
+            '<trkseg>' . $this->generateTrkpt(30, 53.0, 10.0) . '</trkseg>'
+            . '<trkseg>' . $this->generateTrkpt(30, 54.0, 11.0) . '</trkseg>'
+        );
+        $validator = $this->createValidatorWithGpx($gpx);
+
+        $this->assertTrue($validator->validate());
+    }
+
+    public function testMultipleSegmentsWithTooFewPointsThrowsException(): void
+    {
+        $gpx = $this->buildGpx(
+            '<trkseg>' . $this->generateTrkpt(20, 53.0, 10.0) . '</trkseg>'
+            . '<trkseg>' . $this->generateTrkpt(20, 54.0, 11.0) . '</trkseg>'
+        );
+        $validator = $this->createValidatorWithGpx($gpx);
+
+        $this->expectException(NotEnoughCoordsException::class);
+        $validator->validate();
+    }
+
+    public function testMultipleSegmentsWithInvalidLatLonInSecondSegmentThrowsException(): void
+    {
+        $gpx = $this->buildGpx(
+            '<trkseg>' . $this->generateTrkpt(30, 53.0, 10.0) . '</trkseg>'
+            . '<trkseg><trkpt lat="invalid" lon="10.0"><time>2024-01-01T12:00:00Z</time></trkpt>'
+            . $this->generateTrkpt(29, 54.0, 11.0) . '</trkseg>'
+        );
+        $validator = $this->createValidatorWithGpx($gpx);
+
+        $this->expectException(NoLatitudeLongitudeException::class);
+        $validator->validate();
+    }
+
+    public function testMultipleSegmentsWithMissingDateTimeInSecondSegmentThrowsException(): void
+    {
+        $gpx = $this->buildGpx(
+            '<trkseg>' . $this->generateTrkpt(30, 53.0, 10.0) . '</trkseg>'
+            . '<trkseg><trkpt lat="54.000000" lon="11.000000"></trkpt>'
+            . $this->generateTrkpt(29, 54.001, 11.001) . '</trkseg>'
+        );
+        $validator = $this->createValidatorWithGpx($gpx);
+
+        $this->expectException(NoDateTimeException::class);
+        $validator->validate();
+    }
+}


### PR DESCRIPTION
## Summary
- Fix `checkForLatitudeLongitude()` and `checkForDateTime()` in `TrackValidator` to iterate over all `<trkseg>` segments, not just the first one
- GPX files with multiple track segments (e.g. from gpsbabel .fit conversion) previously showed distance=0 because only the first segment was validated
- Remove leftover debug `//echo` comments
- Add unit tests for multi-segment GPX validation

Closes #1001

## Test plan
- [ ] Verify `testValidateSingleSegment` passes (single segment GPX still works)
- [ ] Verify `testValidateMultipleSegments` passes (multi-segment GPX now validated correctly)
- [ ] Verify `testMultipleSegmentsWithTooFewPointsThrowsException` passes
- [ ] Verify `testMultipleSegmentsWithInvalidLatLonInSecondSegmentThrowsException` passes (invalid coords in 2nd segment are caught)
- [ ] Verify `testMultipleSegmentsWithMissingDateTimeInSecondSegmentThrowsException` passes (missing datetime in 2nd segment is caught)
- [ ] Upload a multi-segment GPX file and verify distance is calculated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)