### PR TITLE
Show city on map when ride has no meeting point

### DIFF
--- a/assets/controllers/map/ride_map_controller.js
+++ b/assets/controllers/map/ride_map_controller.js
@@ -12,7 +12,8 @@ export default class extends BaseMapController {
         citySlug: String,
         rideIdentifier: String,
         latitude: Number,
-        longitude: Number
+        longitude: Number,
+        hasLocation: { type: Boolean, default: true }
     };
 
     async connect() {
@@ -26,10 +27,12 @@ export default class extends BaseMapController {
 
         this.map.setView(
             [this.latitudeValue, this.longitudeValue],
-            14
+            this.hasLocationValue ? 14 : 12
         );
 
-        this.addLocationMarker();
+        if (this.hasLocationValue) {
+            this.addLocationMarker();
+        }
 
         const trackLayer = await this.loadTracks();
         this.loadPhotos();

--- a/templates/Ride/Ride.html.twig
+++ b/templates/Ride/Ride.html.twig
@@ -39,8 +39,15 @@
                     style="min-height: 300px;"
                     data-map--ride-map-city-slug-value="{{ ride.city.mainSlugString }}"
                     data-map--ride-map-ride-identifier-value="{{ ride.slug|default(ride.dateTime|date('Y-m-d')) }}"
-                    data-map--ride-map-latitude-value="{{ ride.latitude }}"
-                    data-map--ride-map-longitude-value="{{ ride.longitude }}"
+                    {% if ride.latitude and ride.longitude %}
+                        data-map--ride-map-latitude-value="{{ ride.latitude }}"
+                        data-map--ride-map-longitude-value="{{ ride.longitude }}"
+                        data-map--ride-map-has-location-value="true"
+                    {% else %}
+                        data-map--ride-map-latitude-value="{{ ride.city.latitude }}"
+                        data-map--ride-map-longitude-value="{{ ride.city.longitude }}"
+                        data-map--ride-map-has-location-value="false"
+                    {% endif %}
                 ></div>
                 <button type="button" class="btn btn-light btn-sm position-absolute top-0 end-0 m-2 shadow" style="z-index: 1000;" data-action="map-expand#toggle" title="Karte vergrößern">
                     <i class="far fa-expand" data-map-expand-target="icon"></i>


### PR DESCRIPTION
## Summary
- When a ride has no known meeting point (latitude/longitude are 0), the map showed a marker at coordinates 0,0 in the ocean
- Now falls back to the city's coordinates with a lower zoom level (12 instead of 14) and no marker
- Template checks `ride.latitude`/`ride.longitude` and passes city coordinates + `hasLocation=false` as fallback

## Test plan
- [ ] PHPStan passes
- [ ] PHPUnit passes
- [ ] Ride with known location still shows marker at correct position
- [ ] Ride without location (e.g. `/hannover/2026-05-08`) shows city area without marker

🤖 Generated with [Claude Code](https://claude.com/claude-code)