### PR TITLE
Sanitize Content-Disposition header filenames

### DIFF
--- a/src/Controller/Photo/PhotoDownloadController.php
+++ b/src/Controller/Photo/PhotoDownloadController.php
@@ -35,11 +35,11 @@ class PhotoDownloadController extends AbstractController
 
         $response = new BinaryFileResponse($filename);
 
-        $downloadFilename = sprintf(
+        $downloadFilename = str_replace(["\r", "\n"], ' ', sprintf(
             'criticalmass_%s_%s.jpg',
             $photo->getCity()->getMainSlugString(),
             $photo->getRide()->getDateTime()->format('Y-m-d')
-        );
+        ));
 
         $response->setContentDisposition(
             ResponseHeaderBag::DISPOSITION_ATTACHMENT,

--- a/src/Controller/Ride/CalendarController.php
+++ b/src/Controller/Ride/CalendarController.php
@@ -25,7 +25,7 @@ class CalendarController extends AbstractController
 
         $response = new Response($content);
 
-        $filename = sprintf('%s.ics', $ride->getTitle());
+        $filename = sprintf('%s.ics', str_replace(["\r", "\n"], ' ', $ride->getTitle()));
 
         $response->headers->set('Cache-Control', 'private');
         $response->headers->set('Content-type', 'text/calendar');

--- a/src/Controller/Track/TrackDownloadController.php
+++ b/src/Controller/Track/TrackDownloadController.php
@@ -39,7 +39,7 @@ class TrackDownloadController extends AbstractController
             $track->getRide()->getDateTime()->format('Y-m-d')
         );
 
-        return sprintf('%s.gpx', $filename);
+        return str_replace(["\r", "\n"], ' ', sprintf('%s.gpx', $filename));
     }
 
     protected function getTrackFilename(Track $track, UploaderHelper $uploaderHelper): string


### PR DESCRIPTION
## Summary
- Sanitize filenames in Content-Disposition headers to prevent header injection
- Strip newline characters from entity data used in CalendarController, TrackDownloadController, PhotoDownloadController

Fixes #1306

## Test plan
- [ ] Download ICS calendar file and verify filename is correct
- [ ] Download GPX track file and verify filename is correct
- [ ] Download photo and verify filename is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)