### PR TITLE
Register missing deprecation channel in Monolog config

### DIFF
--- a/config/packages/monolog.yaml
+++ b/config/packages/monolog.yaml
@@ -1,5 +1,7 @@
 when@prod:
     monolog:
+        channels:
+            - deprecation
         handlers:
             main:
                 type: fingers_crossed


### PR DESCRIPTION
## Summary

- The `deprecation` handler uses `channels: ["deprecation"]`, but the channel was never declared
- This caused `cache:clear` to fail: `The logging channel "deprecation" assigned to the "deprecation" handler does not exist`
- Added `channels: [deprecation]` to the Monolog prod config

## Test plan

- [ ] Run `bin/console cache:clear` in prod environment — should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)