### PR TITLE
Fix dynamic property deprecation in AbstractDelegatedRouter

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1598,12 +1598,6 @@ parameters:
 			path: src/Criticalmass/Router/AbstractRouter.php
 
 		-
-			message: '#^Access to an undefined property App\\Criticalmass\\Router\\DelegatedRouter\\AbstractDelegatedRouter\:\:\$objectRouter\.$#'
-			identifier: property.notFound
-			count: 1
-			path: src/Criticalmass/Router/DelegatedRouter/AbstractDelegatedRouter.php
-
-		-
 			message: '#^Method App\\Criticalmass\\Router\\DelegatedRouter\\BoardRouter\:\:generate\(\) has parameter \$parameters with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1

--- a/src/Criticalmass/Router/DelegatedRouter/AbstractDelegatedRouter.php
+++ b/src/Criticalmass/Router/DelegatedRouter/AbstractDelegatedRouter.php
@@ -8,6 +8,7 @@ use App\EntityInterface\RouteableInterface;
 
 abstract class AbstractDelegatedRouter extends AbstractRouter implements DelegatedRouterInterface
 {
+    protected ?ObjectRouterInterface $objectRouter = null;
 
     public function setObjectRouter(ObjectRouterInterface $objectRouter): DelegatedRouterInterface
     {


### PR DESCRIPTION
## Summary

- Declare `$objectRouter` as explicit property in `AbstractDelegatedRouter` to fix PHP 8.2 deprecation warning about dynamic property creation
- Remove corresponding PHPStan baseline entry (no longer needed)

Closes #1264

## Test plan

- [ ] PHPStan passes (verified locally)
- [ ] Ride pages no longer log `Creation of dynamic property ... is deprecated`

🤖 Generated with [Claude Code](https://claude.com/claude-code)