### PR TITLE
Fix return type of getPreviousRideWithSubrides()

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3933,12 +3933,6 @@ parameters:
 			path: src/Repository/RideRepository.php
 
 		-
-			message: '#^Method App\\Repository\\RideRepository\:\:getPreviousRideWithSubrides\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Repository/RideRepository.php
-
-		-
 			message: '#^Method App\\Repository\\RideRepository\:\:searchByQuery\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1

--- a/src/Repository/RideRepository.php
+++ b/src/Repository/RideRepository.php
@@ -345,7 +345,7 @@ class RideRepository extends ServiceEntityRepository
         return $query->getOneOrNullResult();
     }
 
-    public function getPreviousRideWithSubrides(Ride $ride): array
+    public function getPreviousRideWithSubrides(Ride $ride): ?Ride
     {
         $builder = $this->createQueryBuilder('r');
 
@@ -361,9 +361,7 @@ class RideRepository extends ServiceEntityRepository
 
         $query = $builder->getQuery();
 
-        $result = $query->getOneOrNullResult();
-
-        return $result;
+        return $query->getOneOrNullResult();
     }
 
     public function getLocationsForCity(City $city): array


### PR DESCRIPTION
## Summary

- Change return type of `RideRepository::getPreviousRideWithSubrides()` from `array` to `?Ride`
- Method uses `getOneOrNullResult()` which returns a single entity or null, not an array
- Remove related PHPStan baseline entry

Fixes #1303

## Test plan

- [ ] Verify subride copy page still works correctly
- [ ] PHPStan passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)