### PR TITLE
Fix TypeError for nullable SocialNetworkProfile

### DIFF
--- a/src/Criticalmass/Timeline/Item/SocialNetworkFeedItemItem.php
+++ b/src/Criticalmass/Timeline/Item/SocialNetworkFeedItemItem.php
@@ -17,7 +17,7 @@ class SocialNetworkFeedItemItem extends AbstractItem
     {
         $this->socialNetworkFeedItem = $socialNetworkFeedItem;
 
-        $this->tabName = $socialNetworkFeedItem->getSocialNetworkProfile()->getNetwork();
+        $this->tabName = $socialNetworkFeedItem->getSocialNetworkProfile()?->getNetwork();
         
         return $this;
     }

--- a/src/Entity/SocialNetworkFeedItem.php
+++ b/src/Entity/SocialNetworkFeedItem.php
@@ -78,7 +78,7 @@ class SocialNetworkFeedItem
         return $this;
     }
 
-    public function getSocialNetworkProfile(): SocialNetworkProfile
+    public function getSocialNetworkProfile(): ?SocialNetworkProfile
     {
         return $this->socialNetworkProfile;
     }

--- a/src/Twig/Extension/SocialNetworkTwigExtension.php
+++ b/src/Twig/Extension/SocialNetworkTwigExtension.php
@@ -59,7 +59,7 @@ class SocialNetworkTwigExtension extends AbstractExtension
     public function networkIcon($param): string
     {
         if ($param instanceof SocialNetworkFeedItem) {
-            $networkIdentifier = $param->getSocialNetworkProfile()->getNetwork();
+            $networkIdentifier = $param->getSocialNetworkProfile()?->getNetwork();
         } elseif ($param instanceof SocialNetworkProfile) {
             $networkIdentifier = $param->getNetwork();
         } elseif (is_string($param)) {


### PR DESCRIPTION
## Summary
- `SocialNetworkFeedItem::getSocialNetworkProfile()` hatte einen non-nullable Return-Type, obwohl die Property nullable ist — das führte zu einem `TypeError` wenn ein FeedItem kein zugehöriges Profile mehr hat (z.B. nach Löschen)
- Return-Type auf `?SocialNetworkProfile` geändert
- Nullsafe-Operator (`?->`) an beiden Aufrufstellen eingesetzt (`SocialNetworkFeedItemItem`, `SocialNetworkTwigExtension`)

## Test plan
- [ ] PHPStan: `vendor/bin/phpstan analyse` ohne Fehler
- [ ] Feed-Items ohne zugehöriges SocialNetworkProfile verursachen keinen TypeError mehr
- [ ] Timeline und Social-Network-Icons funktionieren weiterhin normal für Feed-Items mit Profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)