### PR TITLE
Fix Monolog FingersCrossed config conflict

### DIFF
--- a/config/packages/monolog.yaml
+++ b/config/packages/monolog.yaml
@@ -5,10 +5,7 @@ when@prod:
                 type: fingers_crossed
                 action_level: error
                 handler: nested
-                excluded_404s:
-                    # regex: exclude all 404 errors from the logs
-                    - ^/
-                excluded_http_codes: [400, 405]
+                excluded_http_codes: [400, 404, 405]
             nested:
                 type: stream
                 path: "%kernel.logs_dir%/%kernel.environment%.log"


### PR DESCRIPTION
## Summary

- `excluded_404s` and `excluded_http_codes` cannot be used together in a Monolog FingersCrossedHandler
- This caused `cache:clear` to fail in production with: `Invalid configuration for path "monolog.handlers.main"`
- Replaced both with a single `excluded_http_codes: [400, 404, 405]`

## Test plan

- [ ] Run `bin/console cache:clear` in prod environment — should succeed without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)