### PR TITLE
Fix null pointer on Photo without Ride

### DIFF
--- a/src/Controller/Photo/PhotoController.php
+++ b/src/Controller/Photo/PhotoController.php
@@ -69,27 +69,33 @@ class PhotoController extends AbstractController
     {
         $seoPage->setPreviewPhoto($photo);
 
+        $ride = $photo->getRide();
+
+        if (null === $ride) {
+            return;
+        }
+
         if ($photo->getLocation()) {
             $title = sprintf(
                 'Fotos von der Critical Mass in %s am %s, %s',
-                $photo->getRide()->getCity()->getCity(),
-                $photo->getRide()->getDateTime()->format('d.m.Y'),
+                $ride->getCity()->getCity(),
+                $ride->getDateTime()->format('d.m.Y'),
                 $photo->getLocation()
             );
             $description = sprintf(
                 'Schau dir Fotos von der %s an, aufgenommen am %s',
-                $photo->getRide()->getTitle(),
+                $ride->getTitle(),
                 $photo->getLocation()
             );
         } else {
             $title = sprintf(
                 'Fotos von der Critical Mass in %s am %s',
-                $photo->getRide()->getCity()->getCity(),
-                $photo->getRide()->getDateTime()->format('d.m.Y')
+                $ride->getCity()->getCity(),
+                $ride->getDateTime()->format('d.m.Y')
             );
             $description = sprintf(
                 'Schau dir Fotos von der %s an',
-                $photo->getRide()->getTitle()
+                $ride->getTitle()
             );
         }
 

--- a/src/Controller/Photo/PhotoGalleryController.php
+++ b/src/Controller/Photo/PhotoGalleryController.php
@@ -74,6 +74,10 @@ class PhotoGalleryController extends AbstractController
 
         /** @var Photo $photo */
         foreach ($photos as $photo) {
+            if (null === $photo->getRide()) {
+                continue;
+            }
+
             /** @var City $city */
             $city = $photo->getRide()->getCity();
             $citySlug = $city->getSlug();


### PR DESCRIPTION
## Summary
- Add null check for `Photo::getRide()` in `PhotoController::setSeoMetaDetails()` with early return when ride is null
- Add null check for `Photo::getRide()` in `PhotoGalleryController::examplegalleryAction()` with `continue` to skip photos without a ride
- Prevents `Call to a member function on null` errors when photos exist without an associated ride

Fixes #1294

## Test plan
- [ ] Verify photos with an associated ride still display correct SEO metadata
- [ ] Verify photos without an associated ride do not cause a 500 error
- [ ] Verify the example gallery page handles photos without rides gracefully
- [ ] Run PHPStan to confirm no new static analysis errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)