### PR TITLE
Configure LiipImagineBundle twig mode to lazy

### DIFF
--- a/config/packages/liip_imagine.yaml
+++ b/config/packages/liip_imagine.yaml
@@ -1,4 +1,7 @@
 liip_imagine:
+    twig:
+        mode: lazy
+
     resolvers:
         default:
             web_path: ~


### PR DESCRIPTION
## Summary
- Configure `liip_imagine.twig.mode` to `lazy` in `config/packages/liip_imagine.yaml`
- Resolves deprecation warnings from `FilterExtension` and `FilterTrait` (deprecated since LiipImagineBundle 2.7, removed in 3.0)

Closes #1265

## Test plan
- [ ] Verify application boots without errors (`bin/console cache:clear`)
- [ ] Verify Twig `imagine_filter` calls still work correctly (e.g. photo thumbnails, city images)
- [ ] Confirm deprecation warnings for `FilterExtension` and `FilterTrait` no longer appear in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)