### PR TITLE
Fix null TypeError in SocialNetworkFeedItemItem tabName

### DIFF
--- a/src/Criticalmass/Timeline/Item/SocialNetworkFeedItemItem.php
+++ b/src/Criticalmass/Timeline/Item/SocialNetworkFeedItemItem.php
@@ -17,7 +17,7 @@ class SocialNetworkFeedItemItem extends AbstractItem
     {
         $this->socialNetworkFeedItem = $socialNetworkFeedItem;
 
-        $this->tabName = $socialNetworkFeedItem->getSocialNetworkProfile()?->getNetwork();
+        $this->tabName = $socialNetworkFeedItem->getSocialNetworkProfile()?->getNetwork() ?? 'standard';
         
         return $this;
     }


### PR DESCRIPTION
## Summary
- Add null coalescing fallback (`?? 'standard'`) to `SocialNetworkFeedItemItem::setSocialNetworkFeedItem()` to prevent TypeError when `getSocialNetworkProfile()` returns null
- The nullsafe operator `?->` propagates null, but `$tabName` is typed as `string` with default value `'standard'` — using the same default as fallback

Fixes #1289

## Test plan
- [ ] Verify PHPStan passes (confirmed locally)
- [ ] Verify timeline rendering works when a `SocialNetworkFeedItem` has no associated `SocialNetworkProfile`
- [ ] Verify timeline rendering still works normally when profile exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)