### PR TITLE
Fix Doctrine auto-mapping deprecation with #[MapEntity]

### DIFF
--- a/src/Controller/Api/CityActivityController.php
+++ b/src/Controller/Api/CityActivityController.php
@@ -7,6 +7,7 @@ use App\Entity\CityActivity;
 use App\Serializer\CriticalSerializerInterface;
 use Doctrine\Persistence\ManagerRegistry;
 use OpenApi\Attributes as OA;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
@@ -25,7 +26,7 @@ class CityActivityController extends BaseController
     #[OA\Tag(name: 'CityActivity')]
     #[OA\RequestBody(description: 'JSON representation of the city activity data', required: true, content: new OA\JsonContent(type: 'object'))]
     #[OA\Response(response: 201, description: 'Activity score created successfully')]
-    public function createAction(Request $request, City $city): JsonResponse
+    public function createAction(Request $request, #[MapEntity(disabled: true)] City $city): JsonResponse
     {
         $data = json_decode($request->getContent(), true);
 

--- a/src/Controller/Api/CityController.php
+++ b/src/Controller/Api/CityController.php
@@ -7,6 +7,7 @@ use MalteHuebner\DataQueryBundle\RequestParameterList\RequestToListConverter;
 use App\Entity\City;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;
 
@@ -99,7 +100,7 @@ class CityController extends BaseController
     #[OA\Tag(name: 'City')]
     #[OA\Parameter(name: 'citySlug', in: 'path', description: 'Slug of the city', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Response(response: 200, description: 'Returned when successful')]
-    public function showAction(City $city): JsonResponse
+    public function showAction(#[MapEntity(disabled: true)] City $city): JsonResponse
     {
         $groups = ['ride-list'];
 

--- a/src/Controller/Api/CycleController.php
+++ b/src/Controller/Api/CycleController.php
@@ -6,6 +6,7 @@ use App\Entity\City;
 use App\Entity\CityCycle;
 use App\Entity\Region;
 use App\Repository\CityCycleRepository;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use OpenApi\Attributes as OA;
@@ -28,8 +29,8 @@ class CycleController extends BaseController
     #[OA\Response(response: 200, description: 'Returned when successful')]
     public function listAction(
         Request $request,
-        ?City $city = null,
-        ?Region $region = null
+        #[MapEntity(disabled: true)] ?City $city = null,
+        #[MapEntity(disabled: true)] ?Region $region = null
     ): JsonResponse {
         $validNow = $request->query->getBoolean('validNow');
         $dayOfWeek = $request->query->getInt('dayOfWeek');
@@ -61,7 +62,7 @@ class CycleController extends BaseController
     #[OA\Tag(name: 'Cycles')]
     #[OA\Parameter(name: 'citySlug', in: 'path', description: 'Slug of the city', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Response(response: 200, description: 'Returned when successful')]
-    public function listCyclesCityAction(City $city, CityCycleRepository $cityCycleRepository): JsonResponse
+    public function listCyclesCityAction(#[MapEntity(disabled: true)] City $city, CityCycleRepository $cityCycleRepository): JsonResponse
     {
         $cycleList = $cityCycleRepository->findByCity($city);
 
@@ -76,7 +77,7 @@ class CycleController extends BaseController
     #[OA\Parameter(name: 'citySlug', in: 'path', description: 'Slug of the city', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\RequestBody(description: 'JSON representation of the cycle to create', required: true, content: new OA\JsonContent(type: 'object'))]
     #[OA\Response(response: 200, description: 'Returned when successfully created')]
-    public function createCycleAction(Request $request, City $city): JsonResponse
+    public function createCycleAction(Request $request, #[MapEntity(disabled: true)] City $city): JsonResponse
     {
         $newCycle = $this->deserializeRequest($request, CityCycle::class);
 

--- a/src/Controller/Api/EstimateController.php
+++ b/src/Controller/Api/EstimateController.php
@@ -11,6 +11,7 @@ use App\Event\RideEstimate\RideEstimateCreatedEvent;
 use App\Model\CreateEstimateModel;
 use App\Serializer\CriticalSerializerInterface;
 use OpenApi\Attributes as OA;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -99,7 +100,7 @@ class EstimateController extends BaseController
     #[OA\Parameter(name: 'rideIdentifier', in: 'path', description: 'Identifier of the ride', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\RequestBody(description: 'JSON representation of the estimate data', required: true, content: new OA\JsonContent(type: 'object'))]
     #[OA\Response(response: 200, description: 'Returned when successful')]
-    public function createRideEstimateAction(Request $request, Ride $ride): JsonResponse
+    public function createRideEstimateAction(Request $request, #[MapEntity(disabled: true)] Ride $ride): JsonResponse
     {
         /** @var CreateEstimateModel $estimateModel */
         $estimateModel = $this->deserializeRequest($request, CreateEstimateModel::class);

--- a/src/Controller/Api/LocationController.php
+++ b/src/Controller/Api/LocationController.php
@@ -5,6 +5,7 @@ namespace App\Controller\Api;
 use App\Entity\City;
 use App\Entity\Location;
 use OpenApi\Attributes as OA;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Attribute\Route;
 
@@ -17,7 +18,7 @@ class LocationController extends BaseController
     #[OA\Tag(name: 'Location')]
     #[OA\Parameter(name: 'citySlug', in: 'path', description: 'Slug of the city', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Response(response: 200, description: 'Returned when successful')]
-    public function listLocationAction(City $city): JsonResponse
+    public function listLocationAction(#[MapEntity(disabled: true)] City $city): JsonResponse
     {
         $locationList = $this->managerRegistry->getRepository(Location::class)->findLocationsByCity($city);
 
@@ -32,7 +33,7 @@ class LocationController extends BaseController
     #[OA\Parameter(name: 'citySlug', in: 'path', description: 'Slug of the city', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Parameter(name: 'locationSlug', in: 'path', description: 'Slug of the location', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Response(response: 200, description: 'Returned when successful')]
-    public function showLocationAction(Location $location): JsonResponse
+    public function showLocationAction(#[MapEntity] Location $location): JsonResponse
     {
         return $this->createStandardResponse($location);
     }

--- a/src/Controller/Api/PhotoController.php
+++ b/src/Controller/Api/PhotoController.php
@@ -7,6 +7,7 @@ use MalteHuebner\DataQueryBundle\RequestParameterList\RequestToListConverter;
 use App\Entity\Photo;
 use App\Entity\Ride;
 use OpenApi\Attributes as OA;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -22,7 +23,7 @@ class PhotoController extends BaseController
     #[OA\Parameter(name: 'citySlug', in: 'path', description: 'Provide a city slug', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Parameter(name: 'rideIdentifier', in: 'path', description: 'Provide a ride identifier', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Response(response: 200, description: 'Returned when successful')]
-    public function listRidePhotosAction(Ride $ride): JsonResponse
+    public function listRidePhotosAction(#[MapEntity(disabled: true)] Ride $ride): JsonResponse
     {
         $photoList = $this->managerRegistry->getRepository(Photo::class)->findPhotosByRide($ride);
 

--- a/src/Controller/Api/RideController.php
+++ b/src/Controller/Api/RideController.php
@@ -7,6 +7,7 @@ use MalteHuebner\DataQueryBundle\RequestParameterList\RequestToListConverter;
 use App\Entity\City;
 use App\Entity\Ride;
 use OpenApi\Attributes as OA;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;
@@ -25,7 +26,7 @@ class RideController extends BaseController
     #[OA\Parameter(name: 'citySlug', in: 'path', description: 'Provide a city slug', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Parameter(name: 'rideIdentifier', in: 'path', description: 'Identify the requested ride', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Response(response: 200, description: 'Returned when successful')]
-    public function showAction(Ride $ride): JsonResponse
+    public function showAction(#[MapEntity(disabled: true)] Ride $ride): JsonResponse
     {
         $context = ['groups' => 'ride-details'];
 
@@ -39,7 +40,7 @@ class RideController extends BaseController
     #[OA\Tag(name: 'Ride')]
     #[OA\Parameter(name: 'citySlug', in: 'path', description: 'Provide a city slug', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Response(response: 200, description: 'Returned when successful')]
-    public function showCurrentAction(Request $request, City $city): JsonResponse
+    public function showCurrentAction(Request $request, #[MapEntity(disabled: true)] City $city): JsonResponse
     {
         $cycleMandatory = $request->query->getBoolean('cycleMandatory', false);
         $slugsAllowed = $request->query->getBoolean('slugsAllowed', true);
@@ -170,7 +171,7 @@ class RideController extends BaseController
     #[OA\Parameter(name: 'rideIdentifier', in: 'path', description: 'Identifier of the ride to be created', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\RequestBody(description: 'JSON representation of ride', required: true, content: new OA\JsonContent(type: 'object'))]
     #[OA\Response(response: 200, description: 'Returned when successful')]
-    public function createRideAction(Request $request, City $city, ValidatorInterface $validator): JsonResponse
+    public function createRideAction(Request $request, #[MapEntity(disabled: true)] City $city, ValidatorInterface $validator): JsonResponse
     {
         /** @var Ride $ride */
         $ride = $this->deserializeRequest($request, Ride::class);
@@ -222,7 +223,7 @@ class RideController extends BaseController
     #[OA\Parameter(name: 'rideIdentifier', in: 'path', description: 'Identifier of the ride to be updated', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\RequestBody(description: 'JSON representation of ride', required: true, content: new OA\JsonContent(type: 'object'))]
     #[OA\Response(response: 200, description: 'Returned when successful')]
-    public function updateRideAction(Request $request, Ride $ride, ValidatorInterface $validator): JsonResponse
+    public function updateRideAction(Request $request, #[MapEntity(disabled: true)] Ride $ride, ValidatorInterface $validator): JsonResponse
     {
         $this->deserializeRequestInto($request, $ride);
 

--- a/src/Controller/Api/SocialNetworkFeedItemController.php
+++ b/src/Controller/Api/SocialNetworkFeedItemController.php
@@ -6,6 +6,7 @@ use App\Entity\City;
 use App\Entity\SocialNetworkFeedItem;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use OpenApi\Attributes as OA;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;
@@ -23,7 +24,7 @@ class SocialNetworkFeedItemController extends BaseController
     #[OA\Parameter(name: 'uniqueIdentifier', in: 'query', description: 'Filter by unique identifier of the feed item', schema: new OA\Schema(type: 'string'))]
     #[OA\Parameter(name: 'networkIdentifier', in: 'query', description: 'Filter by social network identifier (e.g. twitter, facebook, instagram)', schema: new OA\Schema(type: 'string'))]
     #[OA\Response(response: 200, description: 'Returned when successful')]
-    public function listSocialNetworkFeedItemsCityAction(Request $request, City $city): JsonResponse
+    public function listSocialNetworkFeedItemsCityAction(Request $request, #[MapEntity(disabled: true)] City $city): JsonResponse
     {
         $uniqueIdentifier = $request->get('uniqueIdentifier');
         $networkIdentifier = $request->get('networkIdentifier');
@@ -42,7 +43,7 @@ class SocialNetworkFeedItemController extends BaseController
     #[OA\Parameter(name: 'feedItemId', in: 'path', description: 'Id of the feed item to update', required: true, schema: new OA\Schema(type: 'integer'))]
     #[OA\RequestBody(description: 'JSON representation of the feed item properties to update', required: true, content: new OA\JsonContent(type: 'object'))]
     #[OA\Response(response: 200, description: 'Returned when successful')]
-    public function updateSocialNetworkFeedItemAction(Request $request, SocialNetworkFeedItem $socialNetworkFeedItem): JsonResponse
+    public function updateSocialNetworkFeedItemAction(Request $request, #[MapEntity] SocialNetworkFeedItem $socialNetworkFeedItem): JsonResponse
     {
         $this->deserializeRequestInto($request, $socialNetworkFeedItem);
 

--- a/src/Controller/Api/SocialNetworkProfileController.php
+++ b/src/Controller/Api/SocialNetworkProfileController.php
@@ -5,6 +5,7 @@ namespace App\Controller\Api;
 use App\Entity\City;
 use App\Entity\SocialNetworkProfile;
 use OpenApi\Attributes as OA;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -23,7 +24,7 @@ class SocialNetworkProfileController extends BaseController
     #[OA\Parameter(name: 'autoFetch', in: 'query', description: 'Filter by auto-fetch setting', schema: new OA\Schema(type: 'boolean'))]
     #[OA\Parameter(name: 'entities', in: 'query', description: 'Comma-separated list of entity class names to filter by', schema: new OA\Schema(type: 'string'))]
     #[OA\Response(response: 200, description: 'Returned when successful')]
-    public function listSocialNetworkProfilesAction(Request $request, ?City $city = null): JsonResponse
+    public function listSocialNetworkProfilesAction(Request $request, #[MapEntity(disabled: true)] ?City $city = null): JsonResponse
     {
         $networkIdentifier = $request->get('networkIdentifier');
         $autoFetch = (bool)$request->get('autoFetch');
@@ -46,7 +47,7 @@ class SocialNetworkProfileController extends BaseController
     #[OA\Tag(name: 'Social Network Profile')]
     #[OA\Parameter(name: 'citySlug', in: 'path', description: 'Slug of the city', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Response(response: 200, description: 'Returned when successful')]
-    public function listSocialNetworkProfilesCityAction(City $city): JsonResponse
+    public function listSocialNetworkProfilesCityAction(#[MapEntity(disabled: true)] City $city): JsonResponse
     {
         $profileList = $this->managerRegistry->getRepository(SocialNetworkProfile::class)->findByCity($city);
 
@@ -64,7 +65,7 @@ class SocialNetworkProfileController extends BaseController
     #[OA\Response(response: 200, description: 'Returned when successful')]
     public function updateSocialNetworkProfileAction(
         Request $request,
-        SocialNetworkProfile $socialNetworkProfile,
+        #[MapEntity] SocialNetworkProfile $socialNetworkProfile,
     ): Response {
         $this->deserializeRequestInto($request, $socialNetworkProfile);
 
@@ -81,7 +82,7 @@ class SocialNetworkProfileController extends BaseController
     #[OA\Parameter(name: 'citySlug', in: 'path', description: 'Slug of the city', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\RequestBody(description: 'JSON representation of the social network profile to create', required: true, content: new OA\JsonContent(type: 'object'))]
     #[OA\Response(response: 200, description: 'Returned when successfully created')]
-    public function createSocialNetworkProfileAction(Request $request, City $city): JsonResponse
+    public function createSocialNetworkProfileAction(Request $request, #[MapEntity(disabled: true)] City $city): JsonResponse
     {
         $newSocialNetworkProfile = $this->deserializeRequest($request, SocialNetworkProfile::class);
 

--- a/src/Controller/Api/SubrideController.php
+++ b/src/Controller/Api/SubrideController.php
@@ -5,6 +5,7 @@ namespace App\Controller\Api;
 use App\Entity\Ride;
 use App\Entity\Subride;
 use OpenApi\Attributes as OA;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Attribute\Route;
 
@@ -20,7 +21,7 @@ class SubrideController extends BaseController
     #[OA\Parameter(name: 'citySlug', in: 'path', description: 'Slug of the city', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Parameter(name: 'rideIdentifier', in: 'path', description: 'Identifier of the ride (date or slug)', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Response(response: 200, description: 'Returned when successful')]
-    public function listSubrideAction(Ride $ride): JsonResponse
+    public function listSubrideAction(#[MapEntity(disabled: true)] Ride $ride): JsonResponse
     {
         $subrideList = $this->managerRegistry->getRepository(Subride::class)->findByRide($ride);
 
@@ -36,7 +37,7 @@ class SubrideController extends BaseController
     #[OA\Parameter(name: 'rideIdentifier', in: 'path', description: 'Identifier of the ride (date or slug)', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Parameter(name: 'id', in: 'path', description: 'Id of the subride', required: true, schema: new OA\Schema(type: 'integer'))]
     #[OA\Response(response: 200, description: 'Returned when successful')]
-    public function showSubrideAction(Subride $subride): JsonResponse
+    public function showSubrideAction(#[MapEntity] Subride $subride): JsonResponse
     {
         return $this->createStandardResponse($subride);
     }

--- a/src/Controller/Api/TrackController.php
+++ b/src/Controller/Api/TrackController.php
@@ -9,6 +9,7 @@ use App\Entity\Track;
 use App\Event\Track\TrackDeletedEvent;
 use Doctrine\Persistence\ManagerRegistry;
 use OpenApi\Attributes as OA;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -27,7 +28,7 @@ class TrackController extends BaseController
     #[OA\Parameter(name: 'citySlug', in: 'path', description: 'Slug of the city', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Parameter(name: 'rideIdentifier', in: 'path', description: 'Identifier of the ride (date or slug)', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Response(response: 200, description: 'Returned when successful')]
-    public function listRideTrackAction(Ride $ride): JsonResponse
+    public function listRideTrackAction(#[MapEntity(disabled: true)] Ride $ride): JsonResponse
     {
         $trackList = $this->managerRegistry->getRepository(Track::class)->findByRide($ride);
 
@@ -41,7 +42,7 @@ class TrackController extends BaseController
     #[OA\Tag(name: 'Track')]
     #[OA\Parameter(name: 'id', in: 'path', description: 'Id of the track', required: true, schema: new OA\Schema(type: 'integer'))]
     #[OA\Response(response: 200, description: 'Returned when successful')]
-    public function viewAction(Track $track, ?UserInterface $user = null): JsonResponse
+    public function viewAction(#[MapEntity] Track $track, ?UserInterface $user = null): JsonResponse
     {
         $groups = ['api-public'];
 
@@ -130,7 +131,7 @@ class TrackController extends BaseController
     #[OA\Parameter(name: 'id', in: 'path', description: 'Id of the track to delete', required: true, schema: new OA\Schema(type: 'integer'))]
     #[OA\Response(response: 302, description: 'Redirects to track list on success')]
     #[OA\Response(response: 403, description: 'Returned when user lacks edit permissions')]
-    public function deleteAction(Track $track, EventDispatcherInterface $eventDispatcher, ManagerRegistry $managerRegistry): Response
+    public function deleteAction(#[MapEntity] Track $track, EventDispatcherInterface $eventDispatcher, ManagerRegistry $managerRegistry): Response
     {
         $track->setDeleted(true);
 

--- a/src/Controller/Api/WeatherController.php
+++ b/src/Controller/Api/WeatherController.php
@@ -5,6 +5,7 @@ namespace App\Controller\Api;
 use App\Entity\Ride;
 use App\Entity\Weather;
 use OpenApi\Attributes as OA;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;
@@ -40,7 +41,7 @@ class WeatherController extends BaseController
     #[OA\Parameter(name: 'rideIdentifier', in: 'path', description: 'Identifier of the ride (date or slug)', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\RequestBody(description: 'JSON representation of the weather data', required: true, content: new OA\JsonContent(type: 'object'))]
     #[OA\Response(response: 201, description: 'Returned when weather data was successfully created')]
-    public function addWeatherAction(Request $request, Ride $ride): JsonResponse
+    public function addWeatherAction(Request $request, #[MapEntity(disabled: true)] Ride $ride): JsonResponse
     {
         /** @var Weather $weather */
         $weather = $this->deserializeRequest($request, Weather::class, ['groups' => ['weather']]);

--- a/src/Controller/BoardController.php
+++ b/src/Controller/BoardController.php
@@ -42,7 +42,7 @@ class BoardController extends AbstractController
         ThreadRepository $threadRepository,
         ObjectRouterInterface $objectRouter,
         #[MapEntity(mapping: ['boardSlug' => 'slug'])] ?Board $board = null,
-        ?City $city = null
+        #[MapEntity(disabled: true)] ?City $city = null
     ): Response {
         if (!$board && !$city) {
             throw $this->createNotFoundException();
@@ -72,7 +72,7 @@ class BoardController extends AbstractController
     #[Route('/{citySlug}/thread/{threadSlug}', name: 'caldera_criticalmass_board_viewcitythread', priority: 240)]
     public function viewThreadAction(
         PostRepository $postRepository,
-        Thread $thread
+        #[MapEntity(disabled: true)] Thread $thread
     ): Response {
         $posts = $postRepository->findPostsForThread($thread);
         $board = $thread->getCity() ?? $thread->getBoard();
@@ -91,7 +91,7 @@ class BoardController extends AbstractController
         Request $request,
         ObjectRouterInterface $objectRouter,
         #[MapEntity(mapping: ['boardSlug' => 'slug'])] ?Board $board = null,
-        ?City $city = null
+        #[MapEntity(disabled: true)] ?City $city = null
     ): Response {
         $board = $board ?? $city;
 

--- a/src/Controller/City/CityController.php
+++ b/src/Controller/City/CityController.php
@@ -11,6 +11,7 @@ use App\Repository\LocationRepository;
 use App\Repository\PhotoRepository;
 use App\Repository\RideRepository;
 use App\Repository\SocialNetworkProfileRepository;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
@@ -20,7 +21,7 @@ class CityController extends AbstractController
     #[Route('/{citySlug}/missingstats', name: 'caldera_criticalmass_city_missingstats', priority: 100)]
     public function missingStatsAction(
         RideRepository $rideRepository,
-        City $city
+        #[MapEntity(disabled: true)] City $city
     ): Response {
         return $this->render('City/missing_stats.html.twig', [
             'city' => $city,
@@ -31,7 +32,7 @@ class CityController extends AbstractController
     #[Route('/{citySlug}/list', name: 'caldera_criticalmass_city_listrides', priority: 170)]
     public function listRidesAction(
         RideRepository $rideRepository,
-        City $city
+        #[MapEntity(disabled: true)] City $city
     ): Response {
         return $this->render('City/ride_list.html.twig', [
             'city' => $city,
@@ -43,7 +44,7 @@ class CityController extends AbstractController
     public function listGalleriesAction(
         PhotoRepository $photoRepository,
         SeoPageInterface $seoPage,
-        City $city
+        #[MapEntity(disabled: true)] City $city
     ): Response {
         $seoPage->setDescription('Übersicht über Fotos von Critical-Mass-Touren aus ' . $city->getCity());
 
@@ -70,7 +71,7 @@ class CityController extends AbstractController
         BlockedCityRepository $blockedCityRepository,
         PhotoRepository $photoRepository,
         SeoPageInterface $seoPage,
-        ?City $city = null
+        #[MapEntity(disabled: true)] ?City $city = null
     ): Response {
         if (!$city) {
             $citySlug = $request->get('citySlug');
@@ -116,7 +117,7 @@ class CityController extends AbstractController
     #[Route('/{citySlug}/locations', name: 'caldera_criticalmass_city_locations', priority: 100)]
     public function getlocationsAction(
         RideRepository $rideRepository,
-        City $city
+        #[MapEntity(disabled: true)] City $city
     ): Response {
         return new Response(json_encode($rideRepository->getLocationsForCity($city)), Response::HTTP_OK, [
             'Content-Type' => 'text/json',

--- a/src/Controller/City/CityManagementController.php
+++ b/src/Controller/City/CityManagementController.php
@@ -14,6 +14,7 @@ use App\Factory\City\CityFactoryInterface;
 use App\Form\Type\CityType;
 use App\Repository\RegionRepository;
 use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -130,7 +131,7 @@ class CityManagementController extends AbstractController
     public function editAction(
         Request $request,
         EventDispatcherInterface $eventDispatcher,
-        City $city,
+        #[MapEntity(disabled: true)] City $city,
         ObjectRouterInterface $objectRouter,
         ?UserInterface $user = null
     ): Response {

--- a/src/Controller/City/CityTrackListController.php
+++ b/src/Controller/City/CityTrackListController.php
@@ -7,6 +7,7 @@ use App\Entity\City;
 use App\Entity\Track;
 use Knp\Component\Pager\PaginatorInterface;
 use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
@@ -14,7 +15,7 @@ use Symfony\Component\Routing\Attribute\Route;
 class CityTrackListController extends AbstractController
 {
     #[Route('/{citySlug}/tracks', name: 'caldera_criticalmass_city_listtracks', priority: 100)]
-    public function listTracksAction(Request $request, City $city, ManagerRegistry $registry, PaginatorInterface $paginator): Response
+    public function listTracksAction(Request $request, #[MapEntity(disabled: true)] City $city, ManagerRegistry $registry, PaginatorInterface $paginator): Response
     {
         $query = $registry->getRepository(Track::class)->findByCityQuery($city, 'DESC');
 

--- a/src/Controller/CityCycle/CityCycleController.php
+++ b/src/Controller/CityCycle/CityCycleController.php
@@ -7,6 +7,7 @@ use App\Entity\City;
 use App\Entity\CityCycle;
 use App\Entity\Ride;
 use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -15,7 +16,7 @@ class CityCycleController extends AbstractController
 {
     #[IsGranted('ROLE_USER')]
     #[Route('/{citySlug}/cycles/list', name: 'caldera_criticalmass_citycycle_list', priority: 80)]
-    public function listAction(City $city, ManagerRegistry $registry): Response
+    public function listAction(#[MapEntity(disabled: true)] City $city, ManagerRegistry $registry): Response
     {
         $cityCycleRepository = $registry->getRepository(CityCycle::class);
 
@@ -28,7 +29,7 @@ class CityCycleController extends AbstractController
     #[IsGranted('ROLE_USER')]
     #[Route('/{citySlug}/cycles/{id}/list', name: 'caldera_criticalmass_citycycle_ride_list', priority: 80)]
     public function listRidesAction(
-        CityCycle $cityCycle,
+        #[MapEntity] CityCycle $cityCycle,
         ManagerRegistry $registry
     ): Response {
         $rideRepository = $registry->getRepository(Ride::class);

--- a/src/Controller/CityCycle/CityCycleExecuteController.php
+++ b/src/Controller/CityCycle/CityCycleExecuteController.php
@@ -10,6 +10,7 @@ use App\Model\RideGenerator\CycleExecutable;
 use Carbon\Carbon;
 use Carbon\CarbonInterval;
 use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -35,7 +36,7 @@ class CityCycleExecuteController extends AbstractController
     #[Route('/{citySlug}/cycles/{id}/execute', name: 'caldera_criticalmass_citycycle_execute', priority: 80)]
     public function executeAction(
         Request $request,
-        CityCycle $cityCycle,
+        #[MapEntity] CityCycle $cityCycle,
         SerializerInterface $serializer
     ): Response {
         $dateTime = new Carbon();
@@ -82,7 +83,7 @@ class CityCycleExecuteController extends AbstractController
     #[Route('/{citySlug}/cycles/{id}/execute-persist', name: 'caldera_criticalmass_citycycle_execute_persist', priority: 80)]
     public function executePersistAction(
         Request $request,
-        CityCycle $cityCycle,
+        #[MapEntity] CityCycle $cityCycle,
         SessionInterface $session,
         ManagerRegistry $registry,
         SerializerInterface $serializer,

--- a/src/Controller/CityCycle/CityCycleManagementController.php
+++ b/src/Controller/CityCycle/CityCycleManagementController.php
@@ -8,6 +8,7 @@ use App\Entity\City;
 use App\Entity\CityCycle;
 use App\Form\Type\CityCycleType;
 use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -19,7 +20,7 @@ class CityCycleManagementController extends AbstractController
 {
     #[IsGranted('ROLE_USER')]
     #[Route('/{citySlug}/cycles/add', name: 'caldera_criticalmass_citycycle_add', priority: 80)]
-    public function addAction(Request $request, City $city, ObjectRouterInterface $objectRouter, ?UserInterface $user = null): Response
+    public function addAction(Request $request, #[MapEntity(disabled: true)] City $city, ObjectRouterInterface $objectRouter, ?UserInterface $user = null): Response
     {
         $cityCycle = new CityCycle();
         $cityCycle
@@ -73,7 +74,7 @@ class CityCycleManagementController extends AbstractController
     #[Route('/{citySlug}/cycles/{id}/edit', name: 'caldera_criticalmass_citycycle_edit', priority: 80)]
     public function editAction(
         Request $request,
-        CityCycle $cityCycle,
+        #[MapEntity] CityCycle $cityCycle,
         ObjectRouterInterface $objectRouter,
         ?UserInterface $user = null
     ): Response {
@@ -128,7 +129,7 @@ class CityCycleManagementController extends AbstractController
     #[Route('/{citySlug}/cycles/{id}/disable', name: 'caldera_criticalmass_citycycle_disable', methods: ['POST'], priority: 80)]
     public function disableAction(
         Request $request,
-        CityCycle $cityCycle,
+        #[MapEntity] CityCycle $cityCycle,
         ManagerRegistry $managerRegistry,
         ObjectRouterInterface $objectRouter
     ): Response {

--- a/src/Controller/LocationController.php
+++ b/src/Controller/LocationController.php
@@ -7,6 +7,7 @@ use App\Entity\Location;
 use App\Entity\Ride;
 use App\Repository\LocationRepository;
 use App\Repository\RideRepository;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Attribute\Route;
@@ -15,7 +16,7 @@ class LocationController extends AbstractController
 {
     public function listlocationsAction(
         LocationRepository $locationRepository,
-        City $city
+        #[MapEntity(disabled: true)] City $city
     ): Response {
         $locations = $locationRepository->findLocationsByCity($city);
 
@@ -32,7 +33,7 @@ class LocationController extends AbstractController
     public function showAction(
         LocationRepository $locationRepository,
         RideRepository $rideRepository,
-        Location $location
+        #[MapEntity] Location $location
     ): Response {
         $rides = $rideRepository->findRidesForLocation($location);
 
@@ -54,7 +55,7 @@ class LocationController extends AbstractController
     public function rideAction(
         LocationRepository $locationRepository,
         RideRepository $rideRepository,
-        Ride $ride
+        #[MapEntity(disabled: true)] Ride $ride
     ): Response {
         $location = $locationRepository->findLocationForRide($ride);
 

--- a/src/Controller/Photo/LegacyPhotoUploadController.php
+++ b/src/Controller/Photo/LegacyPhotoUploadController.php
@@ -8,6 +8,7 @@ use App\Entity\Photo;
 use App\Entity\Ride;
 use App\Form\Type\LegacyPhotoUploadType;
 use Flagception\Bundle\FlagceptionBundle\Attribute\Feature;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -24,7 +25,7 @@ class LegacyPhotoUploadController extends AbstractController
         name: 'caldera_criticalmass_gallery_legacy_photos_upload_ride',
         priority: 170
     )]
-    public function uploadAction(Request $request, Ride $ride, PhotoUploaderInterface $photoUploader, ?UserInterface $user = null): Response
+    public function uploadAction(Request $request, #[MapEntity(disabled: true)] Ride $ride, PhotoUploaderInterface $photoUploader, ?UserInterface $user = null): Response
     {
         if (Request::METHOD_POST === $request->getMethod()) {
             return $this->uploadPostAction($request, $ride, $photoUploader, $user);

--- a/src/Controller/Photo/PhotoController.php
+++ b/src/Controller/Photo/PhotoController.php
@@ -10,6 +10,7 @@ use App\Entity\Track;
 use App\Repository\PhotoRepository;
 use App\Repository\TrackRepository;
 use Flagception\Bundle\FlagceptionBundle\Attribute\Feature;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
@@ -23,7 +24,7 @@ class PhotoController extends AbstractController
         SeoPageInterface $seoPage,
         TrackRepository $trackRepository,
         ExifWrapperInterface $exifWrapper,
-        Photo $photo
+        #[MapEntity] Photo $photo
     ): Response {
         if (!$photo->isEnabled() || $photo->isDeleted()) {
             throw $this->createAccessDeniedException();

--- a/src/Controller/Photo/PhotoDownloadController.php
+++ b/src/Controller/Photo/PhotoDownloadController.php
@@ -5,6 +5,7 @@ namespace App\Controller\Photo;
 use App\Controller\AbstractController;
 use App\Entity\Photo;
 use Flagception\Bundle\FlagceptionBundle\Attribute\Feature;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\Routing\Attribute\Route;
@@ -18,7 +19,7 @@ class PhotoDownloadController extends AbstractController
     #[IsGranted('ROLE_PHOTO_DOWNLOAD')]
     public function downloadAction(
         UploaderHelper $uploaderHelper,
-        Photo $photo,
+        #[MapEntity] Photo $photo,
         string $uploadDestinationPhoto
     ): BinaryFileResponse {
         if (!$photo->isEnabled() || $photo->isDeleted()) {

--- a/src/Controller/Photo/PhotoGalleryController.php
+++ b/src/Controller/Photo/PhotoGalleryController.php
@@ -9,6 +9,7 @@ use App\Entity\Ride;
 use App\Repository\PhotoRepository;
 use Flagception\Bundle\FlagceptionBundle\Attribute\Feature;
 use Knp\Component\Pager\PaginatorInterface;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
@@ -27,7 +28,7 @@ class PhotoGalleryController extends AbstractController
         Request $request,
         PaginatorInterface $paginator,
         PhotoRepository $photoRepository,
-        Ride $ride
+        #[MapEntity(disabled: true)] Ride $ride
     ): Response {
         if ($ride && $ride->getRestrictedPhotoAccess() && !$this->getUser()) {
             throw $this->createAccessDeniedException();

--- a/src/Controller/Photo/PhotoManagementController.php
+++ b/src/Controller/Photo/PhotoManagementController.php
@@ -12,6 +12,7 @@ use App\Repository\PhotoRepository;
 use App\Repository\TrackRepository;
 use Knp\Component\Pager\PaginatorInterface;
 use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -55,7 +56,7 @@ class PhotoManagementController extends AbstractController
 
     #[IsGranted('edit', 'photo')]
     #[Route('/managephotos/{id}/delete', name: 'caldera_criticalmass_photo_delete', priority: 170)]
-    public function deleteAction(Request $request, Photo $photo, ManagerRegistry $registry): Response
+    public function deleteAction(Request $request, #[MapEntity] Photo $photo, ManagerRegistry $registry): Response
     {
         $this->saveReferer($request);
 
@@ -71,7 +72,7 @@ class PhotoManagementController extends AbstractController
     public function manageAction(
         Request $request,
         PaginatorInterface $paginator,
-        Ride $ride,
+        #[MapEntity(disabled: true)] Ride $ride,
         PhotoRepository $photoRepository
     ): Response {
         $query = $photoRepository->buildQueryPhotosByUserAndRide($this->getUser(), $ride);
@@ -90,7 +91,7 @@ class PhotoManagementController extends AbstractController
 
     #[IsGranted('edit', 'photo')]
     #[Route('/photo/{id}/toggle', name: 'caldera_criticalmass_photo_toggle', priority: 170)]
-    public function toggleAction(Request $request, Photo $photo, ManagerRegistry $registry): Response
+    public function toggleAction(Request $request, #[MapEntity] Photo $photo, ManagerRegistry $registry): Response
     {
         $this->saveReferer($request);
 
@@ -103,7 +104,7 @@ class PhotoManagementController extends AbstractController
 
     #[IsGranted('edit', 'photo')]
     #[Route('/photo/{id}/featured', name: 'caldera_criticalmass_photo_featured', priority: 170)]
-    public function featuredPhotoAction(Request $request, Photo $photo, ManagerRegistry $registry): Response
+    public function featuredPhotoAction(Request $request, #[MapEntity] Photo $photo, ManagerRegistry $registry): Response
     {
         $this->saveReferer($request);
 
@@ -118,7 +119,7 @@ class PhotoManagementController extends AbstractController
     #[Route('/photo/{id}/place', name: 'caldera_criticalmass_photo_place_single', priority: 170)]
     public function placeSingleAction(
         Request $request,
-        Photo $photo,
+        #[MapEntity] Photo $photo,
         ObjectRouterInterface $objectRouter,
         ManagerRegistry $registry
     ): Response {
@@ -172,7 +173,7 @@ class PhotoManagementController extends AbstractController
     public function relocateAction(
         TrackRepository $trackRepository,
         PhotoRepository $photoRepository,
-        Ride $ride
+        #[MapEntity(disabled: true)] Ride $ride
     ): Response {
         $photos = $photoRepository->findPhotosByUserAndRide($this->getUser(), $ride);
 
@@ -187,7 +188,7 @@ class PhotoManagementController extends AbstractController
 
     #[IsGranted('edit', 'photo')]
     #[Route('/photo/{id}/rotate', name: 'caldera_criticalmass_photo_rotate', priority: 170)]
-    public function rotateAction(Request $request, Photo $photo, PhotoManipulatorInterface $photoManipulator): Response
+    public function rotateAction(Request $request, #[MapEntity] Photo $photo, PhotoManipulatorInterface $photoManipulator): Response
     {
         $this->saveReferer($request);
 
@@ -210,7 +211,7 @@ class PhotoManagementController extends AbstractController
     #[Route('/photo/{id}/censor', name: 'caldera_criticalmass_photo_censor_short', options: ['expose' => true], priority: 170)]
     public function censorAction(
         Request $request,
-        Photo $photo,
+        #[MapEntity] Photo $photo,
         PhotoManipulatorInterface $photoManipulator,
         ?UserInterface $user = null
     ): Response {

--- a/src/Controller/Photo/PhotoUploadController.php
+++ b/src/Controller/Photo/PhotoUploadController.php
@@ -6,6 +6,7 @@ use App\Criticalmass\Image\PhotoUploader\PhotoUploaderInterface;
 use App\Controller\AbstractController;
 use App\Entity\Ride;
 use Flagception\Bundle\FlagceptionBundle\Attribute\Feature;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -20,7 +21,7 @@ class PhotoUploadController extends AbstractController
     #[Route('/{citySlug}/{rideIdentifier}/addphoto', name: 'caldera_criticalmass_gallery_photos_upload_ride', priority: 170)]
     public function uploadAction(
         Request $request,
-        Ride $ride,
+        #[MapEntity(disabled: true)] Ride $ride,
         PhotoUploaderInterface $photoUploader,
         ?UserInterface $user = null
     ): Response {

--- a/src/Controller/PostController.php
+++ b/src/Controller/PostController.php
@@ -24,21 +24,21 @@ class PostController extends AbstractController
 {
     #[IsGranted('ROLE_USER')]
     #[Route('/post/write/city/{id}', name: 'caldera_criticalmass_timeline_post_write_city', priority: 120)]
-    public function writeCityAction(Request $request, City $city, ObjectRouterInterface $objectRouter): Response
+    public function writeCityAction(Request $request, #[MapEntity] City $city, ObjectRouterInterface $objectRouter): Response
     {
         return $this->writeAction($request, $city, $objectRouter);
     }
 
     #[IsGranted('ROLE_USER')]
     #[Route('/post/write/ride/{id}', name: 'caldera_criticalmass_timeline_post_write_ride', priority: 120)]
-    public function writeRideAction(Request $request, Ride $ride, ObjectRouterInterface $objectRouter): Response
+    public function writeRideAction(Request $request, #[MapEntity] Ride $ride, ObjectRouterInterface $objectRouter): Response
     {
         return $this->writeAction($request, $ride, $objectRouter);
     }
 
     #[IsGranted('ROLE_USER')]
     #[Route('/post/write/photo/{id}', name: 'caldera_criticalmass_timeline_post_write_photo', priority: 120)]
-    public function writePhotoAction(Request $request, Photo $photo, ObjectRouterInterface $objectRouter): Response
+    public function writePhotoAction(Request $request, #[MapEntity] Photo $photo, ObjectRouterInterface $objectRouter): Response
     {
         return $this->writeAction($request, $photo, $objectRouter);
     }

--- a/src/Controller/Profile/ParticipationController.php
+++ b/src/Controller/Profile/ParticipationController.php
@@ -10,6 +10,7 @@ use App\Entity\Participation;
 use App\Event\Participation\ParticipationDeletedEvent;
 use App\Event\Participation\ParticipationUpdatedEvent;
 use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -67,7 +68,7 @@ class ParticipationController extends AbstractController
         Request $request,
         ManagerRegistry $registry,
         EventDispatcherInterface $eventDispatcher,
-        Participation $participation
+        #[MapEntity] Participation $participation
     ): Response {
         $status = $request->query->get('status', 'maybe');
 
@@ -92,7 +93,7 @@ class ParticipationController extends AbstractController
     public function deleteAction(
         ManagerRegistry $registry,
         EventDispatcherInterface $eventDispatcher,
-        Participation $participation
+        #[MapEntity] Participation $participation
     ): Response {
         $registry->getManager()->remove($participation);
         $registry->getManager()->flush();

--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -3,11 +3,12 @@
 namespace App\Controller;
 
 use App\Entity\User;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\HttpFoundation\Response;
 
 class ProfileController extends AbstractController
 {
-    public function showAction(User $user): Response
+    public function showAction(#[MapEntity] User $user): Response
     {
         return $this->render('App:Profile:show.html.twig', [
             'userProfile' => $user,

--- a/src/Controller/Ride/CalendarController.php
+++ b/src/Controller/Ride/CalendarController.php
@@ -5,6 +5,7 @@ namespace App\Controller\Ride;
 use App\Criticalmass\Ical\RideIcalGeneratorInterface;
 use App\Entity\Ride;
 use App\Controller\AbstractController;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
@@ -17,7 +18,7 @@ class CalendarController extends AbstractController
     )]
     public function icalAction(
         RideIcalGeneratorInterface $rideIcalGenerator,
-        Ride $ride
+        #[MapEntity(disabled: true)] Ride $ride
     ): Response {
         $content = $rideIcalGenerator
             ->generateForRide($ride)

--- a/src/Controller/Ride/ParticipationController.php
+++ b/src/Controller/Ride/ParticipationController.php
@@ -6,6 +6,7 @@ use App\Controller\AbstractController;
 use App\Criticalmass\Participation\Manager\ParticipationManagerInterface;
 use App\Criticalmass\Router\ObjectRouterInterface;
 use App\Entity\Ride;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
@@ -24,7 +25,7 @@ class ParticipationController extends AbstractController
         Request $request,
         ParticipationManagerInterface $participationManager,
         ObjectRouterInterface $objectRouter,
-        Ride $ride,
+        #[MapEntity(disabled: true)] Ride $ride,
         string $status
     ): Response {
         if (!$this->isCsrfTokenValid('participation_' . $ride->getId(), $request->request->get('_token'))) {

--- a/src/Controller/Ride/RideController.php
+++ b/src/Controller/Ride/RideController.php
@@ -17,6 +17,7 @@ use App\Repository\RideRepository;
 use App\Repository\SubrideRepository;
 use App\Repository\TrackRepository;
 use App\Repository\WeatherRepository;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
@@ -56,7 +57,7 @@ class RideController extends AbstractController
         TrackRepository $trackRepository,
         PhotoRepository $photoRepository,
         SeoPageInterface $seoPage,
-        ?Ride $ride = null
+        #[MapEntity(disabled: true)] ?Ride $ride = null
     ): Response {
         if (!$ride) {
             return $this->redirectToRoute('caldera_criticalmass_calendar');

--- a/src/Controller/Ride/RideEstimateController.php
+++ b/src/Controller/Ride/RideEstimateController.php
@@ -8,6 +8,7 @@ use App\Controller\AbstractController;
 use App\Entity\Ride;
 use App\Entity\RideEstimate;
 use App\Form\Type\RideEstimateType;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -25,7 +26,7 @@ class RideEstimateController extends AbstractController
     )]
     public function addestimateAction(
         Request $request,
-        Ride $ride,
+        #[MapEntity(disabled: true)] Ride $ride,
         EventDispatcherInterface $eventDispatcher,
         ObjectRouterInterface $objectRouter,
         ?UserInterface $user = null
@@ -59,7 +60,7 @@ class RideEstimateController extends AbstractController
     )]
     public function anonymousestimateAction(
         Request $request,
-        Ride $ride,
+        #[MapEntity(disabled: true)] Ride $ride,
         EventDispatcherInterface $eventDispatcher,
         ObjectRouterInterface $objectRouter,
         ?UserInterface $user = null

--- a/src/Controller/Ride/RideManagementController.php
+++ b/src/Controller/Ride/RideManagementController.php
@@ -11,6 +11,7 @@ use App\Form\Type\RideSocialPreviewType;
 use App\Form\Type\RideType;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -24,7 +25,7 @@ class RideManagementController extends AbstractController
 {
     #[IsGranted('ROLE_USER')]
     #[Route('/{citySlug}/add-ride', name: 'caldera_criticalmass_ride_add', priority: 70)]
-    public function addAction(Request $request, EntityManagerInterface $entityManager, City $city, ObjectRouterInterface $objectRouter, ?UserInterface $user = null): Response
+    public function addAction(Request $request, EntityManagerInterface $entityManager, #[MapEntity(disabled: true)] City $city, ObjectRouterInterface $objectRouter, ?UserInterface $user = null): Response
     {
         $ride = new Ride();
         $ride
@@ -93,7 +94,7 @@ class RideManagementController extends AbstractController
 
     #[IsGranted('ROLE_USER')]
     #[Route('/{citySlug}/{rideIdentifier}/edit', name: 'caldera_criticalmass_ride_edit', priority: 70)]
-    public function editAction(Request $request, Ride $ride, ObjectRouterInterface $objectRouter, ?UserInterface $user = null): Response
+    public function editAction(Request $request, #[MapEntity(disabled: true)] Ride $ride, ObjectRouterInterface $objectRouter, ?UserInterface $user = null): Response
     {
         $form = $this->createForm(RideType::class, $ride, [
             'action' => $objectRouter->generate($ride, 'caldera_criticalmass_ride_edit'),
@@ -162,7 +163,7 @@ class RideManagementController extends AbstractController
         EntityManagerInterface $entityManager,
         Request $request,
         ObjectRouterInterface $objectRouter,
-        Ride $ride,
+        #[MapEntity(disabled: true)] Ride $ride,
         ?UserInterface $user = null
     ): Response {
         $form = $this->createForm(RideSocialPreviewType::class, $ride, [
@@ -213,7 +214,7 @@ class RideManagementController extends AbstractController
 
     #[IsGranted('ROLE_USER')]
     #[Route('/{citySlug}/{rideIdentifier}/disable', name: 'caldera_criticalmass_ride_disable', priority: 70)]
-    public function disableAction(Request $request, ManagerRegistry $registry, Ride $ride, ObjectRouterInterface $objectRouter, ?UserInterface $user = null): RedirectResponse
+    public function disableAction(Request $request, ManagerRegistry $registry, #[MapEntity(disabled: true)] Ride $ride, ObjectRouterInterface $objectRouter, ?UserInterface $user = null): RedirectResponse
     {
         if (Request::METHOD_POST === $request->getMethod()) {
             $disableForm = $this->createForm(RideDisableType::class, $ride);
@@ -231,7 +232,7 @@ class RideManagementController extends AbstractController
 
     #[IsGranted('ROLE_USER')]
     #[Route('/{citySlug}/{rideIdentifier}/enable', name: 'caldera_criticalmass_ride_enable', methods: ['POST'], priority: 70)]
-    public function enableAction(Request $request, ManagerRegistry $registry, Ride $ride, ObjectRouterInterface $objectRouter, ?UserInterface $user = null): RedirectResponse
+    public function enableAction(Request $request, ManagerRegistry $registry, #[MapEntity(disabled: true)] Ride $ride, ObjectRouterInterface $objectRouter, ?UserInterface $user = null): RedirectResponse
     {
         if (!$this->isCsrfTokenValid('ride_enable_' . $ride->getId(), $request->request->get('_token'))) {
             throw $this->createAccessDeniedException('Invalid CSRF token.');

--- a/src/Controller/Ride/RideTabsController.php
+++ b/src/Controller/Ride/RideTabsController.php
@@ -15,13 +15,14 @@ use App\Repository\SocialNetworkProfileRepository;
 use App\Repository\SubrideRepository;
 use App\Repository\TrackRepository;
 use App\Repository\WeatherRepository;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\HttpFoundation\Response;
 
 class RideTabsController extends AbstractController
 {
     public function renderPhotosTabAction(
         PhotoRepository $photoRepository,
-        Ride $ride
+        #[MapEntity(disabled: true)] Ride $ride
     ): Response {
         $photos = $photoRepository->findPhotosByRide($ride);
 
@@ -34,7 +35,7 @@ class RideTabsController extends AbstractController
 
     public function renderTracksTabAction(
         TrackRepository $trackRepository,
-        Ride $ride
+        #[MapEntity(disabled: true)] Ride $ride
     ): Response {
         $tracks = $trackRepository->findTracksByRide($ride);
 
@@ -45,7 +46,7 @@ class RideTabsController extends AbstractController
         ]);
     }
 
-    public function renderPostsTabAction(Ride $ride): Response
+    public function renderPostsTabAction(#[MapEntity(disabled: true)] Ride $ride): Response
     {
         return $this->render('RideTabs/PostsTab.html.twig', [
             'ride' => $ride,
@@ -53,7 +54,7 @@ class RideTabsController extends AbstractController
     }
 
     public function renderSubridesTabAction(
-        Ride $ride,
+        #[MapEntity(disabled: true)] Ride $ride,
         SubrideRepository $subrideRepository
     ): Response {
         $subrides = $subrideRepository->getSubridesForRide($ride);
@@ -65,7 +66,7 @@ class RideTabsController extends AbstractController
         ]);
     }
 
-    public function renderStatisticTabAction(Ride $ride): Response
+    public function renderStatisticTabAction(#[MapEntity(disabled: true)] Ride $ride): Response
     {
         return $this->render('RideTabs/StatisticTab.html.twig', [
             'ride' => $ride,
@@ -77,7 +78,7 @@ class RideTabsController extends AbstractController
         LocationRepository $locationRepository,
         WeatherRepository $weatherRepository,
         SocialNetworkProfileRepository $socialNetworkProfileRepository,
-        Ride $ride,
+        #[MapEntity(disabled: true)] Ride $ride,
         ObjectRouterInterface $objectRouter
     ): Response {
         /**

--- a/src/Controller/Ride/SubrideController.php
+++ b/src/Controller/Ride/SubrideController.php
@@ -8,6 +8,7 @@ use App\Repository\RideRepository;
 use App\Controller\AbstractController;
 use App\Entity\Subride;
 use App\Form\Type\SubrideType;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -23,7 +24,7 @@ class SubrideController extends AbstractController
         name: 'caldera_criticalmass_subride_add',
         priority: 20
     )]
-    public function addAction(Request $request, Ride $ride, UserInterface $user, ObjectRouterInterface $objectRouter): Response
+    public function addAction(Request $request, #[MapEntity(disabled: true)] Ride $ride, UserInterface $user, ObjectRouterInterface $objectRouter): Response
     {
         $subride = new Subride();
         $subride
@@ -87,7 +88,7 @@ class SubrideController extends AbstractController
         name: 'caldera_criticalmass_subride_edit',
         priority: 20
     )]
-    public function editAction(Request $request, Subride $subride, ObjectRouterInterface $objectRouter): Response
+    public function editAction(Request $request, #[MapEntity] Subride $subride, ObjectRouterInterface $objectRouter): Response
     {
         $form = $this->createForm(SubrideType::class, $subride, [
             'action' => $objectRouter->generate($subride, 'caldera_criticalmass_subride_edit'),
@@ -138,7 +139,7 @@ class SubrideController extends AbstractController
     )]
     public function preparecopyAction(
         RideRepository $rideRepository,
-        Ride $ride
+        #[MapEntity(disabled: true)] Ride $ride
     ): Response {
         $oldRide = $rideRepository->getPreviousRideWithSubrides($ride);
 
@@ -155,7 +156,7 @@ class SubrideController extends AbstractController
         priority: 20
     )]
     public function copyAction(
-        Ride $oldRide,
+        #[MapEntity(disabled: true)] Ride $oldRide,
         string $newDate,
         ObjectRouterInterface $objectRouter,
         RideRepository $rideRepository

--- a/src/Controller/Ride/TimelapseController.php
+++ b/src/Controller/Ride/TimelapseController.php
@@ -7,6 +7,7 @@ use App\Criticalmass\Geo\GpxService\GpxServiceInterface;
 use App\Entity\Ride;
 use App\Entity\Track;
 use App\Repository\TrackRepository;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
@@ -19,7 +20,7 @@ class TimelapseController extends AbstractController
     )]
     public function showAction(
         TrackRepository $trackRepository,
-        Ride $ride
+        #[MapEntity(disabled: true)] Ride $ride
     ): Response {
         $tracks = $trackRepository->findTracksByRide($ride);
 
@@ -35,7 +36,7 @@ class TimelapseController extends AbstractController
         options: ['expose' => true],
         priority: 135
     )]
-    public function loadtrackAction(GpxServiceInterface $gpxService, Track $track): Response
+    public function loadtrackAction(GpxServiceInterface $gpxService, #[MapEntity] Track $track): Response
     {
         $list = $gpxService->generateTimeLatLngList($track);
 

--- a/src/Controller/SocialNetwork/SocialNetworkController.php
+++ b/src/Controller/SocialNetwork/SocialNetworkController.php
@@ -13,6 +13,7 @@ use App\Entity\SocialNetworkProfile;
 use App\EntityInterface\SocialNetworkProfileAble;
 use App\Factory\SocialNetworkProfile\SocialNetworkProfileFactoryInterface;
 use App\Form\Type\SocialNetworkProfileAddType;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -39,8 +40,8 @@ class SocialNetworkController extends AbstractController
         ObjectRouterInterface $objectRouter,
         SocialNetworkProfileFactoryInterface $networkProfileFactory,
         SocialNetworkHelperInterface $socialNetworkHelper,
-        ?City $city = null,
-        ?Ride $ride = null,
+        #[MapEntity(disabled: true)] ?City $city = null,
+        #[MapEntity(disabled: true)] ?Ride $ride = null,
         ?UserInterface $user = null
     ): Response {
         if (!$user) {

--- a/src/Controller/SocialNetwork/SocialNetworkItemListController.php
+++ b/src/Controller/SocialNetwork/SocialNetworkItemListController.php
@@ -6,6 +6,7 @@ use App\Controller\AbstractController;
 use App\Entity\City;
 use App\Entity\SocialNetworkFeedItem;
 use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
@@ -16,7 +17,7 @@ class SocialNetworkItemListController extends AbstractController
         name: 'criticalmass_socialnetwork_city_list_items',
         priority: 60
     )]
-    public function listCityItemsAction(City $city, ManagerRegistry $registry): Response
+    public function listCityItemsAction(#[MapEntity(disabled: true)] City $city, ManagerRegistry $registry): Response
     {
         $itemList = $registry->getRepository(SocialNetworkFeedItem::class);
 

--- a/src/Controller/SocialNetwork/SocialNetworkListController.php
+++ b/src/Controller/SocialNetwork/SocialNetworkListController.php
@@ -12,6 +12,7 @@ use App\EntityInterface\SocialNetworkProfileAble;
 use App\Factory\SocialNetworkProfile\SocialNetworkProfileFactory;
 use App\Factory\SocialNetworkProfile\SocialNetworkProfileFactoryInterface;
 use App\Form\Type\SocialNetworkProfileAddType;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
@@ -26,7 +27,7 @@ class SocialNetworkListController extends AbstractController
     )]
     public function listCityAction(
         ObjectRouterInterface $router,
-        City $city,
+        #[MapEntity(disabled: true)] City $city,
         SocialNetworkProfileFactory $socialNetworkProfileFactory,
         SocialNetworkHelperInterface $socialNetworkHelper,
         UserInterface $user
@@ -54,7 +55,7 @@ class SocialNetworkListController extends AbstractController
     )]
     public function listRideAction(
         ObjectRouterInterface $router,
-        Ride $ride,
+        #[MapEntity(disabled: true)] Ride $ride,
         SocialNetworkProfileFactoryInterface $socialNetworkProfileFactory,
         SocialNetworkHelperInterface $socialNetworkHelper,
         ?UserInterface $user = null

--- a/src/Controller/SocialNetwork/SocialNetworkManagementController.php
+++ b/src/Controller/SocialNetwork/SocialNetworkManagementController.php
@@ -10,6 +10,7 @@ use App\Criticalmass\Util\ClassUtil;
 use App\Entity\SocialNetworkProfile;
 use App\Form\Type\SocialNetworkProfileEditType;
 use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -25,7 +26,7 @@ class SocialNetworkManagementController extends AbstractController
     )]
     public function editAction(
         Request $request,
-        SocialNetworkProfile $socialNetworkProfile,
+        #[MapEntity] SocialNetworkProfile $socialNetworkProfile,
         ObjectRouterInterface $objectRouter,
         SocialNetworkHelperInterface $socialNetworkHelper
     ): Response {
@@ -92,7 +93,7 @@ class SocialNetworkManagementController extends AbstractController
     public function disableAction(
         Request $request,
         EntityManagerInterface $entityManager,
-        SocialNetworkProfile $socialNetworkProfile,
+        #[MapEntity] SocialNetworkProfile $socialNetworkProfile,
         SocialNetworkHelper $socialNetworkHelper
     ): Response {
         if (!$this->isCsrfTokenValid('socialnetwork_disable_' . $socialNetworkProfile->getId(), $request->request->get('_token'))) {

--- a/src/Controller/Statistic/StatisticController.php
+++ b/src/Controller/Statistic/StatisticController.php
@@ -9,6 +9,7 @@ use App\Entity\Region;
 use App\Entity\Ride;
 use App\Repository\RegionRepository;
 use App\Repository\RideRepository;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
@@ -22,7 +23,7 @@ class StatisticController extends AbstractController
     public function citystatisticAction(
         SeoPageInterface $seoPage,
         RideRepository $rideRepository,
-        City $city
+        #[MapEntity(disabled: true)] City $city
     ): Response {
         $rides = $rideRepository->findRidesForCity($city);
 

--- a/src/Controller/Track/StravaController.php
+++ b/src/Controller/Track/StravaController.php
@@ -12,6 +12,7 @@ use App\Event\Track\TrackUploadedEvent;
 use Doctrine\Persistence\ManagerRegistry;
 use Iamstuartwilson\StravaApi;
 use Strava\API\OAuth;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -33,7 +34,7 @@ class StravaController extends AbstractController
 
     #[IsGranted('ROLE_USER')]
     #[Route('/{citySlug}/{rideIdentifier}/stravaauth', name: 'caldera_criticalmass_strava_auth', priority: 130)]
-    public function authAction(Request $request, Ride $ride, ObjectRouterInterface $objectRouter): Response
+    public function authAction(Request $request, #[MapEntity(disabled: true)] Ride $ride, ObjectRouterInterface $objectRouter): Response
     {
         $redirect = $request->getUriForPath($objectRouter->generate($ride, 'caldera_criticalmass_strava_token'));
 
@@ -54,7 +55,7 @@ class StravaController extends AbstractController
 
     #[IsGranted('ROLE_USER')]
     #[Route('/{citySlug}/{rideIdentifier}/stravatoken', name: 'caldera_criticalmass_strava_token', priority: 130)]
-    public function tokenAction(Request $request, Ride $ride, ObjectRouterInterface $objectRouter, SessionInterface $session): Response
+    public function tokenAction(Request $request, #[MapEntity(disabled: true)] Ride $ride, ObjectRouterInterface $objectRouter, SessionInterface $session): Response
     {
         $api = $this->createApi();
 
@@ -73,7 +74,7 @@ class StravaController extends AbstractController
 
     #[IsGranted('ROLE_USER')]
     #[Route('/{citySlug}/{rideIdentifier}/stravalist', name: 'caldera_criticalmass_strava_list', priority: 130)]
-    public function listridesAction(Ride $ride, SessionInterface $session): Response
+    public function listridesAction(#[MapEntity(disabled: true)] Ride $ride, SessionInterface $session): Response
     {
         $afterDateTime = DateTimeUtil::getDayStartDateTime($ride->getDateTime());
         $beforeDateTime = DateTimeUtil::getDayEndDateTime($ride->getDateTime());
@@ -99,7 +100,7 @@ class StravaController extends AbstractController
 
     #[IsGranted('ROLE_USER')]
     #[Route('/{citySlug}/{rideIdentifier}/stravaimport', name: 'caldera_criticalmass_strava_import', priority: 130)]
-    public function importAction(Request $request, UserInterface $user, EventDispatcherInterface $eventDispatcher, ObjectRouterInterface $objectRouter, Ride $ride, TrackImporterInterface $trackImporter): Response
+    public function importAction(Request $request, UserInterface $user, EventDispatcherInterface $eventDispatcher, ObjectRouterInterface $objectRouter, #[MapEntity(disabled: true)] Ride $ride, TrackImporterInterface $trackImporter): Response
     {
         $activityId = (int) $request->get('activityId');
 

--- a/src/Controller/Track/StravaMassImportController.php
+++ b/src/Controller/Track/StravaMassImportController.php
@@ -12,6 +12,7 @@ use App\Event\Track\TrackUploadedEvent;
 use Carbon\Carbon;
 use Strava\API\OAuth;
 use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -131,7 +132,7 @@ class StravaMassImportController extends AbstractController
 
     #[IsGranted('ROLE_USER')]
     #[Route('/trackimport/stravaimport', name: 'caldera_criticalmass_trackmassimport_import', priority: 310)]
-    public function importAction(Request $request, UserInterface $user, EventDispatcherInterface $eventDispatcher, ObjectRouterInterface $objectRouter, Ride $ride, TrackImporterInterface $trackImporter): Response
+    public function importAction(Request $request, UserInterface $user, EventDispatcherInterface $eventDispatcher, ObjectRouterInterface $objectRouter, #[MapEntity(disabled: true)] Ride $ride, TrackImporterInterface $trackImporter): Response
     {
         $activityId = (int)$request->get('activityId');
 

--- a/src/Controller/Track/TrackController.php
+++ b/src/Controller/Track/TrackController.php
@@ -5,6 +5,7 @@ namespace App\Controller\Track;
 use App\Controller\AbstractController;
 use App\Entity\Track;
 use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -17,7 +18,7 @@ class TrackController extends AbstractController
         name: 'caldera_criticalmass_track_view',
         priority: 150
     )]
-    public function viewAction(Track $track): Response
+    public function viewAction(#[MapEntity] Track $track): Response
     {
         return $this->render('Track/view.html.twig', [
             'track' => $track,
@@ -30,7 +31,7 @@ class TrackController extends AbstractController
         name: 'caldera_criticalmass_track_approve',
         priority: 150
     )]
-    public function approveAction(Track $track, ManagerRegistry $registry): Response
+    public function approveAction(#[MapEntity] Track $track, ManagerRegistry $registry): Response
     {
         $track->setReviewed(true);
 

--- a/src/Controller/Track/TrackDownloadController.php
+++ b/src/Controller/Track/TrackDownloadController.php
@@ -5,6 +5,7 @@ namespace App\Controller\Track;
 use League\Flysystem\Filesystem;
 use App\Controller\AbstractController;
 use App\Entity\Track;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -14,7 +15,7 @@ class TrackDownloadController extends AbstractController
 {
     #[IsGranted('edit', 'track')]
     #[Route('/track/download/{id}', name: 'caldera_criticalmass_track_download', priority: 270)]
-    public function downloadAction(Track $track, UploaderHelper $uploaderHelper): Response
+    public function downloadAction(#[MapEntity] Track $track, UploaderHelper $uploaderHelper): Response
     {
         /** @var Filesystem $filesystem */
         $filesystem = $this->get('oneup_flysystem.flysystem_track_track_filesystem');

--- a/src/Controller/Track/TrackManagementController.php
+++ b/src/Controller/Track/TrackManagementController.php
@@ -9,6 +9,7 @@ use App\Event\Track\TrackHiddenEvent;
 use App\Event\Track\TrackShownEvent;
 use App\Repository\TrackRepository;
 use Knp\Component\Pager\PaginatorInterface;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -42,7 +43,7 @@ class TrackManagementController extends AbstractController
 
     #[IsGranted('edit', 'track')]
     #[Route('/{id}/toggle', name: 'toggle', methods: ['POST'], priority: 150)]
-    public function toggleAction(Request $request, EventDispatcherInterface $eventDispatcher, Track $track): Response
+    public function toggleAction(Request $request, EventDispatcherInterface $eventDispatcher, #[MapEntity] Track $track): Response
     {
         if (!$this->isCsrfTokenValid('track_toggle_' . $track->getId(), $request->request->get('_token'))) {
             throw $this->createAccessDeniedException('Invalid CSRF token.');
@@ -63,7 +64,7 @@ class TrackManagementController extends AbstractController
 
     #[IsGranted('edit', 'track')]
     #[Route('/{id}/delete', name: 'delete', methods: ['POST'], priority: 150)]
-    public function deleteAction(Request $request, Track $track, EventDispatcherInterface $eventDispatcher): Response
+    public function deleteAction(Request $request, #[MapEntity] Track $track, EventDispatcherInterface $eventDispatcher): Response
     {
         if (!$this->isCsrfTokenValid('track_delete_' . $track->getId(), $request->request->get('_token'))) {
             throw $this->createAccessDeniedException('Invalid CSRF token.');

--- a/src/Controller/Track/TrackRangeController.php
+++ b/src/Controller/Track/TrackRangeController.php
@@ -7,6 +7,7 @@ use App\Criticalmass\Geo\GpxService\GpxServiceInterface;
 use App\Entity\Track;
 use App\Event\Track\TrackTrimmedEvent;
 use App\Form\Type\TrackRangeType;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -20,7 +21,7 @@ class TrackRangeController extends AbstractController
     #[Route('/track/range/{id}', name: 'caldera_criticalmass_track_range', priority: 270)]
     public function rangeAction(
         Request $request,
-        Track $track,
+        #[MapEntity] Track $track,
         GpxServiceInterface $gpxService,
         EventDispatcherInterface $eventDispatcher
     ): Response {

--- a/src/Controller/Track/TrackTimeController.php
+++ b/src/Controller/Track/TrackTimeController.php
@@ -7,6 +7,7 @@ use App\Criticalmass\Router\ObjectRouterInterface;
 use App\Event\Track\TrackTimeEvent;
 use App\Controller\AbstractController;
 use App\Entity\Track;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\Extension\Core\Type\TimeType;
@@ -29,7 +30,7 @@ class TrackTimeController extends AbstractController
         ObjectRouterInterface $objectRouter,
         EventDispatcherInterface $eventDispatcher,
         GpxServiceInterface $gpxService,
-        Track $track
+        #[MapEntity] Track $track
     ): Response {
         $form = $this->createFormBuilder($track)
             ->setAction($objectRouter->generate($track, 'caldera_criticalmass_track_time'))

--- a/src/Controller/Track/TrackUploadController.php
+++ b/src/Controller/Track/TrackUploadController.php
@@ -11,6 +11,7 @@ use App\Criticalmass\UploadValidator\UploadValidatorException\TrackValidatorExce
 use App\Controller\AbstractController;
 use App\Entity\Ride;
 use App\Entity\Track;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
@@ -25,7 +26,7 @@ class TrackUploadController extends AbstractController
         name: 'caldera_criticalmass_track_upload',
         priority: 270
     )]
-    public function uploadAction(Request $request, EventDispatcherInterface $eventDispatcher, ObjectRouterInterface $objectRouter, Ride $ride, TrackValidator $trackValidator): Response
+    public function uploadAction(Request $request, EventDispatcherInterface $eventDispatcher, ObjectRouterInterface $objectRouter, #[MapEntity(disabled: true)] Ride $ride, TrackValidator $trackValidator): Response
     {
         $track = new Track();
 


### PR DESCRIPTION
## Summary

- Add explicit `#[MapEntity(disabled: true)]` to all entity parameters resolved by custom ValueResolvers (`City`, `Ride`, `Region`, `Thread`) across 50 controllers
- Add explicit `#[MapEntity]` to entity parameters resolved by Doctrine's `EntityValueResolver` (`Photo`, `Track`, `Subride`, `CityCycle`, `Location`, `SocialNetworkProfile`, `SocialNetworkFeedItem`, `User`)
- Covers all web controllers and all 12 API controllers to eliminate Symfony 7.1+ deprecation warnings about implicit Doctrine entity auto-mapping

Closes #1263

## Test plan

- [ ] Verify PHPStan passes (no new errors introduced; 214 pre-existing errors unchanged)
- [ ] Run full test suite with `composer test` to confirm no regressions
- [ ] Verify web controllers still resolve entities correctly (City/Ride pages, Photo galleries, Track views)
- [ ] Verify API endpoints still work (city list/show, ride CRUD, track list, photo list)
- [ ] Confirm Symfony deprecation warnings for Doctrine auto-mapping are gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)