### PR TITLE
Clear LiipImagine cache on ride preview image update

### DIFF
--- a/src/EventSubscriber/RideImageCacheSubscriber.php
+++ b/src/EventSubscriber/RideImageCacheSubscriber.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+
+namespace App\EventSubscriber;
+
+use App\Entity\Ride;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
+use Doctrine\ORM\Event\PreUpdateEventArgs;
+use Doctrine\ORM\Events;
+use Liip\ImagineBundle\Imagine\Cache\CacheManager;
+use Vich\UploaderBundle\Templating\Helper\UploaderHelper;
+
+#[AsDoctrineListener(event: Events::preUpdate)]
+class RideImageCacheSubscriber
+{
+    public function __construct(
+        private readonly CacheManager $cacheManager,
+        private readonly UploaderHelper $uploaderHelper,
+    ) {
+    }
+
+    public function preUpdate(PreUpdateEventArgs $args): void
+    {
+        $entity = $args->getObject();
+
+        if (!$entity instanceof Ride) {
+            return;
+        }
+
+        if (!$args->hasChangedField('imageName')) {
+            return;
+        }
+
+        $oldImageName = $args->getOldValue('imageName');
+
+        if (null === $oldImageName) {
+            return;
+        }
+
+        // Entity already has the new imageName; temporarily restore the old one to resolve the asset path
+        $newImageName = $entity->getImageName();
+        $entity->setImageName($oldImageName);
+        $oldPath = $this->uploaderHelper->asset($entity, 'imageFile');
+        $entity->setImageName($newImageName);
+
+        if (null !== $oldPath) {
+            $this->cacheManager->remove($oldPath);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `RideImageCacheSubscriber` that listens for Doctrine `preUpdate` events on the `Ride` entity
- When the `imageName` field changes, clears all cached LiipImagine filter variations (`ride_image_wide`, `ride_photo_preview`, `facebook_preview_image`, `twitter_summary_large_image`) for the old image path
- Follows the same pattern as the existing `PhotoCache` for `Photo` entities

Closes #50

## Test plan

- [ ] Upload a ride preview image and verify it displays correctly
- [ ] Update the ride preview image with a new one and verify the new image is shown (not the old cached version)
- [ ] Delete the ride preview image and verify it no longer displays

🤖 Generated with [Claude Code](https://claude.com/claude-code)