### PR TITLE
Fix ride location column length: VARCHAR(255) to 512

### DIFF
--- a/migrations/Version20260310130000.php
+++ b/migrations/Version20260310130000.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260310130000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Increase ride location column length from 255 to 512';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE ride MODIFY location VARCHAR(512) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE ride MODIFY location VARCHAR(255) DEFAULT NULL');
+    }
+}

--- a/src/Entity/Ride.php
+++ b/src/Entity/Ride.php
@@ -101,7 +101,7 @@ class Ride implements ParticipateableInterface, PhotoInterface, RouteableInterfa
 
     #[DataQuery\Sortable]
     #[DataQuery\Queryable]
-    #[ORM\Column(type: 'string', length: 255, nullable: true)]
+    #[ORM\Column(type: 'string', length: 512, nullable: true)]
     #[Groups(['ride-list', 'ride-details', 'api-write'])]
     protected ?string $location = null;
 


### PR DESCRIPTION
## Summary

- Increase `location` column length in Ride entity from VARCHAR(255) to VARCHAR(512)
- Add database migration to alter the ride table column

Fixes #1295

## Test plan

- [ ] Run migration on staging and confirm column type is updated
- [ ] Test saving a ride with a location string longer than 255 characters

🤖 Generated with [Claude Code](https://claude.com/claude-code)