### PR TITLE
Fix UserProvider nickname null safety

### DIFF
--- a/src/Security/UserProvider/UserProvider.php
+++ b/src/Security/UserProvider/UserProvider.php
@@ -128,7 +128,7 @@ class UserProvider implements UserProviderInterface, OAuthAwareUserProviderInter
 
         $nickname = $response->getNickname();
 
-        if ($nickname !== '') {
+        if (!empty($nickname)) {
             $user->setUsername($nickname);
         }
 


### PR DESCRIPTION
## Summary
- Use `!empty()` instead of `!== ''` for nickname check in `UserProvider::createUser()`
- `getNickname()` may return null in practice, and `null !== ''` would evaluate to true, passing null to `setUsername()`

## Test plan
- [ ] PHPStan passes
- [ ] PHPUnit passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)