### PR TITLE
Fix migration: use DROP COLUMN IF EXISTS

### DIFF
--- a/migrations/Version20260226000000.php
+++ b/migrations/Version20260226000000.php
@@ -16,8 +16,8 @@ final class Version20260226000000 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE track DROP COLUMN md5_hash');
-        $this->addSql('ALTER TABLE track DROP COLUMN geo_json');
+        $this->addSql('ALTER TABLE track DROP COLUMN IF EXISTS md5_hash');
+        $this->addSql('ALTER TABLE track DROP COLUMN IF EXISTS geo_json');
     }
 
     public function down(Schema $schema): void


### PR DESCRIPTION
## Summary

- Migration `Version20260226000000` fails on production because `md5_hash` and `geo_json` columns were already removed
- Changed `DROP COLUMN` to `DROP COLUMN IF EXISTS` (supported by MariaDB 10.0.2+) for idempotent execution

## Test plan

- [ ] Run `doctrine:migrations:migrate` on production — should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)