### PR TITLE
Register BackedEnumNormalizer to enable enum fields in API write endpoints

### DIFF
--- a/src/Serializer/CriticalSerializer.php
+++ b/src/Serializer/CriticalSerializer.php
@@ -11,6 +11,7 @@ use Symfony\Component\Serializer\NameConverter\MetadataAwareNameConverter;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
+use Symfony\Component\Serializer\Normalizer\BackedEnumNormalizer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
@@ -79,6 +80,7 @@ class CriticalSerializer implements CriticalSerializerInterface
 
         $normalizers = [
             new UnixTimestampDateTimeNormalizer(),
+            new BackedEnumNormalizer(),
             new ObjectNormalizer(
                 classMetadataFactory: $classMetadataFactory,
                 nameConverter: $nameConverter,

--- a/tests/Controller/Api/RideApi/RideApiWriteTest.php
+++ b/tests/Controller/Api/RideApi/RideApiWriteTest.php
@@ -300,4 +300,77 @@ class RideApiWriteTest extends AbstractApiControllerTestCase
         $this->assertIsArray($response);
         $this->assertEquals('Second Slug Event', $response['title']);
     }
+
+    #[TestDox('PUT /api/{citySlug}/{rideIdentifier} accepts ride_type and persists it')]
+    public function testCreateRideWithRideTypeIsPersisted(): void
+    {
+        $cities = $this->entityManager->getRepository(City::class)->findAll();
+        $this->assertNotEmpty($cities);
+
+        $city = $cities[0];
+        $citySlug = $city->getMainSlugString();
+
+        $randomDays = random_int(10951, 14600); // 30-40 years in the future to avoid conflicts
+        $futureDate = (new \DateTime())->modify("+$randomDays days")->format('Y-m-d');
+
+        $rideData = [
+            'title' => 'Test Ride with rideType',
+            'date_time' => (new \DateTime($futureDate . ' 19:00:00'))->getTimestamp(),
+            'ride_type' => 'TOUR',
+        ];
+
+        $this->client->request(
+            'PUT',
+            sprintf('/api/%s/%s', $citySlug, $futureDate),
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            json_encode($rideData)
+        );
+
+        $this->assertResponseIsSuccessful();
+
+        $response = $this->getJsonResponse();
+        $this->assertArrayHasKey('id', $response);
+        $this->assertSame('TOUR', $response['ride_type']);
+
+        $persistedRide = $this->entityManager->getRepository(Ride::class)->find($response['id']);
+        $this->assertNotNull($persistedRide);
+        $this->assertSame('TOUR', $persistedRide->getRideType()?->value);
+    }
+
+    #[TestDox('POST /api/{citySlug}/{rideIdentifier} updates ride_type on existing ride')]
+    public function testUpdateRideTypeOnExistingRide(): void
+    {
+        $rides = $this->entityManager->getRepository(Ride::class)->findAll();
+        $this->assertNotEmpty($rides);
+
+        $ride = $rides[0];
+        $rideId = $ride->getId();
+        $citySlug = $ride->getCity()->getMainSlugString();
+        $dateString = $ride->getDateTime()->format('Y-m-d');
+
+        $updateData = [
+            'ride_type' => 'KIDICAL_MASS',
+        ];
+
+        $this->client->request(
+            'POST',
+            sprintf('/api/%s/%s', $citySlug, $dateString),
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            json_encode($updateData)
+        );
+
+        $this->assertResponseIsSuccessful();
+
+        $response = $this->getJsonResponse();
+        $this->assertSame('KIDICAL_MASS', $response['ride_type']);
+
+        $this->entityManager->clear();
+        $persistedRide = $this->entityManager->getRepository(Ride::class)->find($rideId);
+        $this->assertNotNull($persistedRide);
+        $this->assertSame('KIDICAL_MASS', $persistedRide->getRideType()?->value);
+    }
 }


### PR DESCRIPTION
## Summary
- The custom `CriticalSerializer` did not register Symfony's `BackedEnumNormalizer`, so API PUT/POST requests with backed enum fields (e.g. `ride_type`, `disabled_reason`, `resolution`) failed with `NotNormalizableValueException: Failed to create object because the class "App\Enum\RideTypeEnum" is not instantiable.`
- Add `BackedEnumNormalizer` to the normalizer chain before `ObjectNormalizer` so any backed enum setter (typed `?MyEnum`) can be hydrated from its string value.
- Affects setters: `Ride::setRideType()`, `Ride::setDisabledReason()`, `TrackPolyline::setResolution()`.
- Add two integration tests covering create/update of `ride_type` via the Ride API.

## Test plan
- [x] `vendor/bin/phpunit tests/Controller/Api/RideApi/RideApiWriteTest.php` (11 tests, 42 assertions, all green)
- [x] `vendor/bin/phpunit tests/Controller/Api/` (no new failures vs main; 3 previously failing tests pass with the fix)
- [x] `vendor/bin/phpstan analyse` (no new errors)
- [x] Manual verification: `{"ride_type":"TOUR"}` is now accepted and persisted; invalid values like `"tour"` produce a clear `NotNormalizableValueException: The data must belong to a backed enumeration of type App\Enum\RideTypeEnum`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)