### PR TITLE
Fix RegionController: return 404 for unknown region slugs

### DIFF
--- a/src/Controller/RegionController.php
+++ b/src/Controller/RegionController.php
@@ -5,6 +5,7 @@ namespace App\Controller;
 use App\Repository\CityRepository;
 use App\Repository\RegionRepository;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Attribute\Route;
 
 class RegionController extends AbstractController
@@ -30,6 +31,10 @@ class RegionController extends AbstractController
             $region = $regionRepository->findOneBySlug($slug1);
         } else {
             $region = $regionRepository->find(1);
+        }
+
+        if (null === $region) {
+            throw new NotFoundHttpException();
         }
 
         $cities = $cityRepository->findCitiesOfRegion($region);


### PR DESCRIPTION
## Summary

- Adds null-check for `$region` after slug lookup in `RegionController::indexAction()`
- Throws `NotFoundHttpException` (404) instead of passing `null` to `CityRepository::findCitiesOfRegion()`
- Fixes TypeError that occurred when visiting `/world/{slug}` with a non-existent region slug

Fixes #1317

## Test plan

- [ ] Visit `/world/non-existent-slug` and verify a 404 page is returned
- [ ] Visit `/world` and verify the world overview still works
- [ ] Visit `/world/{valid-slug}` and verify region pages still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)