### PR TITLE
Fix RidePhotoCollector: skip photos without ride

### DIFF
--- a/src/Criticalmass/Timeline/Collector/RidePhotoCollector.php
+++ b/src/Criticalmass/Timeline/Collector/RidePhotoCollector.php
@@ -15,6 +15,10 @@ class RidePhotoCollector extends AbstractTimelineCollector
 
         /** @var Photo $photoEntity */
         foreach ($photoEntities as $photoEntity) {
+            if (null === $photoEntity->getRide()) {
+                continue;
+            }
+
             $userKey = $photoEntity->getUser()->getId();
             $rideKey = $photoEntity->getRide()->getId();
             $photoKey = $photoEntity->getId();


### PR DESCRIPTION
## Summary

- Adds null-check for `getRide()` in `RidePhotoCollector::groupEntities()`
- Skips photos without an associated ride instead of calling `getId()` on null
- Prevents `Error: Call to a member function getId() on null` during timeline generation

Fixes #1316

## Test plan

- [ ] Verify timeline page renders without errors
- [ ] Verify photos with valid rides still appear in the timeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)