### PR TITLE
Fix Track entity: implement OrderedEntityInterface

### DIFF
--- a/src/Entity/Track.php
+++ b/src/Entity/Track.php
@@ -8,6 +8,8 @@ use App\Criticalmass\Router\Attribute as Routing;
 use App\Criticalmass\UploadableDataHandler\UploadableEntity;
 use App\Criticalmass\UploadFaker\FakeUploadable;
 use App\EntityInterface\RouteableInterface;
+use MalteHuebner\OrderedEntitiesBundle\OrderedEntityInterface;
+use MalteHuebner\OrderedEntitiesBundle\Attribute as OE;
 use App\Enum\PolylineResolution;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
@@ -25,7 +27,7 @@ use Vich\UploaderBundle\Mapping\Attribute as Vich;
 #[ORM\Table(name: 'track')]
 #[ORM\Entity(repositoryClass: 'App\Repository\TrackRepository')]
 #[ORM\Index(fields: ['creationDateTime'], name: 'track_creation_date_time_index')]
-class Track extends GeoTrack implements RouteableInterface, TrackInterface, UploadableEntity, FakeUploadable
+class Track extends GeoTrack implements RouteableInterface, TrackInterface, UploadableEntity, FakeUploadable, OrderedEntityInterface
 {
     const TRACK_SOURCE_GPX = 'TRACK_SOURCE_GPX';
     const TRACK_SOURCE_STRAVA = 'TRACK_SOURCE_STRAVA';
@@ -46,6 +48,7 @@ class Track extends GeoTrack implements RouteableInterface, TrackInterface, Uplo
     #[Groups(['timelapse', 'api-private'])]
     protected ?string $username = null;
 
+    #[OE\Identical]
     #[ORM\ManyToOne(targetEntity: 'Ride', inversedBy: 'tracks')]
     #[ORM\JoinColumn(name: 'ride_id', referencedColumnName: 'id')]
     #[Ignore]
@@ -60,6 +63,7 @@ class Track extends GeoTrack implements RouteableInterface, TrackInterface, Uplo
     #[Ignore]
     protected ?RideEstimate $rideEstimate = null;
 
+    #[OE\Order(direction: 'DESC')]
     #[DataQuery\Sortable]
     #[ORM\Column(type: 'datetime', nullable: true)]
     #[Groups(['timelapse', 'api-public'])]
@@ -95,6 +99,7 @@ class Track extends GeoTrack implements RouteableInterface, TrackInterface, Uplo
     protected ?int $endPoint = null;
 
 
+    #[OE\Boolean(value: true)]
     #[DataQuery\DefaultBooleanValue(value: true)]
     #[ORM\Column(type: 'boolean', nullable: true)]
     #[Ignore]


### PR DESCRIPTION
## Summary
- Track entity now implements `OrderedEntityInterface` from OrderedEntitiesBundle
- Added `#[OE\Order(direction: 'DESC')]` on `$creationDateTime` for ordering
- Added `#[OE\Identical]` on `$ride` to scope ordering within the same ride
- Added `#[OE\Boolean(value: true)]` on `$enabled` to filter only enabled tracks
- Follows the same pattern used by `Ride` and `Photo` entities

Fixes #1291

## Test plan
- [ ] Verify `previous_entity(track)` and `next_entity(track)` Twig calls no longer throw TypeError
- [ ] Verify track navigation links work correctly on the track detail page
- [ ] Run PHPStan to confirm no static analysis errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)