### PR TITLE
Block Nominatim lookups for invalid city slugs

### DIFF
--- a/src/Controller/City/CityController.php
+++ b/src/Controller/City/CityController.php
@@ -75,7 +75,7 @@ class CityController extends AbstractController
         if (!$city) {
             $citySlug = $request->get('citySlug');
 
-            if (!$citySlug) {
+            if (!$citySlug || str_contains($citySlug, '.')) {
                 throw $this->createNotFoundException('City not found');
             }
 


### PR DESCRIPTION
## Summary
- Bots requesting `/robots.txt`, `/favicon.ico`, `/euhpb.php` etc. hit the catch-all `/{citySlug}` route
- When no city is found, `MissingCityController` calls Nominatim to look up the "city" — causing 429 rate limits
- Fix: reject slugs containing dots (`.`) early with a 404, since valid city slugs never contain dots

## Test plan
- [ ] PHPStan passes
- [ ] PHPUnit passes
- [ ] `/robots.txt` returns 404 without Nominatim call
- [ ] `/hamburg` still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)