### PR TITLE
Fix untilDateTime condition in RideRepository

### DIFF
--- a/src/Repository/RideRepository.php
+++ b/src/Repository/RideRepository.php
@@ -515,7 +515,7 @@ class RideRepository extends ServiceEntityRepository
                 ->setParameter('fromDateTime', $fromDateTime);
         }
 
-        if ($fromDateTime) {
+        if ($untilDateTime) {
             $builder
                 ->andWhere($builder->expr()->lt('ride.dateTime', ':untilDateTime'))
                 ->setParameter('untilDateTime', $untilDateTime);


### PR DESCRIPTION
## Summary
- Fix bug in `RideRepository::findRides()` where the upper bound date filter checked `$fromDateTime` instead of `$untilDateTime`
- This caused the `untilDateTime` filter to never apply when only `$untilDateTime` was provided, and could crash when `$fromDateTime` was set but `$untilDateTime` was null

## Test plan
- [ ] PHPStan passes
- [ ] PHPUnit passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)