### PR TITLE
Add city-level iCal calendar feed

### DIFF
--- a/src/Controller/City/CalendarController.php
+++ b/src/Controller/City/CalendarController.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace App\Controller\City;
+
+use App\Controller\AbstractController;
+use App\Criticalmass\Ical\RideIcalGeneratorInterface;
+use App\Entity\City;
+use App\Repository\RideRepository;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+class CalendarController extends AbstractController
+{
+    #[Route('/{citySlug}/ical', name: 'caldera_criticalmass_city_ical', priority: 100)]
+    public function icalAction(
+        RideIcalGeneratorInterface $rideIcalGenerator,
+        RideRepository $rideRepository,
+        City $city
+    ): Response {
+        $rides = $rideRepository->findRidesForCity($city);
+
+        $content = $rideIcalGenerator
+            ->generateForRides($rides)
+            ->getSerializedContent();
+
+        $response = new Response($content);
+
+        $filename = sprintf('%s.ics', $city->getCity());
+
+        $response->headers->set('Cache-Control', 'private');
+        $response->headers->set('Content-type', 'text/calendar');
+        $response->headers->set('Content-Disposition', sprintf('attachment; filename="%s";', $filename));
+        $response->headers->set('Content-length', (string) strlen($content));
+
+        return $response;
+    }
+}

--- a/src/Criticalmass/Ical/RideIcalGenerator.php
+++ b/src/Criticalmass/Ical/RideIcalGenerator.php
@@ -24,14 +24,31 @@ class RideIcalGenerator implements RideIcalGeneratorInterface
 
     public function generateForRide(Ride $ride): RideIcalGenerator
     {
-        $vevent = [];
+        $this->addRideEvent($ride);
+
+        return $this;
+    }
+
+    /** @param Ride[] $rides */
+    public function generateForRides(array $rides): RideIcalGenerator
+    {
+        foreach ($rides as $ride) {
+            $this->addRideEvent($ride);
+        }
+
+        return $this;
+    }
+
+    protected function addRideEvent(Ride $ride): void
+    {
+        $vevent = $this->calendar->add('VEVENT');
 
         if ($ride->getTitle()) {
-            $vevent['SUMMARY'] = $ride->getTitle();
+            $vevent->add('SUMMARY', $ride->getTitle());
         }
 
         if ($ride->getDescription()) {
-            $vevent['DESCRIPTION'] = $ride->getDescription();
+            $vevent->add('DESCRIPTION', $ride->getDescription());
         }
 
         if ($ride->getDateTime()) {
@@ -44,31 +61,23 @@ class RideIcalGenerator implements RideIcalGeneratorInterface
             $endDateTime = clone $ride->getDateTime();
             $endDateTime->setTimezone($timezone)->add($durationInterval);
 
-            $vevent['DTSTART'] = $startDateTime;
-            $vevent['DTEND'] = $endDateTime;
+            $vevent->add('DTSTART', $startDateTime);
+            $vevent->add('DTEND', $endDateTime);
         }
 
         if ($ride->getLocation()) {
-            $vevent['LOCATION'] = $ride->getLocation();
+            $vevent->add('LOCATION', $ride->getLocation());
         }
 
         if ($ride->getLatitude() && $ride->getLongitude()) {
-            $vevent['GEO'] = sprintf('%f;%f', $ride->getLatitude(), $ride->getLongitude());
+            $vevent->add('GEO', sprintf('%f;%f', $ride->getLatitude(), $ride->getLongitude()));
         }
 
         if ($uid = $this->generateUid($ride)) {
-            $vevent['UID'] = $uid;
+            $vevent->add('UID', $uid);
         }
 
-        $vevent['URL'] = $this->objectRouter->generate($ride, null, [], Router::ABSOLUTE_URL);
-
-        $this->calendar->VEVENT = $vevent;
-
-        if (!$uid) {
-            unset($this->calendar->VEVENT->UID);
-        }
-
-        return $this;
+        $vevent->add('URL', $this->objectRouter->generate($ride, null, [], Router::ABSOLUTE_URL));
     }
 
     protected function retrieveTimezone(Ride $ride): \DateTimeZone

--- a/src/Criticalmass/Ical/RideIcalGenerator.php
+++ b/src/Criticalmass/Ical/RideIcalGenerator.php
@@ -74,7 +74,7 @@ class RideIcalGenerator implements RideIcalGeneratorInterface
         }
 
         if ($uid = $this->generateUid($ride)) {
-            $vevent->add('UID', $uid);
+            $vevent->UID = $uid;
         }
 
         $vevent->add('URL', $this->objectRouter->generate($ride, null, [], Router::ABSOLUTE_URL));

--- a/src/Criticalmass/Ical/RideIcalGeneratorInterface.php
+++ b/src/Criticalmass/Ical/RideIcalGeneratorInterface.php
@@ -7,4 +7,9 @@ use App\Entity\Ride;
 interface RideIcalGeneratorInterface
 {
     public function generateForRide(Ride $ride): RideIcalGeneratorInterface;
+
+    /** @param Ride[] $rides */
+    public function generateForRides(array $rides): RideIcalGeneratorInterface;
+
+    public function getSerializedContent(): string;
 }

--- a/tests/IcalGenerator/CityIcalFeedTest.php
+++ b/tests/IcalGenerator/CityIcalFeedTest.php
@@ -1,0 +1,126 @@
+<?php declare(strict_types=1);
+
+namespace Tests\IcalGenerator;
+
+use App\Criticalmass\Ical\RideIcalGenerator;
+use App\Criticalmass\Router\ObjectRouterInterface;
+use App\Entity\City;
+use App\Entity\CitySlug;
+use App\Entity\Ride;
+use PHPUnit\Framework\TestCase;
+use Sabre\VObject\Component\VCalendar;
+
+class CityIcalFeedTest extends TestCase
+{
+    protected function createRideIcalGenerator(): RideIcalGenerator
+    {
+        $calendar = new VCalendar();
+
+        $objectRouter = $this->createMock(ObjectRouterInterface::class);
+        $objectRouter->method('generate')->willReturn('https://criticalmass.in/hamburg/2011-06-24');
+
+        return new RideIcalGenerator($calendar, $objectRouter);
+    }
+
+    protected function createCity(): City
+    {
+        $city = new City();
+        $city
+            ->addSlug(new CitySlug('hamburg'))
+            ->setCity('Hamburg')
+            ->setTimezone('Europe/Berlin');
+
+        return $city;
+    }
+
+    public function testGenerateForMultipleRides(): void
+    {
+        $city = $this->createCity();
+
+        $ride1 = new Ride();
+        $ride1
+            ->setDateTime(new \DateTime('2024-01-26 19:00:00', new \DateTimeZone('Europe/Berlin')))
+            ->setCity($city)
+            ->setTitle('Critical Mass Hamburg Januar 2024');
+
+        $ride2 = new Ride();
+        $ride2
+            ->setDateTime(new \DateTime('2024-02-23 19:00:00', new \DateTimeZone('Europe/Berlin')))
+            ->setCity($city)
+            ->setTitle('Critical Mass Hamburg Februar 2024');
+
+        $rideIcalGenerator = $this->createRideIcalGenerator();
+        $rideIcalGenerator->generateForRides([$ride1, $ride2]);
+
+        $actualContent = $rideIcalGenerator->getSerializedContent();
+
+        $this->assertStringContainsString('BEGIN:VCALENDAR', $actualContent);
+        $this->assertStringContainsString('END:VCALENDAR', $actualContent);
+
+        $this->assertEquals(2, substr_count($actualContent, 'BEGIN:VEVENT'));
+        $this->assertEquals(2, substr_count($actualContent, 'END:VEVENT'));
+
+        $this->assertStringContainsString('SUMMARY:Critical Mass Hamburg Januar 2024', $actualContent);
+        $this->assertStringContainsString('SUMMARY:Critical Mass Hamburg Februar 2024', $actualContent);
+    }
+
+    public function testGenerateForEmptyRideList(): void
+    {
+        $rideIcalGenerator = $this->createRideIcalGenerator();
+        $rideIcalGenerator->generateForRides([]);
+
+        $actualContent = $rideIcalGenerator->getSerializedContent();
+
+        $this->assertStringContainsString('BEGIN:VCALENDAR', $actualContent);
+        $this->assertStringContainsString('END:VCALENDAR', $actualContent);
+        $this->assertStringNotContainsString('BEGIN:VEVENT', $actualContent);
+    }
+
+    public function testMultipleRidesHaveUniqueUids(): void
+    {
+        $city = $this->createCity();
+
+        $ride1 = new Ride();
+        $ride1
+            ->setDateTime(new \DateTime('2024-01-26 19:00:00', new \DateTimeZone('Europe/Berlin')))
+            ->setCity($city);
+
+        $ride2 = new Ride();
+        $ride2
+            ->setDateTime(new \DateTime('2024-02-23 19:00:00', new \DateTimeZone('Europe/Berlin')))
+            ->setCity($city);
+
+        $rideIcalGenerator = $this->createRideIcalGenerator();
+        $rideIcalGenerator->generateForRides([$ride1, $ride2]);
+
+        $actualContent = $rideIcalGenerator->getSerializedContent();
+
+        $this->assertEquals(2, substr_count($actualContent, 'UID:criticalmass-one-hamburg-'));
+
+        preg_match_all('/^UID:(.+)$/m', $actualContent, $matches);
+        $this->assertCount(2, $matches[1]);
+        $this->assertNotEquals(trim($matches[1][0]), trim($matches[1][1]));
+    }
+
+    public function testMultipleRidesContainUrlField(): void
+    {
+        $city = $this->createCity();
+
+        $ride1 = new Ride();
+        $ride1
+            ->setDateTime(new \DateTime('2024-01-26 19:00:00', new \DateTimeZone('Europe/Berlin')))
+            ->setCity($city);
+
+        $ride2 = new Ride();
+        $ride2
+            ->setDateTime(new \DateTime('2024-02-23 19:00:00', new \DateTimeZone('Europe/Berlin')))
+            ->setCity($city);
+
+        $rideIcalGenerator = $this->createRideIcalGenerator();
+        $rideIcalGenerator->generateForRides([$ride1, $ride2]);
+
+        $actualContent = $rideIcalGenerator->getSerializedContent();
+
+        $this->assertEquals(2, substr_count($actualContent, 'URL;VALUE=URI:https://criticalmass.in/hamburg/'));
+    }
+}


### PR DESCRIPTION
## Summary

- Add `/{citySlug}/ical` endpoint that returns an iCal calendar with all rides for a city
- Users can subscribe to this URL in their calendar app (Google Calendar, Apple Calendar, etc.) to get automatic updates for upcoming rides
- Refactor `RideIcalGenerator` to support multiple rides via `generateForRides()` using sabre/vobject's `add()` method
- Fix duplicate UID issue where sabre/vobject auto-generated a UID alongside the custom one

Closes #851

## Test plan

- [ ] Run `vendor/bin/phpunit tests/IcalGenerator/` — all 11 tests pass
- [ ] Open `/{citySlug}/ical` for a city — verify `.ics` file download with multiple VEVENT entries
- [ ] Import the downloaded `.ics` file into a calendar app — verify all rides appear
- [ ] Subscribe to the URL in Google Calendar or Apple Calendar — verify it works as a feed
- [ ] Verify single-ride iCal (`/{citySlug}/{rideIdentifier}/ical`) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)