### PR TITLE
Fix ride/photo pagination jumping to wrong city

### DIFF
--- a/src/Entity/Photo.php
+++ b/src/Entity/Photo.php
@@ -11,7 +11,7 @@ use App\EntityInterface\CoordinateInterface;
 use App\EntityInterface\PhotoInterface;
 use App\EntityInterface\PostableInterface;
 use App\EntityInterface\RouteableInterface;
-use MalteHuebner\OrderedEntitiesBundle\Annotation as OE;
+use MalteHuebner\OrderedEntitiesBundle\Attribute as OE;
 use MalteHuebner\OrderedEntitiesBundle\OrderedEntityInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
@@ -43,6 +43,7 @@ class Photo implements FakeUploadable, ManipulateablePhotoInterface, RouteableIn
     #[Ignore]
     protected ?User $user = null;
 
+    #[OE\Identical]
     #[DataQuery\Queryable]
     #[Routing\RouteParameter(name: 'rideIdentifier')]
     #[ORM\ManyToOne(targetEntity: 'Ride', inversedBy: 'photos')]
@@ -74,11 +75,13 @@ class Photo implements FakeUploadable, ManipulateablePhotoInterface, RouteableIn
     #[Groups(['photo-details'])]
     protected ?string $description = null;
 
+    #[OE\Boolean(value: true)]
     #[DataQuery\DefaultBooleanValue(alias: 'isEnabled', value: true)]
     #[ORM\Column(type: 'boolean')]
     #[Ignore]
     protected bool $enabled = true;
 
+    #[OE\Boolean(value: false)]
     #[DataQuery\DefaultBooleanValue(alias: 'isDeleted', value: false)]
     #[ORM\Column(type: 'boolean')]
     #[Ignore]
@@ -161,6 +164,7 @@ class Photo implements FakeUploadable, ManipulateablePhotoInterface, RouteableIn
     #[Groups(['photo-details'])]
     protected ?string $exifCamera = null;
 
+    #[OE\Order(direction: 'ASC')]
     #[DataQuery\DateTimeQueryable(format: 'strict_date_hour_minute_second', pattern: 'Y-m-d\TH:i:s')]
     #[DataQuery\Sortable]
     #[ORM\Column(type: 'datetime')]

--- a/src/Entity/Ride.php
+++ b/src/Entity/Ride.php
@@ -12,6 +12,7 @@ use App\EntityInterface\PhotoInterface;
 use App\EntityInterface\PostableInterface;
 use App\EntityInterface\RouteableInterface;
 use App\EntityInterface\SocialNetworkProfileAble;
+use MalteHuebner\OrderedEntitiesBundle\Attribute as OE;
 use MalteHuebner\OrderedEntitiesBundle\OrderedEntityInterface;
 use App\Enum\RideDisabledReasonEnum;
 use App\Enum\RideTypeEnum;
@@ -53,6 +54,7 @@ class Ride implements ParticipateableInterface, PhotoInterface, RouteableInterfa
     #[Groups(['extended-ride-list', 'ride-details'])]
     protected ?CityCycle $cycle = null;
 
+    #[OE\Identical]
     #[DataQuery\Sortable]
     #[Routing\RouteParameter(name: 'citySlug')]
     #[ORM\ManyToOne(targetEntity: 'City', inversedBy: 'rides', fetch: 'LAZY')]
@@ -93,6 +95,7 @@ class Ride implements ParticipateableInterface, PhotoInterface, RouteableInterfa
     #[Ignore]
     protected ?string $socialDescription = null;
 
+    #[OE\Order(direction: 'ASC')]
     #[DataQuery\Sortable]
     #[DataQuery\DateTimeQueryable(format: 'strict_date', pattern: 'Y-m-d')]
     #[ORM\Column(type: 'datetime', nullable: true)]
@@ -204,6 +207,7 @@ class Ride implements ParticipateableInterface, PhotoInterface, RouteableInterfa
     #[Ignore]
     protected ?string $imageMimeType = null;
 
+    #[OE\Boolean(value: true)]
     #[ORM\Column(type: 'boolean', options: ['default' => true])]
     #[Groups(['ride-list', 'ride-details'])]
     protected bool $enabled = true;

--- a/tests/Entity/OrderedEntityNavigationTest.php
+++ b/tests/Entity/OrderedEntityNavigationTest.php
@@ -1,0 +1,149 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Entity;
+
+use App\Entity\City;
+use App\Entity\Photo;
+use App\Entity\Ride;
+use Doctrine\Common\Collections\Expr\Comparison;
+use Doctrine\Common\Collections\Expr\CompositeExpression;
+use Doctrine\Common\Collections\Expr\Expression;
+use Doctrine\Common\Collections\Expr\Value;
+use MalteHuebner\OrderedEntitiesBundle\CriteriaBuilder\CriteriaBuilder;
+use MalteHuebner\OrderedEntitiesBundle\SortOrder;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression test for the previous/next pagination on ride and photo pages.
+ *
+ * The navigation is powered by maltehuebner/ordered-entities-bundle. The bundle derives the
+ * adjacent entity from #[OE\Identical], #[OE\Order] and #[OE\Boolean] attributes on the entity
+ * properties. When those attributes are missing the bundle builds an empty Criteria and the
+ * navigation escapes the current city — "previous ride in Rostock" ended up in Cologne.
+ *
+ * These tests assert the attributes are present and wired correctly by inspecting the Criteria
+ * the bundle builds for a given entity. No database is required.
+ */
+class OrderedEntityNavigationTest extends TestCase
+{
+    public function testPreviousRideStaysWithinSameCity(): void
+    {
+        $city = (new City())->setCity('Rostock');
+        $ride = (new Ride())
+            ->setCity($city)
+            ->setDateTime(new \DateTime('2026-05-29'))
+            ->setEnabled(true);
+
+        $criteria = (new CriteriaBuilder())->build($ride, SortOrder::ASC);
+        $comparisons = $this->flattenComparisons($criteria->getWhereExpression());
+
+        $cityComparison = $this->findComparison($comparisons, 'city');
+        $this->assertNotNull($cityComparison, 'Previous-ride navigation must be scoped to the same city');
+        $this->assertSame(Comparison::EQ, $cityComparison->getOperator());
+        $this->assertSame($city, $this->unwrap($cityComparison->getValue()));
+
+        $dateComparison = $this->findComparison($comparisons, 'dateTime');
+        $this->assertNotNull($dateComparison);
+        $this->assertSame(Comparison::LT, $dateComparison->getOperator(), 'Previous ride must lie earlier in time');
+
+        $enabledComparison = $this->findComparison($comparisons, 'enabled');
+        $this->assertNotNull($enabledComparison, 'Only enabled rides may be navigated to');
+        $this->assertTrue($this->unwrap($enabledComparison->getValue()));
+
+        $this->assertSame('ASC', $criteria->orderings()['dateTime']->value);
+    }
+
+    public function testNextRideStaysWithinSameCity(): void
+    {
+        $city = (new City())->setCity('Rostock');
+        $ride = (new Ride())
+            ->setCity($city)
+            ->setDateTime(new \DateTime('2026-05-29'))
+            ->setEnabled(true);
+
+        $criteria = (new CriteriaBuilder())->build($ride, SortOrder::DESC);
+        $comparisons = $this->flattenComparisons($criteria->getWhereExpression());
+
+        $cityComparison = $this->findComparison($comparisons, 'city');
+        $this->assertNotNull($cityComparison, 'Next-ride navigation must be scoped to the same city');
+        $this->assertSame(Comparison::EQ, $cityComparison->getOperator());
+        $this->assertSame($city, $this->unwrap($cityComparison->getValue()));
+
+        $dateComparison = $this->findComparison($comparisons, 'dateTime');
+        $this->assertNotNull($dateComparison);
+        $this->assertSame(Comparison::GT, $dateComparison->getOperator(), 'Next ride must lie later in time');
+
+        $this->assertSame('DESC', $criteria->orderings()['dateTime']->value);
+    }
+
+    public function testPreviousPhotoStaysWithinSameRide(): void
+    {
+        $ride = (new Ride())->setDateTime(new \DateTime('2026-05-29'));
+        $photo = (new Photo())
+            ->setRide($ride)
+            ->setEnabled(true)
+            ->setDeleted(false)
+            ->setExifCreationDate(new \DateTime('2026-05-29 18:00:00'));
+
+        $criteria = (new CriteriaBuilder())->build($photo, SortOrder::ASC);
+        $comparisons = $this->flattenComparisons($criteria->getWhereExpression());
+
+        $rideComparison = $this->findComparison($comparisons, 'ride');
+        $this->assertNotNull($rideComparison, 'Photo navigation must be scoped to the same ride');
+        $this->assertSame(Comparison::EQ, $rideComparison->getOperator());
+        $this->assertSame($ride, $this->unwrap($rideComparison->getValue()));
+
+        $this->assertNotNull($this->findComparison($comparisons, 'exifCreationDate'), 'Photos are ordered by capture date');
+
+        $enabledComparison = $this->findComparison($comparisons, 'enabled');
+        $this->assertNotNull($enabledComparison, 'Only enabled photos may be navigated to');
+        $this->assertTrue($this->unwrap($enabledComparison->getValue()));
+
+        $deletedComparison = $this->findComparison($comparisons, 'deleted');
+        $this->assertNotNull($deletedComparison, 'Deleted photos must be excluded from navigation');
+        $this->assertFalse($this->unwrap($deletedComparison->getValue()));
+    }
+
+    /**
+     * Recursively collects all leaf {@see Comparison} nodes from a (possibly composite) Criteria expression.
+     *
+     * @return Comparison[]
+     */
+    private function flattenComparisons(?Expression $expression): array
+    {
+        if ($expression instanceof Comparison) {
+            return [$expression];
+        }
+
+        if ($expression instanceof CompositeExpression) {
+            $comparisons = [];
+
+            foreach ($expression->getExpressionList() as $child) {
+                $comparisons = array_merge($comparisons, $this->flattenComparisons($child));
+            }
+
+            return $comparisons;
+        }
+
+        return [];
+    }
+
+    /**
+     * @param Comparison[] $comparisons
+     */
+    private function findComparison(array $comparisons, string $field): ?Comparison
+    {
+        foreach ($comparisons as $comparison) {
+            if ($comparison->getField() === $field) {
+                return $comparison;
+            }
+        }
+
+        return null;
+    }
+
+    private function unwrap(mixed $value): mixed
+    {
+        return $value instanceof Value ? $value->getValue() : $value;
+    }
+}


### PR DESCRIPTION
## Summary

- Previous/next navigation on ride pages escaped the current city — the "Vorige" link on `/rostock/2026-05-29` led to a ride in Cologne instead of the previous Rostock ride.
- **Root cause:** the Symfony 7 migration (`9215b9b2`) converted Doctrine annotations to PHP 8 attributes but dropped the `@OE\*` annotations on `Ride` and `Photo` without re-adding them as `#[OE\*]` attributes (only `Track` was migrated correctly). With no attributes, `maltehuebner/ordered-entities-bundle` builds an empty `Criteria` (no `WHERE`, no `ORDER BY`), so `repository->matching()` returned all rides and `array_pop()` picked an arbitrary one across every city.
- Restored the attributes the bundle introspects:
  - `Ride`: `#[OE\Identical]` on `city`, `#[OE\Order]` on `dateTime`, `#[OE\Boolean]` on `enabled`
  - `Photo`: `#[OE\Identical]` on `ride`, `#[OE\Order]` on `exifCreationDate`, `#[OE\Boolean]` on `enabled`/`deleted`; also fixed the stale `Annotation` import (that namespace no longer exists in the bundle) to `Attribute`
- Added a regression test asserting the built `Criteria` is scoped to the same city (`Ride`) / ride (`Photo`), ordered by date and filtered to enabled (non-deleted) entities.

## Test Plan

- `vendor/bin/phpunit tests/Entity/OrderedEntityNavigationTest.php` → 3 tests, 22 assertions, green
- `vendor/bin/phpstan analyse src/Entity/Ride.php src/Entity/Photo.php tests/Entity/OrderedEntityNavigationTest.php` (level 6) → no errors
- Manual: the "Vorige"/"Nächste" links on a ride page now stay within the same city.

🤖 Generated with [Claude Code](https://claude.com/claude-code)