### PR TITLE
Fix Photo entity referencing dropped views column

### DIFF
--- a/src/Entity/Photo.php
+++ b/src/Entity/Photo.php
@@ -74,12 +74,6 @@ class Photo implements FakeUploadable, ManipulateablePhotoInterface, RouteableIn
     #[Groups(['photo-details'])]
     protected ?string $description = null;
 
-    #[DataQuery\Sortable]
-    #[ORM\Column(type: 'integer')]
-    #[Groups(['photo-details'])]
-    protected int $views = 0;
-
-
     #[DataQuery\DefaultBooleanValue(alias: 'isEnabled', value: true)]
     #[ORM\Column(type: 'boolean')]
     #[Ignore]
@@ -208,18 +202,6 @@ class Photo implements FakeUploadable, ManipulateablePhotoInterface, RouteableIn
     public function setEnabled(bool $enabled): Photo
     {
         $this->enabled = $enabled;
-
-        return $this;
-    }
-
-    public function getViews(): int
-    {
-        return $this->views;
-    }
-
-    public function setViews(int $views): Photo
-    {
-        $this->views = $views;
 
         return $this;
     }

--- a/tests/Controller/Api/PhotoControllerTest.php
+++ b/tests/Controller/Api/PhotoControllerTest.php
@@ -26,7 +26,6 @@ class PhotoControllerTest extends AbstractApiControllerTestCase
         $this->assertEquals($photo->getDescription(), $response['description']);
         $this->assertEquals($photo->getLocation(), $response['location']);
         $this->assertEquals($photo->getImageName(), $response['image_name']);
-        $this->assertArrayHasKey('views', $response);
         $this->assertArrayHasKey('exif_creation_date', $response);
         $this->assertArrayHasKey('creation_date_time', $response);
     }


### PR DESCRIPTION
## Summary

- Remove `$views` property and `#[ORM\Column]` mapping from `Photo` entity — the database column was already dropped by migration `Version20260210001548`, causing `SQLSTATE[42S22]: Column not found` errors on every Photo query
- Remove `getViews()`/`setViews()` accessors from `Photo`
- Remove `views` assertion from `PhotoControllerTest`

## Test plan

- [ ] PHPStan passes (verified locally)
- [ ] Photo API endpoints (`/api/photo`, `/api/photo/{id}`) no longer throw `InvalidFieldNameException`
- [ ] Photo pages load without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)