### PR TITLE
Fix ValueError for invalid RideDisabledReasonEnum values

### DIFF
--- a/migrations/Version20260310120000.php
+++ b/migrations/Version20260310120000.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260310120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Fix typo in ride disabledReason: WRONG_AUTO_GNERATION -> WRONG_AUTO_GENERATION';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("UPDATE ride SET disabledReason = 'WRONG_AUTO_GENERATION' WHERE disabledReason = 'WRONG_AUTO_GNERATION'");
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/src/Entity/Ride.php
+++ b/src/Entity/Ride.php
@@ -882,7 +882,7 @@ class Ride implements ParticipateableInterface, PhotoInterface, RouteableInterfa
 
     public function getDisabledReason(): ?RideDisabledReasonEnum
     {
-        return $this->disabledReason !== null ? RideDisabledReasonEnum::from($this->disabledReason) : null;
+        return $this->disabledReason !== null ? RideDisabledReasonEnum::tryFrom($this->disabledReason) : null;
     }
 
     public function setDisabledReason(?RideDisabledReasonEnum $disabledReason = null): Ride


### PR DESCRIPTION
## Summary
- Use `tryFrom()` instead of `from()` in `Ride::getDisabledReason()` to gracefully handle invalid enum backing values stored in the database
- Add database migration to fix the typo `WRONG_AUTO_GNERATION` -> `WRONG_AUTO_GENERATION` in existing ride records

Fixes #1290

## Test plan
- [ ] Verify rides with correct `disabledReason` values still resolve to the proper enum case
- [ ] Verify rides with the typo `WRONG_AUTO_GNERATION` no longer throw a `ValueError`
- [ ] Run the migration and confirm affected rows are updated
- [ ] Run PHPStan to confirm no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)