### PR TITLE
Raise prod log level, separate deprecations

### DIFF
--- a/config/packages/monolog.yaml
+++ b/config/packages/monolog.yaml
@@ -8,10 +8,15 @@ when@prod:
                 excluded_404s:
                     # regex: exclude all 404 errors from the logs
                     - ^/
+                excluded_http_codes: [400, 405]
             nested:
                 type: stream
                 path: "%kernel.logs_dir%/%kernel.environment%.log"
-                level: debug
+                level: warning
+            deprecation:
+                type: stream
+                path: "%kernel.logs_dir%/%kernel.environment%.deprecations.log"
+                channels: ["deprecation"]
             console:
                 type:   console
                 process_psr_3_messages: false


### PR DESCRIPTION
## Summary
- Raise `nested` handler level from `debug` to `warning` — stops flushing DEBUG/INFO noise (security authenticator checks, route matching) into prod.log on every error
- Add dedicated `deprecation` handler writing to `prod.deprecations.log` so deprecation notices are preserved but don't clutter the main log
- Exclude HTTP 400/405 from `fingers_crossed` trigger — these are mostly bot requests with malformed query parameters (e.g. `?page=5%2F`)

## Log analysis

The prod.log was flooded with ~8 messages per request that aren't actionable:

| Count | Type | Reason to filter |
|-------|------|-----------------|
| ~4/req | `security.DEBUG` authenticator checks | Framework internals |
| ~1/req | `php.INFO` Doctrine Proxy deprecated | Vendor deprecation |
| ~2/req | `php.INFO` LiipImagine deprecated | Vendor deprecation |
| ~1/req | `request.INFO` matched route | Not needed in prod |

Actual errors (LOCK_DSN, Enum ValueError, null Photo) remain visible at WARNING+ level.

## Test plan
- [ ] Deploy and verify prod.log only contains WARNING/ERROR/CRITICAL entries
- [ ] Verify deprecations are written to prod.deprecations.log
- [ ] Verify Loggly still receives ERROR+ messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)