### PR TITLE
Fix undefined array key 'state' in NominatimCityBridge

### DIFF
--- a/src/Criticalmass/OpenStreetMap/NominatimCityBridge/NominatimCityBridge.php
+++ b/src/Criticalmass/OpenStreetMap/NominatimCityBridge/NominatimCityBridge.php
@@ -35,7 +35,8 @@ class NominatimCityBridge extends AbstractNominatimCityBridge
 
     protected function createCity(array $result): ?City
     {
-        $region = $this->doctrine->getRepository(Region::class)->findOneByName($result['address']['state']);
+        $state = $result['address']['state'] ?? null;
+        $region = $state !== null ? $this->doctrine->getRepository(Region::class)->findOneByName($state) : null;
 
         $cityName = $this->getCityNameFromResult($result);
 


### PR DESCRIPTION
## Summary
- Use null coalescing operator to safely access `$result['address']['state']` in `NominatimCityBridge::createCity()`
- Prevents `Undefined array key 'state'` error when Nominatim results lack a state field
- Returns `null` for region when state is missing, which is already handled by the existing null check

Fixes #1297

## Test plan
- [ ] Verify PHPStan passes on `src/Criticalmass/OpenStreetMap/NominatimCityBridge/NominatimCityBridge.php`
- [ ] Test city lookup with a location that has no state in the Nominatim response (e.g. city-states or non-US locations)
- [ ] Test city lookup with a location that has a state to confirm existing behavior is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)