### PR TITLE
Separate city statistics chart lines by ride type

### DIFF
--- a/assets/controllers/statistic_city_chart_controller.js
+++ b/assets/controllers/statistic_city_chart_controller.js
@@ -1,6 +1,32 @@
 import { Controller } from '@hotwired/stimulus';
 import Chart from 'chart.js/auto';
 
+const rideTypeColors = {
+    CRITICAL_MASS: 'rgba(255, 0, 0, 1)',
+    KIDICAL_MASS: 'rgba(255, 165, 0, 1)',
+    NIGHT_RIDE: 'rgba(128, 0, 128, 1)',
+    LUNCH_RIDE: 'rgba(0, 128, 0, 1)',
+    DAWN_RIDE: 'rgba(255, 200, 0, 1)',
+    DUSK_RIDE: 'rgba(100, 100, 200, 1)',
+    DEMONSTRATION: 'rgba(200, 50, 50, 1)',
+    ALLEYCAT: 'rgba(0, 200, 200, 1)',
+    TOUR: 'rgba(150, 100, 50, 1)',
+    EVENT: 'rgba(200, 100, 200, 1)',
+};
+
+const rideTypeLabels = {
+    CRITICAL_MASS: 'Critical Mass',
+    KIDICAL_MASS: 'Kidical Mass',
+    NIGHT_RIDE: 'Nightride',
+    LUNCH_RIDE: 'Lunch Ride',
+    DAWN_RIDE: 'Dawn Ride',
+    DUSK_RIDE: 'Dusk Ride',
+    DEMONSTRATION: 'Demonstration',
+    ALLEYCAT: 'Alleycat',
+    TOUR: 'Tour',
+    EVENT: 'Event',
+};
+
 export default class extends Controller {
     static targets = ['canvas', 'rideData'];
 
@@ -15,14 +41,30 @@ export default class extends Controller {
     }
 
     createChart() {
+        const dates = this.collectRideDates();
+        const rideTypes = this.collectRideTypes();
+        const uniqueTypes = [...new Set(rideTypes)];
+
         const datasets = [];
 
-        datasets.push(this.createDataset('Teilnehmer', 'participants', 'rgba(255, 0, 0, 1)', this.collectParticipantsData()));
+        for (const type of uniqueTypes) {
+            const color = rideTypeColors[type] || 'rgba(128, 128, 128, 1)';
+            const label = uniqueTypes.length > 1
+                ? `Teilnehmer — ${rideTypeLabels[type] || type}`
+                : 'Teilnehmer';
+
+            const data = this.rideDataTargets.map((el, i) =>
+                rideTypes[i] === type ? el.dataset.estimatedParticipants : null
+            );
+
+            datasets.push(this.createDataset(label, 'participants', color, data));
+        }
+
         datasets.push(this.createDataset('Fahrtlänge', 'distance', 'rgba(0, 255, 0, 1)', this.collectDistanceData()));
         datasets.push(this.createDataset('Fahrtdauer', 'duration', 'rgba(0, 0, 255, 1)', this.collectDurationData()));
 
         const data = {
-            labels: this.collectRideDates(),
+            labels: dates,
             datasets: datasets
         };
 
@@ -30,6 +72,7 @@ export default class extends Controller {
             type: 'line',
             data: data,
             options: {
+                spanGaps: false,
                 scales: {
                     participants: {
                         type: 'linear',
@@ -75,8 +118,8 @@ export default class extends Controller {
         return this.rideDataTargets.map(el => el.dataset.rideDatetime);
     }
 
-    collectParticipantsData() {
-        return this.rideDataTargets.map(el => el.dataset.estimatedParticipants);
+    collectRideTypes() {
+        return this.rideDataTargets.map(el => el.dataset.rideType || 'CRITICAL_MASS');
     }
 
     collectDurationData() {

--- a/templates/Statistic/city_statistic.html.twig
+++ b/templates/Statistic/city_statistic.html.twig
@@ -54,6 +54,7 @@
                     {% for ride in rides %}
                         <span class="d-none" data-statistic-city-chart-target="rideData"
                               data-ride-datetime="{{ ride.dateTime ? ride.dateTime|date('Y-m-d') : '' }}"
+                              data-ride-type="{{ ride.rideType ? ride.rideType.value : 'CRITICAL_MASS' }}"
                               data-estimated-participants="{{ ride.estimatedParticipants|default(0) }}"
                               data-estimated-duration="{{ ride.estimatedDuration|default(0) }}"
                               data-estimated-distance="{{ ride.estimatedDistance|default(0) }}"></span>


### PR DESCRIPTION
## Summary

- Separate participant chart lines by ride type (Critical Mass, Kidical Mass, Nightride, etc.) on the city statistics page
- Each ride type gets its own colored line, preventing zigzag patterns when different event types with vastly different participant counts alternate
- Distance and duration remain as single combined lines
- Cities with only one ride type display unchanged (label stays "Teilnehmer" without suffix)

Fixes #793

## Test plan

- [ ] Open `/{citySlug}/statistic` for a city with multiple ride types — verify separate colored lines per ride type for participants
- [ ] Open `/{citySlug}/statistic` for a city with only one ride type — verify chart displays as before
- [ ] Verify distance and duration still show as single lines
- [ ] Verify chart legend shows ride type names (e.g. "Teilnehmer — Kidical Mass")

🤖 Generated with [Claude Code](https://claude.com/claude-code)