### PR TITLE
Migrate VichUploaderBundle Annotation to Attribute

### DIFF
--- a/src/Entity/City.php
+++ b/src/Entity/City.php
@@ -21,7 +21,7 @@ use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Serializer\Annotation\Ignore;
 use Symfony\Component\Serializer\Annotation\SerializedName;
 use Symfony\Component\Validator\Constraints as Assert;
-use Vich\UploaderBundle\Mapping\Annotation as Vich;
+use Vich\UploaderBundle\Mapping\Attribute as Vich;
 
 #[Vich\Uploadable]
 #[Routing\DefaultRoute(name: 'caldera_criticalmass_city_show')]

--- a/src/Entity/FrontpageTeaser.php
+++ b/src/Entity/FrontpageTeaser.php
@@ -7,7 +7,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\HttpFoundation\File\File;
-use Vich\UploaderBundle\Mapping\Annotation as Vich;
+use Vich\UploaderBundle\Mapping\Attribute as Vich;
 
 #[Vich\Uploadable]
 #[ORM\Table(name: 'frontpage_teaser')]

--- a/src/Entity/Photo.php
+++ b/src/Entity/Photo.php
@@ -21,7 +21,7 @@ use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Serializer\Annotation\Ignore;
 use Symfony\Component\Validator\Constraints as Assert;
-use Vich\UploaderBundle\Mapping\Annotation as Vich;
+use Vich\UploaderBundle\Mapping\Attribute as Vich;
 
 #[Vich\Uploadable]
 #[Routing\DefaultRoute(name: 'caldera_criticalmass_photo_show_ride')]

--- a/src/Entity/Ride.php
+++ b/src/Entity/Ride.php
@@ -24,7 +24,7 @@ use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Serializer\Annotation\Ignore;
 use Symfony\Component\Validator\Constraints as Assert;
-use Vich\UploaderBundle\Mapping\Annotation as Vich;
+use Vich\UploaderBundle\Mapping\Attribute as Vich;
 
 #[CriticalAssert\SingleRideForDay]
 #[Vich\Uploadable]

--- a/src/Entity/Track.php
+++ b/src/Entity/Track.php
@@ -18,7 +18,7 @@ use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Serializer\Annotation\Ignore;
 use Symfony\Component\Serializer\Annotation\SerializedName;
 use Symfony\Component\Validator\Constraints as Assert;
-use Vich\UploaderBundle\Mapping\Annotation as Vich;
+use Vich\UploaderBundle\Mapping\Attribute as Vich;
 
 #[Vich\Uploadable]
 #[Routing\DefaultRoute(name: 'caldera_criticalmass_track_view')]

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -14,7 +14,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Serializer\Annotation\Ignore;
 use Symfony\Component\Validator\Constraints as Assert;
-use Vich\UploaderBundle\Mapping\Annotation as Vich;
+use Vich\UploaderBundle\Mapping\Attribute as Vich;
 
 #[Vich\Uploadable]
 #[ORM\Table(name: 'user')]


### PR DESCRIPTION
## Summary

- Replace deprecated `Vich\UploaderBundle\Mapping\Annotation` with `Vich\UploaderBundle\Mapping\Attribute` in all 6 entities:
  - `Photo`, `Ride`, `City`, `Track`, `User`, `FrontpageTeaser`
- Eliminates up to 17 deprecation warnings per API request

Closes #1266

## Test plan

- [ ] PHPStan passes (no new errors introduced)
- [ ] File uploads (photos, tracks) still work correctly
- [ ] VichUploaderBundle deprecation warnings no longer appear in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)