### PR TITLE
Remove references to criticalmass.live from static pages

### DIFF
--- a/templates/Static/critical-maps.html.twig
+++ b/templates/Static/critical-maps.html.twig
@@ -14,13 +14,8 @@
                         </h1>
 
                         <p class="text-muted mb-4">
-                            Wenn du diese Seite siehst, bist du vermutlich einen veralteten Link gefolgt &mdash; bitte besuche
-                            criticalmass.live für weitere Informationen zum Live-Tracking.
+                            Wenn du diese Seite siehst, bist du vermutlich einen veralteten Link gefolgt.
                         </p>
-
-                        <a href="https://criticalmass.live/" class="btn btn-primary">
-                            <i class="far fa-external-link-alt me-1"></i>criticalmass.live
-                        </a>
                     </div>
                 </div>
             </div>

--- a/templates/Static/glympse.html.twig
+++ b/templates/Static/glympse.html.twig
@@ -14,13 +14,8 @@
                         </h1>
 
                         <p class="text-muted mb-4">
-                            Wenn du diese Seite siehst, bist du vermutlich einen veralteten Link gefolgt &mdash; bitte besuche
-                            criticalmass.live für weitere Informationen zum Live-Tracking.
+                            Wenn du diese Seite siehst, bist du vermutlich einen veralteten Link gefolgt.
                         </p>
-
-                        <a href="https://criticalmass.live/" class="btn btn-primary">
-                            <i class="far fa-external-link-alt me-1"></i>criticalmass.live
-                        </a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- Drop the `criticalmass.live` mention and external link button from `templates/Static/glympse.html.twig` and `templates/Static/critical-maps.html.twig`
- Both fallback pages now just inform visitors that they followed an outdated link, without pointing to a third-party domain

## Test plan
- [ ] Visit `/glympse` and `/critical-maps` and confirm no `criticalmass.live` text or button is rendered
- [ ] CI (PHPStan + PHPUnit) is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)