### PR TITLE
Fix ride generator API serialization

### DIFF
--- a/src/Controller/CityCycle/CityCycleExecuteController.php
+++ b/src/Controller/CityCycle/CityCycleExecuteController.php
@@ -44,6 +44,7 @@ class CityCycleExecuteController extends AbstractController
         $executeable = new CycleExecutable();
         $executeable
             ->setCityCycle($cityCycle)
+            ->setCitySlug($cityCycle->getCity()->getMainSlug()->getSlug())
             ->setFromDate($dateTime->startOfMonth())
             ->setUntilDate((clone $dateTime)->add($sixMonthInterval)->endOfMonth());
 
@@ -52,16 +53,7 @@ class CityCycleExecuteController extends AbstractController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $json = $serializer->serialize($executeable, 'json');
-
-            $response = $this->httpClient->request('POST', $this->rideGeneratorBaseUrl . '/api/preview', [
-                'headers' => ['Content-Type' => 'application/json'],
-                'body' => $json,
-            ]);
-
-            $rideList = $serializer->deserialize($response->getContent(), Ride::class.'[]', 'json', [
-                'groups' => ['api-write'],
-            ]);
+            $rideList = $this->fetchRidePreview($executeable, $serializer);
 
             return $this->render('CityCycle/execute_preview.html.twig', [
                 'cityCycle' => $cityCycle,
@@ -98,18 +90,10 @@ class CityCycleExecuteController extends AbstractController
             $executeable
                 ->setFromDate((new \DateTime())->setTimestamp($request->request->getInt('fromDate')))
                 ->setUntilDate((new \DateTime())->setTimestamp((int) $request->request->get('untilDate')))
-                ->setCityCycle($cityCycle);
+                ->setCityCycle($cityCycle)
+                ->setCitySlug($cityCycle->getCity()->getMainSlug()->getSlug());
 
-            $json = $serializer->serialize($executeable, 'json');
-
-            $response = $this->httpClient->request('POST', $this->rideGeneratorBaseUrl . '/api/preview', [
-                'headers' => ['Content-Type' => 'application/json'],
-                'body' => $json,
-            ]);
-
-            $rideList = $serializer->deserialize($response->getContent(), Ride::class.'[]', 'json', [
-                'groups' => ['api-write'],
-            ]);
+            $rideList = $this->fetchRidePreview($executeable, $serializer);
 
             $em = $registry->getManager();
 
@@ -141,6 +125,20 @@ class CityCycleExecuteController extends AbstractController
         return $this->redirectToRoute('caldera_criticalmass_citycycle_execute', [
             'citySlug' => $cityCycle->getCity()->getMainSlug()->getSlug(),
             'id' => $cityCycle->getId(),
+        ]);
+    }
+
+    private function fetchRidePreview(CycleExecutable $executeable, SerializerInterface $serializer): array
+    {
+        $json = $serializer->serialize($executeable, 'json');
+
+        $response = $this->httpClient->request('POST', $this->rideGeneratorBaseUrl . '/api/preview', [
+            'headers' => ['Content-Type' => 'application/json'],
+            'body' => $json,
+        ]);
+
+        return $serializer->deserialize($response->getContent(), Ride::class.'[]', 'json', [
+            'groups' => ['api-write'],
         ]);
     }
 }

--- a/src/Model/RideGenerator/CycleExecutable.php
+++ b/src/Model/RideGenerator/CycleExecutable.php
@@ -5,14 +5,17 @@ namespace App\Model\RideGenerator;
 use App\Entity\City;
 use App\Entity\CityCycle;
 use Carbon\Carbon;
+use Symfony\Component\Serializer\Attribute\Ignore;
 use Symfony\Component\Validator\Constraints as Assert;
 
 class CycleExecutable
 {
     protected ?string $citySlug = null;
 
+    #[Ignore]
     protected ?City $city = null;
 
+    #[Ignore]
     protected ?CityCycle $cityCycle = null;
 
     #[Assert\GreaterThanOrEqual('1992-09-01', message: 'Vor September 1992 können keine Touren angelegt werden — das ist übrigens das Datum der allerersten Critical Mass in San Francisco.')]


### PR DESCRIPTION
## Summary
- Add `#[Ignore]` to `city` and `cityCycle` properties in `CycleExecutable` to prevent serializing full Doctrine entity graphs
- Set `citySlug` explicitly from the CityCycle's city before serialization
- Extract `fetchRidePreview()` helper method to reduce duplication in both controller actions

Companion to ride-generator PR criticalmass-one/ride-generator#33, which switched the API to accept camelCase + ISO 8601 dates.

## Test plan
- [ ] Test cycle execute on `/berlin/cycles/7/execute`
- [ ] Verify rides are generated correctly
- [ ] Verify persist action works

🤖 Generated with [Claude Code](https://claude.com/claude-code)