### PR TITLE
Add mime type validation for photo uploads

### DIFF
--- a/src/Controller/Photo/PhotoUploadController.php
+++ b/src/Controller/Photo/PhotoUploadController.php
@@ -56,6 +56,12 @@ class PhotoUploadController extends AbstractController
         $uploadedFile = $request->files->get('file');
 
         if ($uploadedFile instanceof UploadedFile) {
+            $allowedMimeTypes = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+
+            if (!in_array($uploadedFile->getMimeType(), $allowedMimeTypes, true)) {
+                return new Response('Invalid file type. Only JPEG, PNG, GIF, and WebP images are allowed.', Response::HTTP_UNPROCESSABLE_ENTITY);
+            }
+
             $photoUploader
                 ->setRide($ride)
                 ->setUser($user)

--- a/src/Criticalmass/Image/PhotoUploader/PhotoUploader.php
+++ b/src/Criticalmass/Image/PhotoUploader/PhotoUploader.php
@@ -87,8 +87,19 @@ class PhotoUploader implements PhotoUploaderInterface
         return $this->addedPhotoList;
     }
 
+    protected function isAllowedMimeType(UploadedFile $uploadedFile): bool
+    {
+        $allowedMimeTypes = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+
+        return in_array($uploadedFile->getMimeType(), $allowedMimeTypes, true);
+    }
+
     protected function createUploadedPhotoEntity(UploadedFile $uploadedFile): Photo
     {
+        if (!$this->isAllowedMimeType($uploadedFile)) {
+            throw new \InvalidArgumentException(sprintf('File type "%s" is not allowed. Only JPEG, PNG, GIF, and WebP images are accepted.', $uploadedFile->getMimeType()));
+        }
+
         $photo = new Photo();
 
         $photo


### PR DESCRIPTION
## Summary
- Add server-side mime type validation for photo uploads
- Reject non-image files (video, HEIC) before they are persisted to the database
- Prevents LiipImagineBundle crashes during thumbnail generation

Fixes #1292

## Test plan
- [ ] Upload a JPEG photo and verify it works
- [ ] Upload a PNG photo and verify it works
- [ ] Attempt to upload a .mp4 file and verify it is rejected
- [ ] Verify existing photos still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)