### PR TITLE
Fix TypeError when clearing description field

### DIFF
--- a/src/Entity/City.php
+++ b/src/Entity/City.php
@@ -368,7 +368,7 @@ class City implements BoardInterface, PhotoInterface, RouteableInterface, Audita
         return $this->slugs;
     }
 
-    public function setDescription(string $description): City
+    public function setDescription(?string $description = null): City
     {
         $this->description = $description;
 

--- a/src/Entity/Ride.php
+++ b/src/Entity/Ride.php
@@ -374,7 +374,7 @@ class Ride implements ParticipateableInterface, PhotoInterface, RouteableInterfa
         return $this->title;
     }
 
-    public function setDescription(string $description): Ride
+    public function setDescription(?string $description = null): Ride
     {
         $this->description = $description;
 
@@ -386,7 +386,7 @@ class Ride implements ParticipateableInterface, PhotoInterface, RouteableInterfa
         return $this->description;
     }
 
-    public function setSocialDescription(string $socialDescription): Ride
+    public function setSocialDescription(?string $socialDescription = null): Ride
     {
         $this->socialDescription = $socialDescription;
 

--- a/src/Entity/Subride.php
+++ b/src/Entity/Subride.php
@@ -104,7 +104,7 @@ class Subride implements AuditableInterface, SocialNetworkProfileAble, Routeable
         return $this->title;
     }
 
-    public function setDescription(string $description): Subride
+    public function setDescription(?string $description = null): Subride
     {
         $this->description = $description;
 


### PR DESCRIPTION
## Summary

- `Ride::setDescription()` and `Ride::setSocialDescription()` did not accept `null`, but the properties are `?string` and DB columns are `nullable: true`
- When users cleared the description textarea and saved, Symfony passed `null` to the setter → `TypeError` → 500 error
- Fixed the same issue in `City::setDescription()` and `Subride::setDescription()`

Closes #1257

## Test plan

- [ ] Edit a ride and add a description, save → should work
- [ ] Edit the same ride and clear the description field, save → should work without error
- [ ] Verify the description is empty after saving

🤖 Generated with [Claude Code](https://claude.com/claude-code)