### PR TITLE
Add cache:warmup to composer auto-scripts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -107,6 +107,7 @@
         ],
         "auto-scripts": {
             "cache:clear": "symfony-cmd",
+            "cache:warmup": "symfony-cmd",
             "assets:install %PUBLIC_DIR%": "symfony-cmd"
         },
         "test:db:reset": [


### PR DESCRIPTION
## Summary
- Add `cache:warmup` to composer auto-scripts to ensure Doctrine proxy files are generated after deployment
- Prevents missing proxy file errors in production

Fixes #1301

## Test plan
- [ ] Run `composer install` and verify cache:warmup executes after cache:clear
- [ ] Verify Doctrine proxy files exist in var/cache/prod/doctrine/orm/Proxies/

🤖 Generated with [Claude Code](https://claude.com/claude-code)