### PR TITLE
Update existing estimate instead of creating duplicates

### DIFF
--- a/src/Controller/Api/EstimateController.php
+++ b/src/Controller/Api/EstimateController.php
@@ -7,10 +7,14 @@ use MalteHuebner\DataQueryBundle\DataQueryManager\DataQueryManagerInterface;
 use MalteHuebner\DataQueryBundle\RequestParameterList\RequestParameterList;
 use App\Entity\Ride;
 use App\Entity\RideEstimate;
+use App\Entity\User;
 use App\Event\RideEstimate\RideEstimateCreatedEvent;
+use App\Event\RideEstimate\RideEstimateUpdatedEvent;
 use App\Model\CreateEstimateModel;
+use App\Repository\RideEstimateRepository;
 use App\Serializer\CriticalSerializerInterface;
 use OpenApi\Attributes as OA;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -23,6 +27,8 @@ class EstimateController extends BaseController
         CriticalSerializerInterface $serializer,
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly DataQueryManagerInterface $dataQueryManager,
+        private readonly RideEstimateRepository $rideEstimateRepository,
+        private readonly Security $security,
         ManagerRegistry $managerRegistry,
     )
     {
@@ -57,7 +63,7 @@ class EstimateController extends BaseController
         /** @var CreateEstimateModel $estimateModel */
         $estimateModel = $this->deserializeRequest($request, CreateEstimateModel::class);
 
-        $rideEstimation = $this->createRideEstimate($estimateModel);
+        [$rideEstimation, $isUpdate] = $this->createOrUpdateRideEstimate($estimateModel);
 
         if (!$rideEstimation) {
             throw new BadRequestHttpException();
@@ -66,7 +72,11 @@ class EstimateController extends BaseController
         $this->managerRegistry->getManager()->persist($rideEstimation);
         $this->managerRegistry->getManager()->flush();
 
-        $this->eventDispatcher->dispatch(new RideEstimateCreatedEvent($rideEstimation), RideEstimateCreatedEvent::NAME);
+        if ($isUpdate) {
+            $this->eventDispatcher->dispatch(new RideEstimateUpdatedEvent($rideEstimation), RideEstimateUpdatedEvent::NAME);
+        } else {
+            $this->eventDispatcher->dispatch(new RideEstimateCreatedEvent($rideEstimation), RideEstimateCreatedEvent::NAME);
+        }
 
         return $this->createStandardResponse($rideEstimation);
     }
@@ -104,7 +114,7 @@ class EstimateController extends BaseController
         /** @var CreateEstimateModel $estimateModel */
         $estimateModel = $this->deserializeRequest($request, CreateEstimateModel::class);
 
-        $rideEstimation = $this->createRideEstimate($estimateModel, $ride);
+        [$rideEstimation, $isUpdate] = $this->createOrUpdateRideEstimate($estimateModel, $ride);
 
         if (!$rideEstimation) {
             throw new BadRequestHttpException();
@@ -113,12 +123,19 @@ class EstimateController extends BaseController
         $this->managerRegistry->getManager()->persist($rideEstimation);
         $this->managerRegistry->getManager()->flush();
 
-        $this->eventDispatcher->dispatch(new RideEstimateCreatedEvent($rideEstimation), RideEstimateCreatedEvent::NAME);
+        if ($isUpdate) {
+            $this->eventDispatcher->dispatch(new RideEstimateUpdatedEvent($rideEstimation), RideEstimateUpdatedEvent::NAME);
+        } else {
+            $this->eventDispatcher->dispatch(new RideEstimateCreatedEvent($rideEstimation), RideEstimateCreatedEvent::NAME);
+        }
 
         return $this->createStandardResponse($rideEstimation);
     }
 
-    protected function createRideEstimate(CreateEstimateModel $model, ?Ride $ride = null): ?RideEstimate
+    /**
+     * @return array{0: ?RideEstimate, 1: bool}
+     */
+    protected function createOrUpdateRideEstimate(CreateEstimateModel $model, ?Ride $ride = null): array
     {
         if (!$model->getDateTime()) {
             $model->setDateTime(new \DateTime());
@@ -128,21 +145,37 @@ class EstimateController extends BaseController
             $ride = $this->findNearestRide($model);
 
             if (!$ride) {
-                return null;
+                return [null, false];
             }
         }
 
-        $estimate = new RideEstimate();
+        $isUpdate = false;
+        $estimate = null;
+        $user = $this->security->getUser();
+
+        if ($user instanceof User) {
+            $estimate = $this->rideEstimateRepository->findByUserAndRide($user, $ride);
+        }
+
+        if ($estimate) {
+            $isUpdate = true;
+        } else {
+            $estimate = new RideEstimate();
+            $estimate->setRide($ride);
+
+            if ($user instanceof User) {
+                $estimate->setUser($user);
+            }
+        }
 
         $estimate
             ->setEstimatedParticipants($model->getEstimation())
             ->setLatitude($model->getLatitude())
             ->setLongitude($model->getLongitude())
             ->setDateTime($model->getDateTime())
-            ->setSource($model->getSource())
-            ->setRide($ride);
+            ->setSource($model->getSource());
 
-        return $estimate;
+        return [$estimate, $isUpdate];
     }
 
     protected function findNearestRide(CreateEstimateModel $model): ?Ride

--- a/src/Controller/Ride/RideEstimateController.php
+++ b/src/Controller/Ride/RideEstimateController.php
@@ -4,10 +4,13 @@ namespace App\Controller\Ride;
 
 use App\Criticalmass\Router\ObjectRouterInterface;
 use App\Event\RideEstimate\RideEstimateCreatedEvent;
+use App\Event\RideEstimate\RideEstimateUpdatedEvent;
 use App\Controller\AbstractController;
 use App\Entity\Ride;
 use App\Entity\RideEstimate;
+use App\Entity\User;
 use App\Form\Type\RideEstimateType;
+use App\Repository\RideEstimateRepository;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -26,14 +29,26 @@ class RideEstimateController extends AbstractController
     public function addestimateAction(
         Request $request,
         Ride $ride,
+        RideEstimateRepository $rideEstimateRepository,
         EventDispatcherInterface $eventDispatcher,
         ObjectRouterInterface $objectRouter,
         ?UserInterface $user = null
     ): Response {
-        $rideEstimate = new RideEstimate();
-        $rideEstimate
-            ->setUser($user)
-            ->setRide($ride);
+        $isUpdate = false;
+        $rideEstimate = null;
+
+        if ($user instanceof User) {
+            $rideEstimate = $rideEstimateRepository->findByUserAndRide($user, $ride);
+        }
+
+        if ($rideEstimate) {
+            $isUpdate = true;
+        } else {
+            $rideEstimate = new RideEstimate();
+            $rideEstimate
+                ->setUser($user)
+                ->setRide($ride);
+        }
 
         $estimateForm = $this->createForm(RideEstimateType::class, $rideEstimate, [
             'action' => $objectRouter->generate($ride, 'caldera_criticalmass_ride_addestimate')
@@ -46,7 +61,11 @@ class RideEstimateController extends AbstractController
             $manager->persist($estimateForm->getData());
             $manager->flush();
 
-            $eventDispatcher->dispatch(new RideEstimateCreatedEvent($rideEstimate), RideEstimateCreatedEvent::NAME);
+            if ($isUpdate) {
+                $eventDispatcher->dispatch(new RideEstimateUpdatedEvent($rideEstimate), RideEstimateUpdatedEvent::NAME);
+            } else {
+                $eventDispatcher->dispatch(new RideEstimateCreatedEvent($rideEstimate), RideEstimateCreatedEvent::NAME);
+            }
         }
 
         return $this->redirect($objectRouter->generate($ride));
@@ -60,14 +79,27 @@ class RideEstimateController extends AbstractController
     public function anonymousestimateAction(
         Request $request,
         Ride $ride,
+        RideEstimateRepository $rideEstimateRepository,
         EventDispatcherInterface $eventDispatcher,
         ObjectRouterInterface $objectRouter,
         ?UserInterface $user = null
     ): Response {
-        $rideEstimate = new RideEstimate();
-        $rideEstimate
-            ->setUser($this->getUser())
-            ->setRide($ride);
+        $isUpdate = false;
+        $rideEstimate = null;
+        $currentUser = $this->getUser();
+
+        if ($currentUser instanceof User) {
+            $rideEstimate = $rideEstimateRepository->findByUserAndRide($currentUser, $ride);
+        }
+
+        if ($rideEstimate) {
+            $isUpdate = true;
+        } else {
+            $rideEstimate = new RideEstimate();
+            $rideEstimate
+                ->setUser($currentUser)
+                ->setRide($ride);
+        }
 
         $estimateForm = $this->createForm(RideEstimateType::class, $rideEstimate, [
             'action' => $objectRouter->generate($ride, 'caldera_criticalmass_ride_addestimate_anonymous')
@@ -80,7 +112,11 @@ class RideEstimateController extends AbstractController
             $manager->persist($estimateForm->getData());
             $manager->flush();
 
-            $eventDispatcher->dispatch(new RideEstimateCreatedEvent($rideEstimate), RideEstimateCreatedEvent::NAME);
+            if ($isUpdate) {
+                $eventDispatcher->dispatch(new RideEstimateUpdatedEvent($rideEstimate), RideEstimateUpdatedEvent::NAME);
+            } else {
+                $eventDispatcher->dispatch(new RideEstimateCreatedEvent($rideEstimate), RideEstimateCreatedEvent::NAME);
+            }
 
             return $this->redirect($objectRouter->generate($ride));
         }

--- a/src/Repository/RideEstimateRepository.php
+++ b/src/Repository/RideEstimateRepository.php
@@ -4,6 +4,7 @@ namespace App\Repository;
 
 use App\Entity\Ride;
 use App\Entity\RideEstimate;
+use App\Entity\User;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -52,6 +53,11 @@ class RideEstimateRepository extends ServiceEntityRepository
         $result = $query->getResult();
 
         return $result;
+    }
+
+    public function findByUserAndRide(User $user, Ride $ride): ?RideEstimate
+    {
+        return $this->findOneBy(['user' => $user, 'ride' => $ride]);
     }
 
     public function findByRideAndParticipants(Ride $ride, int $estimatedParticipants): ?RideEstimate


### PR DESCRIPTION
## Summary

- Adds `RideEstimateRepository::findByUserAndRide()` to look up existing estimates by user and ride
- **Web controller** (`RideEstimateController`): Both `addestimateAction` and `anonymousestimateAction` now check for an existing estimate by the current user before creating a new one. If found, the existing estimate is updated instead
- **API controller** (`EstimateController`): Both `createEstimateAction` and `createRideEstimateAction` use the same update-or-create logic
- Dispatches `RideEstimateUpdatedEvent` instead of `RideEstimateCreatedEvent` when updating

Previously, each submission created a new estimate row, causing the same user's multiple estimates to skew the average (e.g. estimating 100 then correcting to 500 resulted in an average of 300 instead of 500).

Closes #745

## Test plan

- [ ] Submit a participant estimate as a logged-in user — verify it is created
- [ ] Submit a second estimate for the same ride as the same user — verify the first estimate is updated (not a new row)
- [ ] Submit estimates as different users — verify they are stored separately
- [ ] Verify anonymous (not logged-in) estimates still create new rows each time
- [ ] Test via API endpoint with authenticated user — same update behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)