### PR TITLE
Fix extractFilename() in PhotoUploader

### DIFF
--- a/src/Criticalmass/Image/PhotoUploader/PhotoUploader.php
+++ b/src/Criticalmass/Image/PhotoUploader/PhotoUploader.php
@@ -141,6 +141,6 @@ class PhotoUploader implements PhotoUploaderInterface
     {
         $filenameParts = explode('/', $sourceFilename);
 
-        return array_shift($filenameParts);
+        return array_pop($filenameParts);
     }
 }


### PR DESCRIPTION
## Summary
- Fix `extractFilename()` in `PhotoUploader` using `array_shift()` instead of `array_pop()`
- `array_shift()` returns the first path segment (empty string for absolute paths like `/path/to/photo.jpg`), not the actual filename
- `array_pop()` correctly returns the last segment, i.e. the filename

## Test plan
- [ ] PHPStan passes
- [ ] PHPUnit passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)