### PR TITLE
Fix NonUniqueResultException in RideRepository

### DIFF
--- a/src/Repository/RideRepository.php
+++ b/src/Repository/RideRepository.php
@@ -181,7 +181,8 @@ class RideRepository extends ServiceEntityRepository
             ->where($builder->expr()->eq('r.city', ':city'))
             ->andWhere($builder->expr()->eq('r.slug', ':slug'))
             ->setParameter('city', $city)
-            ->setParameter('slug', $slug);
+            ->setParameter('slug', $slug)
+            ->setMaxResults(1);
 
         $query = $builder->getQuery();
 
@@ -199,7 +200,8 @@ class RideRepository extends ServiceEntityRepository
             ->where($builder->expr()->eq('cs.slug', ':citySlug'))
             ->andWhere($builder->expr()->eq('r.slug', ':rideSlug'))
             ->setParameter('citySlug', $citySlug)
-            ->setParameter('rideSlug', $rideSlug);
+            ->setParameter('rideSlug', $rideSlug)
+            ->setMaxResults(1);
 
         $query = $builder->getQuery();
 
@@ -338,7 +340,8 @@ class RideRepository extends ServiceEntityRepository
             ->andWhere($builder->expr()->lt('r.dateTime', ':untilDateTime'))
             ->setParameter('citySlug', $citySlug)
             ->setParameter('fromDateTime', $fromDateTime)
-            ->setParameter('untilDateTime', $untilDateTime);
+            ->setParameter('untilDateTime', $untilDateTime)
+            ->setMaxResults(1);
 
         $query = $builder->getQuery();
 


### PR DESCRIPTION
## Summary
- Add `setMaxResults(1)` to `findOneByCityAndSlug()` query builder to prevent NonUniqueResultException
- Add `setMaxResults(1)` to `findOneByCitySlugAndSlug()` query builder to prevent NonUniqueResultException
- Add `setMaxResults(1)` to `findByCitySlugAndRideDate()` query builder to prevent NonUniqueResultException

Fixes #1293

## Test plan
- [ ] Verify PHPStan passes without new errors
- [ ] Verify queries using `getOneOrNullResult()` no longer throw `NonUniqueResultException` when duplicate data exists
- [ ] Verify ride detail pages still load correctly via city+slug and city+date URL patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)