### PR TITLE
Remove unused Track properties md5Hash and geoJson

### DIFF
--- a/migrations/Version20260226000000.php
+++ b/migrations/Version20260226000000.php
@@ -11,20 +11,18 @@ final class Version20260226000000 extends AbstractMigration
 {
     public function getDescription(): string
     {
-        return 'Remove unused columns md5_hash, lat_lng_list, and geo_json from track table';
+        return 'Remove unused columns md5_hash and geo_json from track table';
     }
 
     public function up(Schema $schema): void
     {
         $this->addSql('ALTER TABLE track DROP COLUMN md5_hash');
-        $this->addSql('ALTER TABLE track DROP COLUMN lat_lng_list');
         $this->addSql('ALTER TABLE track DROP COLUMN geo_json');
     }
 
     public function down(Schema $schema): void
     {
         $this->addSql('ALTER TABLE track ADD COLUMN md5_hash VARCHAR(32) DEFAULT NULL');
-        $this->addSql('ALTER TABLE track ADD COLUMN lat_lng_list LONGTEXT DEFAULT NULL');
         $this->addSql('ALTER TABLE track ADD COLUMN geo_json LONGTEXT DEFAULT NULL');
     }
 }

--- a/src/Entity/Track.php
+++ b/src/Entity/Track.php
@@ -105,6 +105,12 @@ class Track extends GeoTrack implements RouteableInterface, TrackInterface, Uplo
     #[Ignore]
     protected ?bool $deleted = false;
 
+    /**
+     * @deprecated
+     */
+    #[ORM\Column(type: 'text', nullable: true)]
+    #[Ignore]
+    protected ?string $latLngList = null;
 
     /** @var Collection<int, TrackPolyline> */
     #[ORM\OneToMany(targetEntity: TrackPolyline::class, mappedBy: 'track', cascade: ['persist', 'remove'], orphanRemoval: true)]
@@ -234,6 +240,17 @@ class Track extends GeoTrack implements RouteableInterface, TrackInterface, Uplo
         return $this->rideEstimate;
     }
 
+    public function setLatLngList(string $latLngList): Track
+    {
+        $this->latLngList = $latLngList;
+
+        return $this;
+    }
+
+    public function getLatLngList(): string
+    {
+        return $this->latLngList;
+    }
 
     /** @return Collection<int, TrackPolyline> */
     public function getTrackPolylines(): Collection

--- a/src/EventSubscriber/TrackEventSubscriber.php
+++ b/src/EventSubscriber/TrackEventSubscriber.php
@@ -92,6 +92,7 @@ class TrackEventSubscriber implements EventSubscriberInterface
 
         $this->loadTrackProperties($track, $gpxFile);
         $this->addRideEstimate($track, $track->getRide());
+        $this->updateLatLngList($track);
         $this->updatePolyline($track);
 
         $this->registry->getManager()->flush();
@@ -106,6 +107,8 @@ class TrackEventSubscriber implements EventSubscriberInterface
         $this->removeEstimateFromTrack($track);
 
         $this->updatePolyline($track);
+
+        $this->updateLatLngList($track);
 
         $this->updateTrackProperties($track);
 
@@ -147,6 +150,10 @@ class TrackEventSubscriber implements EventSubscriberInterface
         }
     }
 
+    protected function updateLatLngList(Track $track): void
+    {
+        $track->setLatLngList($this->gpxService->generateLatLngList($track));
+    }
 
     protected function loadTrackProperties(Track $track, GpxFile $gpxFile): void
     {


### PR DESCRIPTION
## Summary

- Remove `$md5Hash` property from Track entity — was only written in fixtures, never read
- Remove `$geoJson` property from Track entity — declared but never set or read anywhere, getter had name mismatch (`getWaypointList`)
- Remove `setMd5Hash()` call from TrackFixtures
- Add Doctrine migration to drop `md5_hash` and `geo_json` columns from `track` table
- `$latLngList` is kept — still actively populated by TrackEventSubscriber

## Test plan

- [ ] PHPStan passes
- [ ] PHPUnit passes — no tests depend on these properties
- [ ] Run migration on staging before production

🤖 Generated with [Claude Code](https://claude.com/claude-code)