### PR TITLE
Fix CircularReferenceException in City serialization

### DIFF
--- a/src/Entity/CitySlug.php
+++ b/src/Entity/CitySlug.php
@@ -6,6 +6,7 @@ use App\Criticalmass\Router\Attribute as Routing;
 use App\EntityInterface\RouteableInterface;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Serializer\Annotation\Ignore;
 
 #[ORM\Table(name: 'cityslug')]
 #[ORM\Entity(repositoryClass: 'App\Repository\CitySlugRepository')]
@@ -24,6 +25,7 @@ class CitySlug implements RouteableInterface
 
     #[ORM\ManyToOne(targetEntity: 'City', inversedBy: 'slugs', fetch: 'EAGER')]
     #[ORM\JoinColumn(name: 'city_id', referencedColumnName: 'id')]
+    #[Ignore]
     protected ?City $city = null;
 
     public function __construct(?string $slug = null)


### PR DESCRIPTION
## Summary
- Add `#[Ignore]` attribute to `CitySlug::$city` to break circular reference during serialization
- City → CitySlug → City loop caused CircularReferenceException

Fixes #1300

## Test plan
- [ ] Verify City API endpoints return correct JSON without circular reference errors
- [ ] Verify city slugs still work correctly for routing

🤖 Generated with [Claude Code](https://claude.com/claude-code)