### PR TITLE
Fix missing Font Awesome brand icons

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -9,3 +9,4 @@ window.bootstrap = bootstrap;
 import '@fortawesome/fontawesome-pro/js/fontawesome';
 import '@fortawesome/fontawesome-pro/js/solid';
 import '@fortawesome/fontawesome-pro/js/regular';
+import '@fortawesome/fontawesome-pro/js/brands';


### PR DESCRIPTION
## Summary
- Add missing `@fortawesome/fontawesome-pro/js/brands` import to `assets/app.js`
- Social network icons (`fab fa-instagram`, `fab fa-twitter`, `fab fa-mastodon`, etc.) were not rendering because only `solid` and `regular` icon sets were imported

## Test plan
- [ ] Run `yarn build` — verify no errors
- [ ] Check any page with social network icons (e.g. `/{citySlug}/socialnetwork/list-items`) — brand icons should now render

🤖 Generated with [Claude Code](https://claude.com/claude-code)