### PR TITLE
Fix migration: convert disabledReason ENUM to VARCHAR

### DIFF
--- a/migrations/Version20260310120000.php
+++ b/migrations/Version20260310120000.php
@@ -9,11 +9,12 @@ final class Version20260310120000 extends AbstractMigration
 {
     public function getDescription(): string
     {
-        return 'Fix typo in ride disabledReason: WRONG_AUTO_GNERATION -> WRONG_AUTO_GENERATION';
+        return 'Convert disabledReason from ENUM to VARCHAR and fix typo WRONG_AUTO_GNERATION -> WRONG_AUTO_GENERATION';
     }
 
     public function up(Schema $schema): void
     {
+        $this->addSql("ALTER TABLE ride MODIFY disabledReason VARCHAR(255) DEFAULT NULL");
         $this->addSql("UPDATE ride SET disabledReason = 'WRONG_AUTO_GENERATION' WHERE disabledReason = 'WRONG_AUTO_GNERATION'");
     }
 


### PR DESCRIPTION
## Summary
- The `disabledReason` column in the `ride` table was still an ENUM in the database
- Migration `Version20260310120000` tried to UPDATE the value to `WRONG_AUTO_GENERATION`, but this value wasn't in the old ENUM definition, causing: `SQLSTATE[01000]: Warning: 1265 Data truncated for column 'disabledReason' at row 314`
- Fix: convert the column to `VARCHAR(255)` first (matching the entity mapping), then update the data

## Test plan
- [ ] PHPStan passes
- [ ] PHPUnit passes
- [ ] Migration runs without errors on production database

🤖 Generated with [Claude Code](https://claude.com/claude-code)