### PR TITLE
Remove Städteliste from breadcrumbs

### DIFF
--- a/templates/City/blocked.html.twig
+++ b/templates/City/blocked.html.twig
@@ -4,7 +4,6 @@
 {% block title %}{{ city.title }}{% endblock %}
 
 {% block breadcrumb %}
-    {{ breadcrumb.item('Städteliste', path('caldera_criticalmass_city_list')) }}
     {{ breadcrumb.active(city.city) }}
 {% endblock %}
 

--- a/templates/City/gallery_list.html.twig
+++ b/templates/City/gallery_list.html.twig
@@ -4,7 +4,6 @@
 {% block title %}Fotos aus {{ city.city }}{% endblock %}
 
 {% block breadcrumb %}
-    {{ breadcrumb.item('Städteliste', path('caldera_criticalmass_city_list')) }}
     {{ breadcrumb.item(city.city, object_path(city)) }}
     {{ breadcrumb.active('Foto-Galerien') }}
 {% endblock %}

--- a/templates/City/missing_stats.html.twig
+++ b/templates/City/missing_stats.html.twig
@@ -4,7 +4,6 @@
 {% block title %}Touren mit fehlenden Statistiken aus {{ city.city }}{% endblock %}
 
 {% block breadcrumb %}
-    {{ breadcrumb.item('Städteliste', path('caldera_criticalmass_city_list')) }}
     {{ breadcrumb.item(city.city, object_path(city)) }}
     {{ breadcrumb.active('Fehlende Statistiken') }}
 {% endblock %}

--- a/templates/City/ride_list.html.twig
+++ b/templates/City/ride_list.html.twig
@@ -4,7 +4,6 @@
 {% block title %}Touren in {{ city.city }}{% endblock %}
 
 {% block breadcrumb %}
-    {{ breadcrumb.item('Städteliste', path('caldera_criticalmass_city_list')) }}
     {{ breadcrumb.item(city.city, object_path(city)) }}
     {{ breadcrumb.active('Tour-Übersicht') }}
 {% endblock %}

--- a/templates/City/show.html.twig
+++ b/templates/City/show.html.twig
@@ -4,7 +4,6 @@
 {% block title %}{{ city.title }}{% endblock %}
 
 {% block breadcrumb %}
-    {{ breadcrumb.item('Städteliste', path('caldera_criticalmass_city_list')) }}
     {{ breadcrumb.active(city.city) }}
 {% endblock %}
 

--- a/templates/City/track_list.html.twig
+++ b/templates/City/track_list.html.twig
@@ -4,7 +4,6 @@
 {% block title %}Tracks aus {{ city.city }}{% endblock %}
 
 {% block breadcrumb %}
-    {{ breadcrumb.item('Städteliste', path('caldera_criticalmass_city_list')) }}
     {{ breadcrumb.item(city.city, object_path(city)) }}
     {{ breadcrumb.active('Track-Übersicht') }}
 {% endblock %}

--- a/templates/Location/show.html.twig
+++ b/templates/Location/show.html.twig
@@ -4,7 +4,6 @@
 {% block title %}Übersicht zum Treffpunkt {{ location.title }} der {{ location.city.title }}{% endblock %}
 
 {% block breadcrumb %}
-    {{ breadcrumb.item('Städteliste', path('caldera_criticalmass_city_list')) }}
     {{ breadcrumb.item(location.city.city, object_path(location.city)) }}
     {% if ride %}
         {{ breadcrumb.item(ride.title, object_path(ride)) }}

--- a/templates/Photo/show.html.twig
+++ b/templates/Photo/show.html.twig
@@ -5,7 +5,6 @@
 {% set next_photo = next_entity(photo) %}
 
 {% block breadcrumb %}
-    {{ breadcrumb.item('Städteliste', path('caldera_criticalmass_city_list')) }}
     {{ breadcrumb.item(city.city, object_path(city)) }}
     {{ breadcrumb.item(ride.title, object_path(ride)) }}
     {{ breadcrumb.item('Fotos', object_path(ride, 'caldera_criticalmass_photo_ride_list')) }}

--- a/templates/PhotoGallery/example_gallery.html.twig
+++ b/templates/PhotoGallery/example_gallery.html.twig
@@ -4,7 +4,6 @@
 {% block title %}Fotogalerie{% endblock %}
 
 {% block breadcrumb %}
-    {{ breadcrumb.item('Städteliste', path('caldera_criticalmass_city_list')) }}
     {{ breadcrumb.active('Fotogalerie') }}
 {% endblock %}
 

--- a/templates/PhotoGallery/gallery_list.html.twig
+++ b/templates/PhotoGallery/gallery_list.html.twig
@@ -6,7 +6,6 @@
 {% block title %}Fotos{% endblock %}
 
 {% block breadcrumb %}
-    {{ breadcrumb.item('Städteliste', path('caldera_criticalmass_city_list')) }}
     {{ breadcrumb.item(ride.city.city, object_path(ride.city)) }}
     {{ breadcrumb.item(ride.title, object_path(ride)) }}
     {{ breadcrumb.active('Fotos') }}

--- a/templates/PhotoManagement/city_gallery.html.twig
+++ b/templates/PhotoManagement/city_gallery.html.twig
@@ -4,7 +4,6 @@
 {% block title %}Fotogalerie{% endblock %}
 
 {% block breadcrumb %}
-    {{ breadcrumb.item('Städteliste', path('caldera_criticalmass_city_list')) }}
     {{ breadcrumb.active('Fotogalerie') }}
 {% endblock %}
 

--- a/templates/PhotoManagement/place.html.twig
+++ b/templates/PhotoManagement/place.html.twig
@@ -7,7 +7,6 @@
 {% block title %}Foto platzieren{% endblock %}
 
 {% block breadcrumb %}
-    {{ breadcrumb.item('Städteliste', path('caldera_criticalmass_city_list')) }}
     {{ breadcrumb.item(photo.ride.city.title, object_path(photo.ride.city)) }}
     {{ breadcrumb.item(photo.ride.title, object_path(photo.ride)) }}
     {{ breadcrumb.active('Foto platzieren') }}

--- a/templates/PhotoManagement/ride_list.html.twig
+++ b/templates/PhotoManagement/ride_list.html.twig
@@ -4,7 +4,6 @@
 {% block title %}Deine Fotos{% endblock %}
 
 {% block breadcrumb %}
-    {{ breadcrumb.item('Städteliste', path('caldera_criticalmass_city_list')) }}
     {{ breadcrumb.item(ride.city.city, object_path(ride.city)) }}
     {{ breadcrumb.item(ride.title, object_path(ride)) }}
     {{ breadcrumb.active('Fotos') }}

--- a/templates/PhotoUpload/legacy.html.twig
+++ b/templates/PhotoUpload/legacy.html.twig
@@ -6,7 +6,6 @@
 {% block title %}Fotos hochladen{% endblock %}
 
 {% block breadcrumb %}
-    {{ breadcrumb.item('Städteliste', path('caldera_criticalmass_city_list')) }}
     {{ breadcrumb.item(city.title, object_path(city)) }}
     {{ breadcrumb.item(ride.title, object_path(ride)) }}
     {{ breadcrumb.active('Fotos hochladen') }}

--- a/templates/PhotoUpload/upload.html.twig
+++ b/templates/PhotoUpload/upload.html.twig
@@ -6,7 +6,6 @@
 {% block title %}Fotos hochladen{% endblock %}
 
 {% block breadcrumb %}
-    {{ breadcrumb.item('Städteliste', path('caldera_criticalmass_city_list')) }}
     {{ breadcrumb.item(city.title, object_path(city)) }}
     {{ breadcrumb.item(ride.title, object_path(ride)) }}
     {{ breadcrumb.active('Fotos hochladen') }}

--- a/templates/Ride/blocked.html.twig
+++ b/templates/Ride/blocked.html.twig
@@ -4,7 +4,6 @@
 {% block title %}{{ ride.title }}{% endblock %}
 
 {% block breadcrumb %}
-    {{ breadcrumb.item('Städteliste', path('caldera_criticalmass_city_list')) }}
     {{ breadcrumb.item(ride.city.city, object_path(ride.city)) }}
     {{ breadcrumb.active(ride.title) }}
 {% endblock %}

--- a/templates/Ride/show.html.twig
+++ b/templates/Ride/show.html.twig
@@ -4,7 +4,6 @@
 {% block title %}{{ ride.title }}{% endblock %}
 
 {% block breadcrumb %}
-    {{ breadcrumb.item('Städteliste', path('caldera_criticalmass_city_list')) }}
     {{ breadcrumb.item(city.city, object_path(city)) }}
     {{ breadcrumb.active(ride.title) }}
 {% endblock %}

--- a/templates/RideManagement/edit.html.twig
+++ b/templates/RideManagement/edit.html.twig
@@ -12,7 +12,6 @@
 {% block title %}{{ title }}{% endblock %}
 
 {% block breadcrumb %}
-    {{ breadcrumb.item('Städteliste', path('caldera_criticalmass_city_list')) }}
     {{ breadcrumb.item(city.city, object_path(city)) }}
     {% if ride %}
         {{ breadcrumb.item(ride.title, object_path(ride)) }}

--- a/templates/RideManagement/social_preview.html.twig
+++ b/templates/RideManagement/social_preview.html.twig
@@ -4,7 +4,6 @@
 {% block title %}Details für soziale Netzwerke{% endblock %}
 
 {% block breadcrumb %}
-    {{ breadcrumb.item('Städteliste', path('caldera_criticalmass_city_list')) }}
     {{ breadcrumb.item(ride.city.city, object_path(ride.city)) }}
     {{ breadcrumb.item(ride.title, object_path(ride)) }}
     {{ breadcrumb.active('Details für soziale Netzwerke') }}

--- a/templates/SocialNetwork/add.html.twig
+++ b/templates/SocialNetwork/add.html.twig
@@ -2,7 +2,6 @@
 {% import 'Template/Macros/breadcrumb.html.twig' as breadcrumb %}
 
 {% block breadcrumb %}
-    {{ breadcrumb.item('Städteliste', path('caldera_criticalmass_city_list')) }}
     {% if profileAbleType == 'city' %}
         {{ breadcrumb.item(profileAble.city, object_path(profileAble)) }}
         {{ breadcrumb.item('Soziale Netzwerke', object_path(profileAble, 'criticalmass_socialnetwork_city_list')) }}

--- a/templates/SocialNetwork/edit.html.twig
+++ b/templates/SocialNetwork/edit.html.twig
@@ -2,7 +2,6 @@
 {% import 'Template/Macros/breadcrumb.html.twig' as breadcrumb %}
 
 {% block breadcrumb %}
-    {{ breadcrumb.item('Städteliste', path('caldera_criticalmass_city_list')) }}
     {% if profileAbleType == 'city' %}
         {{ breadcrumb.item(profileAble.city, object_path(profileAble)) }}
         {{ breadcrumb.item('Soziale Netzwerke', object_path(profileAble, 'criticalmass_socialnetwork_city_list')) }}

--- a/templates/SocialNetwork/list.html.twig
+++ b/templates/SocialNetwork/list.html.twig
@@ -2,7 +2,6 @@
 {% import 'Template/Macros/breadcrumb.html.twig' as breadcrumb %}
 
 {% block breadcrumb %}
-    {{ breadcrumb.item('Städteliste', path('caldera_criticalmass_city_list')) }}
     {% if profileAbleType == 'city' %}
         {{ breadcrumb.item(profileAble.city, object_path(profileAble)) }}
         {{ breadcrumb.active('Soziale Netzwerke') }}

--- a/templates/SocialNetwork/list_city_items.html.twig
+++ b/templates/SocialNetwork/list_city_items.html.twig
@@ -2,7 +2,6 @@
 {% import 'Template/Macros/breadcrumb.html.twig' as breadcrumb %}
 
 {% block breadcrumb %}
-    {{ breadcrumb.item('Städteliste', path('caldera_criticalmass_city_list')) }}
     {{ breadcrumb.item(city.city, object_path(city)) }}
     {{ breadcrumb.active('Soziale Netzwerke') }}
 {% endblock %}

--- a/templates/Statistic/city_statistic.html.twig
+++ b/templates/Statistic/city_statistic.html.twig
@@ -4,7 +4,6 @@
 {% block title %}Statistiken aus {{ city.city }}{% endblock %}
 
 {% block breadcrumb %}
-    {{ breadcrumb.item('Städteliste', path('caldera_criticalmass_city_list')) }}
     {{ breadcrumb.item(city.city, object_path(city)) }}
     {{ breadcrumb.active('Statistiken') }}
 {% endblock %}

--- a/templates/Strava/auth.html.twig
+++ b/templates/Strava/auth.html.twig
@@ -4,7 +4,6 @@
 {% block title %}Verbinde dich mit Strava{% endblock %}
 
 {% block breadcrumb %}
-    {{ breadcrumb.item('Städteliste', path('caldera_criticalmass_city_list')) }}
     {{ breadcrumb.item(ride.city.city, object_path(ride.city)) }}
     {{ breadcrumb.item(ride.title, object_path(ride)) }}
     {{ breadcrumb.active('Track importieren') }}

--- a/templates/Strava/list.html.twig
+++ b/templates/Strava/list.html.twig
@@ -4,7 +4,6 @@
 {% block title %}Track von Strava importieren{% endblock %}
 
 {% block breadcrumb %}
-    {{ breadcrumb.item('Städteliste', path('caldera_criticalmass_city_list')) }}
     {{ breadcrumb.item(ride.city.city, object_path(ride.city)) }}
     {{ breadcrumb.item(ride.title, object_path(ride)) }}
     {{ breadcrumb.active('Track importieren') }}

--- a/templates/Subride/edit.html.twig
+++ b/templates/Subride/edit.html.twig
@@ -10,7 +10,6 @@
 {% block title %}{{ title }}{% endblock %}
 
 {% block breadcrumb %}
-    {{ breadcrumb.item('Städteliste', path('caldera_criticalmass_city_list')) }}
     {{ breadcrumb.item(ride.city.city, object_path(ride.city)) }}
     {{ breadcrumb.item(ride.title, object_path(ride)) }}
     {% if subride %}

--- a/templates/Template/Macros/breadcrumb.html.twig
+++ b/templates/Template/Macros/breadcrumb.html.twig
@@ -5,7 +5,6 @@
     {% import 'Template/Macros/breadcrumb.html.twig' as breadcrumb %}
 
     {% block breadcrumb %}
-        {{ breadcrumb.item('Städteliste', path('caldera_criticalmass_city_list')) }}
         {{ breadcrumb.item(city.city, object_path(city)) }}
         {{ breadcrumb.active(ride.title) }}
     {% endblock %}

--- a/templates/Track/upload.html.twig
+++ b/templates/Track/upload.html.twig
@@ -4,7 +4,6 @@
 {% block title %}Gpx-Datei hochladen{% endblock %}
 
 {% block breadcrumb %}
-    {{ breadcrumb.item('Städteliste', path('caldera_criticalmass_city_list')) }}
     {{ breadcrumb.item(ride.city.city, object_path(ride.city)) }}
     {{ breadcrumb.item(ride.title, object_path(ride)) }}
     {{ breadcrumb.active('Track hochladen') }}


### PR DESCRIPTION
## Summary
- Remove the redundant "Städteliste" breadcrumb item from all 29 templates
- The city list link as first breadcrumb level adds no navigation value

## Test plan
- [ ] Visit any city page (e.g. `/mainz`) — breadcrumb should start with the city name
- [ ] Visit a ride page — breadcrumb should not contain "Städteliste"
- [ ] Visit the city list page itself — "Städteliste" as active breadcrumb remains unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)