### PR TITLE
Redesign-Fundament: Schriften, Design-Tokens, cm-Komponenten

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,10 +32,29 @@ vendor/bin/phpstan analyse                  # PHPStan level 6
 
 ### Frontend Assets
 ```bash
-yarn dev          # Build once for development
-yarn watch        # Dev build with file watching
-yarn build        # Production build
+npm install --legacy-peer-deps   # Install (npm, NOT yarn — there is no yarn.lock;
+                                 # --legacy-peer-deps needed: encore 6 vs. webpack-cli 5)
+npm run dev       # Build once for development
+npm run watch     # Dev build with file watching
+npm run build     # Production build
 ```
+
+## Redesign „Aktivität" (laufend, seit Juni 2026)
+
+Die UI wird schrittweise auf das Design „Aktivität" umgestellt: Activity-Feed-Optik,
+Akzent `#f4581c` auf kühlem Grau, Archivo + IBM Plex Mono (selbst gehostet via
+@fontsource), „Klingeln" (Fahrradklingel) statt Likes.
+
+- **Referenz:** 16 verlinkte HTML-Prototypen in `design-prototypes/` (Einstieg
+  `index.html`, Mobil-Ansicht `_mobile-check.html`) — bei UI-Arbeit zuerst dort
+  nachsehen; neue Screens zuerst als Prototyp ergänzen.
+- **Plan & PR-Schnitt:** `design-prototypes/UMSETZUNG.md` (Tokens, Komponenten,
+  PR 1–11, Stolpersteine).
+- **Stand:** PR 1 (Fundament: Fonts, Bootstrap-Tokens, additive `cm-*`-Komponenten
+  in `assets/scss/redesign/`) → Branch `feature/redesign-activity`, PR #1406.
+  Folge-PRs werden darauf gestapelt, bis #1406 gemerged ist.
+- **Konvention:** Neue UI-Klassen tragen das Präfix `cm-`; Bestands-Styles nicht
+  entfernen, solange alte Templates sie nutzen (Bootstrap-3-Kompat-Layer zuletzt).
 
 ### Docker Services
 ```bash

--- a/assets/app.js
+++ b/assets/app.js
@@ -1,4 +1,14 @@
 import './bootstrap.js';
+
+// Redesign „Aktivität": selbst gehostete Schriften (DSGVO — kein Google-CDN)
+import '@fontsource/archivo/400.css';
+import '@fontsource/archivo/500.css';
+import '@fontsource/archivo/600.css';
+import '@fontsource/archivo/700.css';
+import '@fontsource/archivo/800.css';
+import '@fontsource/ibm-plex-mono/500.css';
+import '@fontsource/ibm-plex-mono/600.css';
+
 import './scss/criticalmass.scss';
 import 'dropzone/dist/dropzone.css';
 import 'friendly-challenge/widget';

--- a/assets/scss/bootstrap5.scss
+++ b/assets/scss/bootstrap5.scss
@@ -5,14 +5,35 @@
 @import "../../node_modules/bootstrap/scss/functions";
 
 // 2. Include any default variable overrides here
-$primary: #337ab7;
-$secondary: #6c757d;
-$success: #5cb85c;
-$info: #5bc0de;
-$warning: #f0ad4e;
-$danger: #d9534f;
-$light: #f8f9fa;
-$dark: #343a40;
+// Redesign „Aktivität" — Tokens siehe design-prototypes/UMSETZUNG.md
+$primary: #f4581c;
+$secondary: #707684;
+$success: #1e7d4f;
+$info: #2b6cb0;
+$warning: #b07814;
+$danger: #d8232a;
+$light: #f2f3f5;
+$dark: #16181c;
+
+$body-bg: #f2f3f5;
+$body-color: #16181c;
+$border-color: #e3e5e8;
+
+$font-family-sans-serif: "Archivo", system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+$font-family-monospace: "IBM Plex Mono", SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+$headings-font-weight: 800;
+
+$border-radius: .65rem;
+$border-radius-sm: .5rem;
+$border-radius-lg: .9rem;
+$border-radius-xl: 1rem;
+
+$btn-font-weight: 700;
+$link-decoration: none;
+$link-hover-decoration: underline;
+
+$card-border-color: #e3e5e8;
+$card-cap-bg: #fafbfc;
 
 // Breadcrumbs
 $breadcrumb-divider: quote("/");

--- a/assets/scss/criticalmass.scss
+++ b/assets/scss/criticalmass.scss
@@ -5,6 +5,7 @@
 @import "criticalmass/frontpage3";
 @import "criticalmass/explore";
 @import "criticalmass/bulk-upload";
+@import "redesign/index";
 
 .input-daterange input {
   text-align: left !important;

--- a/assets/scss/redesign/_components.scss
+++ b/assets/scss/redesign/_components.scss
@@ -1,0 +1,292 @@
+// Redesign „Aktivität" — Komponenten (Präfix cm-, additiv zu Bootstrap)
+// 1:1 aus den Prototypen design-prototypes/06*.html portiert.
+
+// ---------- Buttons ----------
+.cm-kbtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  border: 1px solid var(--cm-line);
+  background: var(--cm-card);
+  border-radius: var(--cm-radius-btn);
+  padding: 8px 15px;
+  font-weight: 700;
+  font-size: .88rem;
+  color: var(--cm-ink);
+  text-decoration: none;
+  cursor: pointer;
+
+  &:hover { border-color: #c9cdd3; color: var(--cm-ink); }
+  svg { stroke: currentColor; flex: none; }
+
+  &.cm-kbtn-solid {
+    background: var(--cm-accent);
+    border-color: var(--cm-accent);
+    color: #fff;
+    &:hover { background: var(--cm-accent-deep); color: #fff; }
+  }
+  &.cm-kbtn-rung {
+    border-color: var(--cm-accent);
+    color: var(--cm-accent);
+    background: var(--cm-accent-soft);
+  }
+  &.cm-kbtn-sm { padding: 6px 12px; font-size: .82rem; }
+}
+
+// ---------- Avatare ----------
+.cm-ava {
+  width: 34px;
+  height: 34px;
+  border-radius: var(--cm-radius-pill);
+  flex: none;
+  display: inline-grid;
+  place-items: center;
+  font-weight: 800;
+  font-size: .78rem;
+  color: #fff;
+  background: #3d4350;
+  text-decoration: none;
+
+  &.cm-ava-l { width: 44px; height: 44px; font-size: .95rem; }
+  &.cm-ava-xl { width: 76px; height: 76px; font-size: 1.5rem; border-radius: 24px; }
+  &.cm-ava-xs { width: 24px; height: 24px; font-size: .6rem; border: 2px solid #fff; }
+}
+.cm-facepile {
+  display: inline-flex;
+  .cm-ava-xs + .cm-ava-xs { margin-left: -8px; }
+}
+
+// ---------- Aktivitätskarte ----------
+.cm-activity {
+  background: var(--cm-card);
+  border: 1px solid var(--cm-line);
+  border-radius: var(--cm-radius-card);
+  overflow: hidden;
+}
+.cm-act-head {
+  display: flex;
+  gap: 12px;
+  padding: 14px 18px 10px;
+  align-items: center;
+
+  .cm-who { line-height: 1.3; min-width: 0; b { font-weight: 700; } }
+  .cm-sub { color: var(--cm-dim); font-size: .82rem; }
+  .cm-badge {
+    margin-left: auto;
+    font-family: var(--cm-font-mono);
+    font-size: .68rem;
+    text-transform: uppercase;
+    letter-spacing: .1em;
+    color: var(--cm-dim);
+    border: 1px solid var(--cm-line);
+    border-radius: 6px;
+    padding: 3px 8px;
+    white-space: nowrap;
+  }
+}
+.cm-act-title {
+  padding: 0 18px 12px;
+  h3, .h3 { font-size: 1.12rem; font-weight: 800; letter-spacing: -.015em; margin: 0; }
+  .cm-where { color: var(--cm-dim); font-size: .86rem; margin-top: 2px; }
+}
+
+// ---------- Statistikband ----------
+.cm-statband {
+  display: flex;
+  border-top: 1px solid var(--cm-line);
+  border-bottom: 1px solid var(--cm-line);
+  background: #fafbfc;
+
+  > div { flex: 1; padding: 12px 18px; }
+  > div + div { border-left: 1px solid var(--cm-line); }
+  .cm-v {
+    font-family: var(--cm-font-mono);
+    font-weight: 600;
+    font-size: 1.25rem;
+    small { font-size: .68em; color: var(--cm-dim); margin-left: 2px; }
+  }
+  .cm-k {
+    font-size: .72rem;
+    color: var(--cm-dim);
+    text-transform: uppercase;
+    letter-spacing: .08em;
+    margin-top: 1px;
+  }
+
+  @media (max-width: 767.98px) {
+    flex-wrap: wrap;
+    > div { flex: 1 1 40%; border-top: 1px solid var(--cm-line); margin-top: -1px; }
+    .cm-v { font-size: 1.05rem; }
+  }
+}
+
+// ---------- Kudos / Klingeln ----------
+.cm-kudosbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 11px 18px;
+  flex-wrap: wrap;
+
+  .cm-note { color: var(--cm-dim); font-size: .84rem; b { color: var(--cm-ink); } }
+  .cm-spacer { flex: 1; }
+}
+
+// ---------- Tabs (Segmented Control) ----------
+.cm-tabs {
+  display: flex;
+  gap: 2px;
+  background: var(--cm-card);
+  border: 1px solid var(--cm-line);
+  border-radius: 12px;
+  padding: 4px;
+  overflow-x: auto;
+
+  a, button {
+    flex: 1;
+    text-align: center;
+    font-weight: 700;
+    font-size: .88rem;
+    color: var(--cm-dim);
+    border-radius: var(--cm-radius-btn);
+    padding: 8px 12px;
+    white-space: nowrap;
+    text-decoration: none;
+    border: 0;
+    background: transparent;
+    cursor: pointer;
+
+    &:hover { color: var(--cm-ink); }
+    &.active { background: var(--cm-bg); color: var(--cm-ink); }
+    .cm-n { font-family: var(--cm-font-mono); font-size: .72rem; color: var(--cm-dim); margin-left: 4px; }
+  }
+}
+
+// ---------- Terminzeile („Bald unterwegs") ----------
+.cm-dayhead {
+  font-size: .7rem;
+  font-weight: 800;
+  color: var(--cm-dim);
+  text-transform: uppercase;
+  letter-spacing: .1em;
+  margin: 8px 8px 2px;
+}
+.cm-uprow {
+  display: flex;
+  gap: 10px;
+  align-items: baseline;
+  padding: 6px 8px;
+  border-radius: 8px;
+  font-size: .9rem;
+  text-decoration: none;
+  color: var(--cm-ink);
+
+  &:hover { background: #f6f7f8; color: var(--cm-ink); }
+  .cm-t { font-family: var(--cm-font-mono); font-size: .8rem; font-weight: 600; width: 52px; flex: none; }
+  .cm-c { font-weight: 700; }
+  .cm-p { margin-left: auto; color: var(--cm-dim); font-size: .78rem; text-align: right; }
+  &.cm-live .cm-t { color: var(--cm-accent); }
+}
+
+// ---------- Datums-Badge ----------
+.cm-datebadge {
+  flex: none;
+  width: 56px;
+  border: 2px solid var(--cm-ink);
+  border-radius: 11px;
+  text-align: center;
+  overflow: hidden;
+
+  .cm-m {
+    display: block;
+    background: var(--cm-ink);
+    color: #fff;
+    font-size: .62rem;
+    font-weight: 800;
+    letter-spacing: .12em;
+    padding: 2.5px 0;
+    text-transform: uppercase;
+  }
+  .cm-d { display: block; font-size: 1.35rem; font-weight: 800; padding: 3px 0 4px; }
+}
+
+// ---------- Ranking ----------
+.cm-rankrow {
+  display: grid;
+  grid-template-columns: 26px 1fr auto;
+  gap: 10px;
+  align-items: center;
+  padding: 7px 8px;
+  border-radius: 8px;
+  font-size: .94rem;
+  text-decoration: none;
+  color: var(--cm-ink);
+
+  &:hover { background: #f6f7f8; color: var(--cm-ink); }
+  .cm-nr { font-family: var(--cm-font-mono); font-size: .8rem; color: var(--cm-dim); }
+  .cm-city { font-weight: 700; }
+  .cm-bar {
+    display: block;
+    height: 5px;
+    border-radius: 4px;
+    background: #ffe0d1;
+    position: relative;
+    margin-top: 5px;
+    i { position: absolute; inset: 0 auto 0 0; border-radius: 4px; background: var(--cm-accent); }
+  }
+  .cm-n { font-family: var(--cm-font-mono); font-size: .88rem; font-weight: 600; }
+}
+
+// ---------- Status-Chips (Upload-Zuordnung) ----------
+.cm-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: .76rem;
+  font-weight: 800;
+  border-radius: var(--cm-radius-pill);
+  padding: 4px 11px;
+  white-space: nowrap;
+
+  &.cm-status-ok { background: var(--cm-green-soft); color: var(--cm-green); }
+  &.cm-status-check { background: var(--cm-amber-soft); color: var(--cm-amber); }
+  &.cm-status-parked { background: var(--cm-bg); color: var(--cm-dim); }
+}
+
+// ---------- Mobile Tab-Leiste ----------
+.cm-tabbar {
+  display: none;
+
+  @media (max-width: 991.98px) {
+    display: flex;
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 1030;
+    background: rgba(255, 255, 255, .96);
+    backdrop-filter: blur(10px);
+    border-top: 1px solid var(--cm-line);
+    padding: 6px 8px calc(6px + env(safe-area-inset-bottom));
+
+    a {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 2px;
+      font-size: .62rem;
+      font-weight: 700;
+      color: var(--cm-dim);
+      padding: 4px 0;
+      text-decoration: none;
+
+      svg { stroke: currentColor; }
+      &.active { color: var(--cm-accent); }
+    }
+  }
+}
+// Platz für die Tab-Leiste auf Mobil
+@media (max-width: 991.98px) {
+  body.cm-has-tabbar { padding-bottom: 70px; }
+}

--- a/assets/scss/redesign/_index.scss
+++ b/assets/scss/redesign/_index.scss
@@ -1,0 +1,5 @@
+// Redesign „Aktivität" — Einstiegspunkt
+// Tokens + additive Komponenten; Referenz-Prototypen in design-prototypes/
+
+@import "tokens";
+@import "components";

--- a/assets/scss/redesign/_tokens.scss
+++ b/assets/scss/redesign/_tokens.scss
@@ -1,0 +1,24 @@
+// Redesign „Aktivität" — Design-Tokens als CSS Custom Properties
+// Referenz: design-prototypes/06-feed-aktiv.html + UMSETZUNG.md
+
+:root {
+  --cm-bg: #f2f3f5;
+  --cm-card: #ffffff;
+  --cm-line: #e3e5e8;
+  --cm-ink: #16181c;
+  --cm-dim: #707684;
+  --cm-accent: #f4581c;
+  --cm-accent-deep: #d8450e;
+  --cm-accent-soft: #fff4ee;
+  --cm-green: #1e7d4f;
+  --cm-green-soft: #e8f3ed;
+  --cm-amber: #b07814;
+  --cm-amber-soft: #fdf3e0;
+
+  --cm-font-sans: "Archivo", system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --cm-font-mono: "IBM Plex Mono", SFMono-Regular, Menlo, Consolas, monospace;
+
+  --cm-radius-card: 14px;
+  --cm-radius-btn: 9px;
+  --cm-radius-pill: 99px;
+}

--- a/design-prototypes/01-plakat.html
+++ b/design-prototypes/01-plakat.html
@@ -1,0 +1,567 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Prototyp 1 · Plakat — criticalmass.in</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Anton&family=Archivo:wght@400;500;600;700;900&display=swap" rel="stylesheet">
+<style>
+:root {
+  --paper: #f3efe5;
+  --paper-2: #ebe6d8;
+  --ink: #181511;
+  --pink: #ff2e7e;
+  --blue: #2438e8;
+  --orange: #ff571f;
+  --display: "Anton", "Arial Narrow", sans-serif;
+  --text: "Archivo", "Helvetica Neue", Arial, sans-serif;
+}
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html { scroll-behavior: smooth; }
+html, body { overflow-x: clip; }
+body {
+  font-family: var(--text);
+  background: var(--paper);
+  color: var(--ink);
+  line-height: 1.5;
+  position: relative;
+}
+/* Papierkorn */
+body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  opacity: .35;
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="240" height="240"><filter id="n"><feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="2"/><feColorMatrix type="saturate" values="0"/><feComponentTransfer><feFuncA type="linear" slope="0.06"/></feComponentTransfer></filter><rect width="240" height="240" filter="url(%23n)"/></svg>');
+  z-index: 5;
+}
+a { color: inherit; }
+
+/* ---------- Topbar ---------- */
+.topbar {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  padding: 1rem 1.25rem;
+  border-bottom: 3px solid var(--ink);
+  flex-wrap: wrap;
+}
+.brand {
+  font-family: var(--display);
+  font-size: 1.35rem;
+  letter-spacing: .02em;
+  text-transform: lowercase;
+  background: #fff;
+  border: 3px solid var(--ink);
+  padding: .15rem .6rem .25rem;
+  transform: rotate(-1.5deg);
+  text-decoration: none;
+  box-shadow: 4px 4px 0 var(--ink);
+}
+.topbar nav {
+  display: flex;
+  gap: 1.25rem;
+  flex-wrap: wrap;
+  margin-left: auto;
+}
+.topbar nav a {
+  text-decoration: none;
+  text-transform: uppercase;
+  font-weight: 700;
+  font-size: .8rem;
+  letter-spacing: .12em;
+  border-bottom: 3px solid transparent;
+  padding-bottom: .15rem;
+}
+.topbar nav a:hover { border-color: var(--pink); }
+.topbar nav a.cta {
+  border: 3px solid var(--ink);
+  padding: .35rem .8rem;
+  background: var(--pink);
+  color: #fff;
+  box-shadow: 3px 3px 0 var(--ink);
+}
+
+/* ---------- Hero ---------- */
+.hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(280px, 1fr);
+  gap: 3rem;
+  padding: 4rem 1.25rem 4.5rem;
+  max-width: 1200px;
+  margin: 0 auto;
+  align-items: center;
+}
+.kicker {
+  display: inline-block;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .14em;
+  font-size: .8rem;
+  border: 2px solid var(--ink);
+  padding: .3rem .7rem;
+  background: var(--paper-2);
+  transform: rotate(-.6deg);
+  margin-bottom: 1.5rem;
+}
+.hero h1 {
+  font-family: var(--display);
+  font-size: clamp(3.2rem, 9.5vw, 7.5rem);
+  line-height: .92;
+  text-transform: uppercase;
+  letter-spacing: .005em;
+}
+.hero h1 .outline {
+  color: transparent;
+  -webkit-text-stroke: 3px var(--pink);
+  text-stroke: 3px var(--pink);
+}
+.hero p.lead {
+  margin-top: 1.5rem;
+  font-size: 1.15rem;
+  max-width: 34rem;
+}
+.hero .actions { margin-top: 2rem; display: flex; gap: 1rem; flex-wrap: wrap; }
+.btn {
+  font-family: var(--text);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .1em;
+  font-size: .85rem;
+  text-decoration: none;
+  border: 3px solid var(--ink);
+  padding: .8rem 1.3rem;
+  display: inline-block;
+  background: var(--ink);
+  color: var(--paper);
+  box-shadow: 5px 5px 0 rgba(24,21,17,.35);
+  transition: transform .1s ease, box-shadow .1s ease;
+}
+.btn:hover { transform: translate(-2px,-2px); box-shadow: 7px 7px 0 rgba(24,21,17,.35); }
+.btn.ghost { background: transparent; color: var(--ink); box-shadow: none; }
+.btn.ghost:hover { background: var(--paper-2); transform: none; }
+
+/* ---------- Spoke Card ---------- */
+.spokecard {
+  background: #fff;
+  border: 3px solid var(--ink);
+  box-shadow: 8px 8px 0 var(--ink);
+  padding: 2.6rem 1.6rem 1.6rem;
+  transform: rotate(2deg);
+  position: relative;
+  max-width: 340px;
+  justify-self: center;
+}
+.spokecard .hole {
+  position: absolute;
+  top: 14px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--paper);
+  border: 3px solid var(--ink);
+}
+.spokecard .label {
+  text-transform: uppercase;
+  font-size: .7rem;
+  font-weight: 700;
+  letter-spacing: .16em;
+  color: var(--blue);
+  text-align: center;
+}
+.spokecard .city {
+  font-family: var(--display);
+  font-size: 2.6rem;
+  text-transform: uppercase;
+  text-align: center;
+  line-height: 1;
+  margin: .4rem 0 1rem;
+}
+.spokecard .date-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: center;
+  gap: .8rem;
+  border-top: 2px solid var(--ink);
+  border-bottom: 2px solid var(--ink);
+  padding: .7rem 0;
+}
+.spokecard .date-row .big {
+  font-family: var(--display);
+  font-size: 3.4rem;
+  line-height: 1;
+  color: var(--pink);
+}
+.spokecard .date-row .rest { font-weight: 600; line-height: 1.3; }
+.spokecard dl {
+  margin: 1rem 0 1.2rem;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: .3rem .8rem;
+  font-size: .95rem;
+}
+.spokecard dt { font-weight: 700; text-transform: uppercase; font-size: .7rem; letter-spacing: .1em; align-self: center; }
+.spokecard dd { font-weight: 600; }
+.spokecard .card-actions { display: grid; grid-template-columns: 1fr 1fr; gap: .7rem; }
+.spokecard .card-actions .btn { text-align: center; padding: .65rem .5rem; box-shadow: none; }
+.spokecard .card-actions .btn.primary { background: var(--blue); color: #fff; }
+.spokecard .stamp {
+  position: absolute;
+  right: -22px;
+  top: -18px;
+  border: 3px solid var(--orange);
+  color: var(--orange);
+  font-weight: 900;
+  text-transform: uppercase;
+  font-size: .65rem;
+  letter-spacing: .14em;
+  padding: .35rem .6rem;
+  transform: rotate(8deg);
+  background: rgba(255,255,255,.85);
+}
+
+/* ---------- Marquee ---------- */
+.marquee {
+  border-top: 3px solid var(--ink);
+  border-bottom: 3px solid var(--ink);
+  background: var(--ink);
+  color: var(--paper);
+  overflow: hidden;
+  white-space: nowrap;
+}
+.marquee span {
+  display: inline-block;
+  font-family: var(--display);
+  text-transform: uppercase;
+  font-size: 1.5rem;
+  padding: .55rem 0;
+  animation: slide 40s linear infinite;
+}
+.marquee em { font-style: normal; color: var(--pink); }
+@keyframes slide { from { transform: translateX(0); } to { transform: translateX(-50%); } }
+@media (prefers-reduced-motion: reduce) { .marquee span { animation: none; } }
+
+/* ---------- Flyerwand ---------- */
+.wall { max-width: 1200px; margin: 0 auto; padding: 4rem 1.25rem 2rem; }
+.wall-head { display: flex; align-items: baseline; gap: 1.2rem; flex-wrap: wrap; margin-bottom: 2.2rem; }
+.wall-head h2, .after h2 {
+  font-family: var(--display);
+  font-size: clamp(2rem, 5vw, 3.2rem);
+  text-transform: uppercase;
+}
+.wall-head .count { font-weight: 600; color: var(--blue); }
+.flyers {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 1.8rem;
+}
+.flyer {
+  background: #fff;
+  border: 3px solid var(--ink);
+  padding: 1.2rem 1.2rem 1.4rem;
+  position: relative;
+  text-decoration: none;
+  display: block;
+  transition: transform .12s ease;
+}
+.flyer::before {
+  content: "";
+  position: absolute;
+  top: -12px;
+  left: 50%;
+  width: 90px;
+  height: 24px;
+  transform: translateX(-50%) rotate(-2deg);
+  background: rgba(244, 240, 228, .65);
+  border-left: 1px dashed rgba(24,21,17,.25);
+  border-right: 1px dashed rgba(24,21,17,.25);
+}
+.flyer:nth-child(3n)   { transform: rotate(-1.3deg); }
+.flyer:nth-child(3n+1) { transform: rotate(.9deg); }
+.flyer:nth-child(4n)   { transform: rotate(1.6deg); }
+.flyer:hover { transform: rotate(0) scale(1.02); z-index: 2; }
+.flyer .day {
+  display: inline-block;
+  font-weight: 900;
+  text-transform: uppercase;
+  font-size: .7rem;
+  letter-spacing: .12em;
+  background: var(--ink);
+  color: var(--paper);
+  padding: .25rem .5rem;
+}
+.flyer:nth-child(3n) .day { background: var(--pink); color: #fff; }
+.flyer:nth-child(4n) .day { background: var(--blue); color: #fff; }
+.flyer .city {
+  font-family: var(--display);
+  font-size: 1.9rem;
+  text-transform: uppercase;
+  line-height: 1.05;
+  margin: .6rem 0 .4rem;
+}
+.flyer .meta { font-size: .9rem; font-weight: 600; }
+.flyer .meta .time { color: var(--orange); font-weight: 900; }
+.wall-more { margin-top: 2.4rem; display: flex; gap: 1rem; flex-wrap: wrap; }
+
+/* ---------- Danach ---------- */
+.after { max-width: 1200px; margin: 0 auto; padding: 3rem 1.25rem 4rem; }
+.after h2 { margin-bottom: .4rem; }
+.after .sub { max-width: 38rem; margin-bottom: 2.2rem; }
+.after-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 1.8rem; }
+.after-card {
+  border: 3px solid var(--ink);
+  background: var(--paper-2);
+  padding: 1.4rem;
+}
+.after-card h3 { font-family: var(--display); text-transform: uppercase; font-size: 1.4rem; margin-bottom: .6rem; }
+.after-card p { font-size: .95rem; margin-bottom: 1rem; }
+.after-card .fact {
+  background: #fff;
+  border: 2px solid var(--ink);
+  padding: .6rem .8rem;
+  font-weight: 700;
+  font-size: .9rem;
+  margin-bottom: 1rem;
+}
+.after-card .fact small { display: block; font-weight: 500; color: rgba(24,21,17,.65); }
+.after-card svg { display: block; margin-bottom: .8rem; }
+.flip {
+  display: inline-flex;
+  gap: 3px;
+  margin-bottom: .8rem;
+}
+.flip b {
+  font-family: var(--display);
+  background: var(--ink);
+  color: var(--paper);
+  font-size: 1.6rem;
+  padding: .15rem .45rem;
+  border-radius: 3px;
+}
+
+/* ---------- Footer ---------- */
+footer {
+  border-top: 3px solid var(--ink);
+  background: var(--ink);
+  color: var(--paper);
+  padding: 3rem 1.25rem 5rem;
+}
+.foot-inner { max-width: 1200px; margin: 0 auto; }
+footer .wordmark {
+  font-family: var(--display);
+  font-size: clamp(2.4rem, 8vw, 5rem);
+  text-transform: lowercase;
+  line-height: 1;
+  color: var(--paper);
+}
+footer .claim { color: var(--pink); font-weight: 700; margin: .6rem 0 2rem; }
+footer nav { display: flex; gap: 1.5rem; flex-wrap: wrap; font-size: .85rem; }
+footer nav a { color: var(--paper); text-decoration: none; border-bottom: 2px solid rgba(243,239,229,.3); }
+footer nav a:hover { border-color: var(--pink); }
+footer .credits { margin-top: 2rem; font-size: .75rem; color: rgba(243,239,229,.55); }
+
+.proto-back {
+  position: fixed;
+  bottom: 14px;
+  right: 14px;
+  z-index: 50;
+  font-size: .75rem;
+  font-weight: 700;
+  text-decoration: none;
+  background: #fff;
+  border: 2px solid var(--ink);
+  padding: .35rem .7rem;
+  box-shadow: 3px 3px 0 var(--ink);
+}
+
+/* ---------- Mobil ---------- */
+@media (max-width: 860px) {
+  .hero { grid-template-columns: 1fr; gap: 2.5rem; padding-top: 2.5rem; }
+  .spokecard { transform: rotate(1deg); justify-self: start; }
+  .topbar nav { gap: .9rem; }
+}
+@media (max-width: 520px) {
+  .flyer, .flyer:nth-child(n) { transform: none; }
+  .topbar { gap: .8rem; }
+  .topbar nav a:not(.cta) { font-size: .72rem; }
+  .spokecard { max-width: 100%; }
+  .spokecard .stamp { right: 4px; top: -16px; }
+}
+</style>
+</head>
+<body>
+
+<header class="topbar">
+  <a class="brand" href="#">criticalmass.in</a>
+  <nav>
+    <a href="#">Städte</a>
+    <a href="#">Kalender</a>
+    <a href="#">Fotos</a>
+    <a href="#">Forum</a>
+    <a class="cta" href="#">Anmelden</a>
+  </nav>
+</header>
+
+<section class="hero">
+  <div>
+    <span class="kicker">Jeden letzten Freitag im Monat · überall</span>
+    <h1>Wir sind<br>der <span class="outline">Verkehr.</span></h1>
+    <p class="lead">Critical Mass ist keine Veranstaltung und hat keinen Chef. Sie findet statt,
+      weil du hinkommst — gemeinsam, langsam, laut und mit Klingel. criticalmass.in sagt dir,
+      wann und wo sich die Masse in über 600 Städten trifft.</p>
+    <div class="actions">
+      <a class="btn" href="#wall">Nächste Tour finden</a>
+      <a class="btn ghost" href="#">Was ist Critical Mass?</a>
+    </div>
+  </div>
+
+  <aside class="spokecard" aria-label="Nächste Tour">
+    <span class="hole" aria-hidden="true"></span>
+    <p class="label">Nächste Tour in deiner Nähe</p>
+    <p class="city">Hamburg</p>
+    <div class="date-row">
+      <span class="big">26.</span>
+      <span class="rest">Juni 2026<br>Freitag</span>
+    </div>
+    <dl>
+      <dt>Start</dt><dd>19:00 Uhr</dd>
+      <dt>Treffpunkt</dt><dd>Alstervorland, Höhe Milchstraße</dd>
+      <dt>Zuletzt</dt><dd>~ 2.400 Radfahrende</dd>
+    </dl>
+    <div class="card-actions">
+      <a class="btn primary" href="#">Dabei?</a>
+      <a class="btn ghost" href="#">Kalender</a>
+    </div>
+    <span class="stamp">Eintritt frei · für immer</span>
+  </aside>
+</section>
+
+<div class="marquee" aria-hidden="true">
+  <span>Wir behindern nicht den Verkehr — <em>wir sind der Verkehr</em> — Wir behindern nicht den Verkehr — <em>wir sind der Verkehr</em> — Wir behindern nicht den Verkehr — <em>wir sind der Verkehr</em> — Wir behindern nicht den Verkehr — <em>wir sind der Verkehr</em> — </span>
+</div>
+
+<section class="wall" id="wall">
+  <div class="wall-head">
+    <h2>Bald unterwegs</h2>
+    <span class="count">43 Touren in den nächsten 14 Tagen</span>
+  </div>
+  <div class="flyers">
+    <a class="flyer" href="#">
+      <span class="day">Fr · 12. Juni</span>
+      <span class="city">Düsseldorf</span>
+      <span class="meta"><span class="time">19:00</span> · Fürstenplatz</span>
+    </a>
+    <a class="flyer" href="#">
+      <span class="day">Fr · 12. Juni</span>
+      <span class="city">Darmstadt</span>
+      <span class="meta"><span class="time">19:00</span> · Treffpunkt auf der Karte</span>
+    </a>
+    <a class="flyer" href="#">
+      <span class="day">Fr · 12. Juni</span>
+      <span class="city">Essen</span>
+      <span class="meta"><span class="time">19:00</span> · Treffpunkt auf der Karte</span>
+    </a>
+    <a class="flyer" href="#">
+      <span class="day">Di · 16. Juni</span>
+      <span class="city">Lisboa</span>
+      <span class="meta"><span class="time">21:00</span> · Marquês de Pombal</span>
+    </a>
+    <a class="flyer" href="#">
+      <span class="day">Fr · 19. Juni</span>
+      <span class="city">Wien</span>
+      <span class="meta"><span class="time">17:00</span> · Schwarzenbergplatz</span>
+    </a>
+    <a class="flyer" href="#">
+      <span class="day">Fr · 19. Juni</span>
+      <span class="city">Los Angeles</span>
+      <span class="meta"><span class="time">18:30</span> · Treffpunkt auf der Karte</span>
+    </a>
+    <a class="flyer" href="#">
+      <span class="day">So · 21. Juni</span>
+      <span class="city">Köln</span>
+      <span class="meta"><span class="time">13:00</span> · Treffpunkt auf der Karte</span>
+    </a>
+    <a class="flyer" href="#">
+      <span class="day">Fr · 26. Juni</span>
+      <span class="city">Berlin</span>
+      <span class="meta"><span class="time">20:00</span> · Mariannenplatz</span>
+    </a>
+    <a class="flyer" href="#">
+      <span class="day">Fr · 26. Juni</span>
+      <span class="city">Hamburg</span>
+      <span class="meta"><span class="time">19:00</span> · Alstervorland</span>
+    </a>
+  </div>
+  <div class="wall-more">
+    <a class="btn ghost" href="#">Alle Städte</a>
+    <a class="btn ghost" href="#">Kalender ansehen</a>
+    <a class="btn ghost" href="#">Karte öffnen</a>
+  </div>
+</section>
+
+<section class="after">
+  <h2>Und danach?</h2>
+  <p class="sub">Die Masse lebt davon, dass alle etwas zurücklegen — Kilometer, Fotos, Zahlen.
+    Ohne Konto kannst du gucken, mit Konto kannst du mitmachen.</p>
+  <div class="after-grid">
+    <article class="after-card">
+      <svg width="120" height="54" viewBox="0 0 120 54" aria-hidden="true">
+        <polyline points="4,44 22,40 30,22 52,16 68,28 88,20 108,34 116,24"
+          fill="none" stroke="#2438e8" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+        <circle cx="4" cy="44" r="4" fill="#ff2e7e"/>
+        <circle cx="116" cy="24" r="4" fill="#181511"/>
+      </svg>
+      <h3>Track hochladen</h3>
+      <div class="fact">36,23 km · 3 h 44 min
+        <small>zuletzt: Critical Mass Berlin</small></div>
+      <p>GPX oder FIT aufs Portal werfen — die Route landet bei der Tour und in der Statistik.</p>
+      <a class="btn ghost" href="#">Hochladen</a>
+    </article>
+    <article class="after-card">
+      <div class="flip" aria-hidden="true"><b>0</b><b>0</b><b>1</b><b>2</b></div>
+      <h3>Masse schätzen</h3>
+      <div class="fact">12 Radfahrende in Norderstedt
+        <small>geschätzt von Katrin, vor 3 Tagen</small></div>
+      <p>Wie viele waren es? Deine Schätzung zählt — der Mittelwert wird zur offiziellen Zahl.</p>
+      <a class="btn ghost" href="#">Schätzen</a>
+    </article>
+    <article class="after-card">
+      <svg width="120" height="54" viewBox="0 0 120 54" aria-hidden="true">
+        <rect x="4" y="10" width="40" height="34" fill="none" stroke="#181511" stroke-width="3"/>
+        <rect x="40" y="6" width="40" height="34" fill="#fff" stroke="#181511" stroke-width="3" transform="rotate(4 60 23)"/>
+        <rect x="76" y="12" width="40" height="34" fill="none" stroke="#ff2e7e" stroke-width="3" transform="rotate(-3 96 29)"/>
+      </svg>
+      <h3>Fotos teilen</h3>
+      <div class="fact">4 neue Fotos aus Bonn
+        <small>Tour vom 29. Mai 2026</small></div>
+      <p>Lade deine Bilder hoch und markiere, wer einverstanden ist. Gesichter? Verpixeln geht direkt im Portal.</p>
+      <a class="btn ghost" href="#">Galerie</a>
+    </article>
+  </div>
+</section>
+
+<footer>
+  <div class="foot-inner">
+    <div class="wordmark">criticalmass.in</div>
+    <p class="claim">Hej, wir fahren Fahrrad!</p>
+    <nav>
+      <a href="#">Über die Critical Mass</a>
+      <a href="#">FAQ</a>
+      <a href="#">API</a>
+      <a href="#">Impressum</a>
+      <a href="#">Datenschutz</a>
+      <a href="#">Quellcode auf GitHub</a>
+    </nav>
+    <p class="credits">Karten: OpenStreetMap-Mitwirkende · Wetter: OpenWeatherMap · Open Source seit Tag eins</p>
+  </div>
+</footer>
+
+<a class="proto-back" href="index.html">← Übersicht</a>
+
+</body>
+</html>

--- a/design-prototypes/02-nachtfahrt.html
+++ b/design-prototypes/02-nachtfahrt.html
@@ -1,0 +1,586 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Prototyp 2 · Nachtfahrt — criticalmass.in</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+:root {
+  --asphalt: #0c0e12;
+  --panel: #14171d;
+  --panel-2: #1a1e26;
+  --line: #262b35;
+  --fg: #e9edf3;
+  --fg-dim: #9aa3b2;
+  --reflex: #d9ff3d;     /* Reflektor-Gelbgrün */
+  --katzenauge: #ff4a3a; /* Rücklicht */
+  --frontlicht: #bfe3ff;
+  --sans: "Space Grotesk", "Helvetica Neue", Arial, sans-serif;
+  --mono: "IBM Plex Mono", "SF Mono", Menlo, monospace;
+}
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html { color-scheme: dark; }
+html, body { overflow-x: clip; }
+body {
+  font-family: var(--sans);
+  background: var(--asphalt);
+  color: var(--fg);
+  line-height: 1.55;
+  padding-bottom: 76px; /* Platz für Tabbar auf Mobil */
+}
+a { color: inherit; }
+
+/* ---------- Header ---------- */
+.top {
+  position: sticky;
+  top: 0;
+  z-index: 40;
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  padding: .9rem 1.25rem;
+  background: rgba(12,14,18,.82);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid var(--line);
+}
+.brand {
+  font-weight: 700;
+  letter-spacing: .01em;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: .55rem;
+}
+.brand .patch {
+  width: 14px;
+  height: 22px;
+  background: var(--reflex);
+  clip-path: polygon(0 0, 100% 12%, 100% 100%, 0 88%);
+  box-shadow: 0 0 14px rgba(217,255,61,.55);
+}
+.top nav { display: flex; gap: 1.4rem; margin-left: auto; }
+.top nav a {
+  text-decoration: none;
+  font-size: .9rem;
+  color: var(--fg-dim);
+}
+.top nav a:hover, .top nav a[aria-current] { color: var(--fg); }
+.top .login {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: .35rem .95rem;
+  font-size: .85rem;
+  text-decoration: none;
+  color: var(--fg);
+}
+.top .login:hover { border-color: var(--reflex); color: var(--reflex); }
+
+/* ---------- Hero ---------- */
+.hero {
+  position: relative;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 4.5rem 1.25rem 3.5rem;
+  overflow: hidden;
+}
+.hero-route {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  opacity: .8;
+}
+.hero-grid {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0,1.3fr) minmax(280px, 1fr);
+  gap: 3rem;
+  align-items: center;
+}
+.label {
+  font-family: var(--mono);
+  font-size: .75rem;
+  letter-spacing: .18em;
+  text-transform: uppercase;
+  color: var(--reflex);
+}
+.hero h1 {
+  font-size: clamp(2.4rem, 6vw, 4.4rem);
+  font-weight: 700;
+  line-height: 1.04;
+  margin: .8rem 0 1rem;
+  letter-spacing: -.015em;
+}
+.hero h1 small {
+  display: block;
+  font-size: .42em;
+  font-weight: 500;
+  color: var(--fg-dim);
+  letter-spacing: 0;
+  margin-top: .55rem;
+}
+.hero p.sub { color: var(--fg-dim); max-width: 30rem; }
+.hero .actions { display: flex; gap: .9rem; margin-top: 1.8rem; flex-wrap: wrap; }
+.btn {
+  font-weight: 600;
+  font-size: .9rem;
+  text-decoration: none;
+  border-radius: 10px;
+  padding: .75rem 1.25rem;
+  border: 1px solid var(--line);
+  background: var(--panel);
+}
+.btn.primary {
+  background: var(--reflex);
+  border-color: var(--reflex);
+  color: #11130a;
+  box-shadow: 0 0 22px rgba(217,255,61,.28);
+}
+.btn.primary:hover { box-shadow: 0 0 34px rgba(217,255,61,.45); }
+.btn:not(.primary):hover { border-color: var(--fg-dim); }
+
+/* Countdown */
+.count-card {
+  background: linear-gradient(180deg, var(--panel-2), var(--panel));
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  padding: 1.6rem;
+}
+.count-card .where {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  margin-bottom: 1.2rem;
+}
+.count-card .where strong { font-size: 1.15rem; }
+.count-card .where span { font-family: var(--mono); font-size: .8rem; color: var(--fg-dim); }
+.digits { display: flex; gap: .6rem; }
+.digit {
+  flex: 1;
+  background: var(--asphalt);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  text-align: center;
+  padding: .8rem .2rem .6rem;
+}
+.digit b {
+  font-family: var(--mono);
+  font-size: clamp(1.6rem, 4vw, 2.3rem);
+  font-weight: 600;
+  color: var(--reflex);
+  text-shadow: 0 0 18px rgba(217,255,61,.4);
+}
+.digit span {
+  display: block;
+  font-family: var(--mono);
+  font-size: .62rem;
+  text-transform: uppercase;
+  letter-spacing: .14em;
+  color: var(--fg-dim);
+  margin-top: .35rem;
+}
+.count-card .meet {
+  margin-top: 1.2rem;
+  padding-top: 1.1rem;
+  border-top: 1px dashed var(--line);
+  font-size: .9rem;
+  color: var(--fg-dim);
+  display: flex;
+  gap: .6rem;
+  align-items: center;
+}
+.count-card .meet svg { flex: none; }
+.count-card .meet b { color: var(--fg); font-weight: 600; }
+
+/* ---------- Abschnitte ---------- */
+section.block { max-width: 1200px; margin: 0 auto; padding: 2.6rem 1.25rem; }
+.block-head { display: flex; align-items: baseline; gap: .4rem 1rem; margin-bottom: 1.4rem; flex-wrap: wrap; }
+.block-head h2 { font-size: 1.5rem; font-weight: 700; letter-spacing: -.01em; }
+.block-head a { margin-left: auto; font-size: .85rem; color: var(--fg-dim); text-decoration: none; }
+.block-head a:hover { color: var(--reflex); }
+
+/* Heute-Reihe */
+.tonight {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));
+  gap: .9rem;
+}
+.ride {
+  display: flex;
+  align-items: center;
+  gap: .95rem;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: .95rem 1.05rem;
+  text-decoration: none;
+  transition: border-color .15s ease, transform .15s ease;
+}
+.ride:hover { border-color: var(--reflex); transform: translateY(-2px); }
+.ride .time {
+  font-family: var(--mono);
+  font-weight: 600;
+  font-size: .95rem;
+  color: var(--reflex);
+  background: rgba(217,255,61,.08);
+  border: 1px solid rgba(217,255,61,.25);
+  border-radius: 8px;
+  padding: .35rem .5rem;
+  white-space: nowrap;
+}
+.ride .name { font-weight: 600; line-height: 1.25; }
+.ride .place { display: block; font-size: .78rem; color: var(--fg-dim); font-weight: 400; }
+.ride.live .time { color: var(--katzenauge); border-color: rgba(255,74,58,.4); background: rgba(255,74,58,.08); }
+.live-dot {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--katzenauge);
+  margin-left: auto;
+  box-shadow: 0 0 0 0 rgba(255,74,58,.6);
+  animation: pulse 1.8s ease-out infinite;
+}
+@keyframes pulse {
+  0% { box-shadow: 0 0 0 0 rgba(255,74,58,.55); }
+  100% { box-shadow: 0 0 0 12px rgba(255,74,58,0); }
+}
+@media (prefers-reduced-motion: reduce) { .live-dot { animation: none; } }
+
+/* Tacho-Kacheln */
+.dash {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: .9rem;
+}
+.tile {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 1.1rem 1.2rem;
+}
+.tile .v {
+  font-family: var(--mono);
+  font-size: 1.7rem;
+  font-weight: 600;
+}
+.tile .v sup { font-size: .55em; color: var(--fg-dim); font-weight: 400; margin-left: .2rem; }
+.tile .k {
+  font-size: .75rem;
+  color: var(--fg-dim);
+  text-transform: uppercase;
+  letter-spacing: .1em;
+  margin-top: .3rem;
+}
+.tile.hl { border-color: rgba(217,255,61,.35); }
+.tile.hl .v { color: var(--reflex); }
+.dash-note { margin-top: .9rem; font-size: .8rem; color: var(--fg-dim); }
+.dash-note a { color: var(--frontlicht); }
+
+/* Karte-Teaser */
+.mapteaser {
+  position: relative;
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  background:
+    radial-gradient(ellipse at 30% 20%, rgba(90,169,255,.08), transparent 50%),
+    radial-gradient(ellipse at 75% 70%, rgba(217,255,61,.05), transparent 45%),
+    var(--panel);
+  min-height: 300px;
+  overflow: hidden;
+  display: flex;
+  align-items: flex-end;
+}
+.mapteaser svg.dots { position: absolute; inset: 0; width: 100%; height: 100%; }
+.mapteaser .cta {
+  position: relative;
+  margin: 1.4rem;
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.mapteaser .cta p { font-size: .9rem; color: var(--fg-dim); }
+
+/* ---------- Footer ---------- */
+footer {
+  border-top: 1px solid var(--line);
+  margin-top: 2rem;
+  padding: 2.5rem 1.25rem 3rem;
+}
+.foot { max-width: 1200px; margin: 0 auto; display: flex; flex-wrap: wrap; gap: 2rem; justify-content: space-between; }
+.foot nav { display: flex; gap: 1.4rem; flex-wrap: wrap; }
+.foot a { color: var(--fg-dim); text-decoration: none; font-size: .85rem; }
+.foot a:hover { color: var(--reflex); }
+.foot .sig { font-family: var(--mono); font-size: .75rem; color: var(--fg-dim); }
+
+/* ---------- Mobile Tabbar ---------- */
+.tabbar {
+  position: fixed;
+  bottom: 0; left: 0; right: 0;
+  z-index: 50;
+  display: none;
+  background: rgba(16,19,24,.92);
+  backdrop-filter: blur(12px);
+  border-top: 1px solid var(--line);
+  padding: .45rem .5rem calc(.45rem + env(safe-area-inset-bottom));
+}
+.tabbar a {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: .2rem;
+  text-decoration: none;
+  font-size: .62rem;
+  letter-spacing: .04em;
+  color: var(--fg-dim);
+  padding: .3rem 0;
+}
+.tabbar a svg { stroke: currentColor; }
+.tabbar a.active { color: var(--reflex); }
+
+.proto-back {
+  position: fixed;
+  bottom: 90px;
+  right: 14px;
+  z-index: 60;
+  font-size: .72rem;
+  text-decoration: none;
+  background: var(--panel-2);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: .35rem .8rem;
+  color: var(--fg-dim);
+}
+
+/* ---------- Responsive ---------- */
+@media (max-width: 900px) {
+  .hero-grid { grid-template-columns: 1fr; gap: 2.2rem; }
+  .top nav { display: none; }
+  .tabbar { display: flex; }
+}
+@media (min-width: 901px) {
+  body { padding-bottom: 0; }
+  .proto-back { bottom: 14px; }
+}
+</style>
+</head>
+<body>
+
+<header class="top">
+  <a class="brand" href="#"><span class="patch" aria-hidden="true"></span>criticalmass.in</a>
+  <nav>
+    <a href="#" aria-current="page">Start</a>
+    <a href="#">Städte</a>
+    <a href="#">Kalender</a>
+    <a href="#">Karte</a>
+    <a href="#">Forum</a>
+  </nav>
+  <a class="login" href="#">Anmelden</a>
+</header>
+
+<section class="hero">
+  <svg class="hero-route" viewBox="0 0 1200 520" preserveAspectRatio="xMidYMid slice" aria-hidden="true">
+    <defs>
+      <filter id="glow" x="-30%" y="-30%" width="160%" height="160%">
+        <feGaussianBlur stdDeviation="7" result="b"/>
+        <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
+      </filter>
+    </defs>
+    <polyline points="-40,420 140,400 230,300 330,330 420,250 560,280 660,180 800,220 920,140 1080,190 1240,120"
+      fill="none" stroke="rgba(90,169,255,.16)" stroke-width="26" stroke-linecap="round" stroke-linejoin="round"/>
+    <polyline points="-40,420 140,400 230,300 330,330 420,250 560,280 660,180 800,220 920,140 1080,190 1240,120"
+      fill="none" stroke="rgba(217,255,61,.5)" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"
+      filter="url(#glow)" stroke-dasharray="14 10" class="trail"/>
+    <style>
+      .trail { animation: ride 9s linear infinite; }
+      @keyframes ride { to { stroke-dashoffset: -240; } }
+      @media (prefers-reduced-motion: reduce) { .trail { animation: none; } }
+    </style>
+  </svg>
+
+  <div class="hero-grid">
+    <div>
+      <span class="label">Letzter Freitag im Monat · 19:00</span>
+      <h1>Nachts gehört<br>die Stadt allen.
+        <small>Critical Mass — gemeinsame Ausfahrten in über 600 Städten.
+        Kein Verein, keine Anmeldung. Einfach hinkommen.</small>
+      </h1>
+      <div class="actions">
+        <a class="btn primary" href="#">Tour in deiner Nähe</a>
+        <a class="btn" href="#">Wie funktioniert das?</a>
+      </div>
+    </div>
+
+    <div class="count-card" aria-label="Countdown zur nächsten Tour">
+      <div class="where">
+        <strong>Critical Mass Hamburg</strong>
+        <span>FR 26.06. · 19:00</span>
+      </div>
+      <div class="digits" id="countdown">
+        <div class="digit"><b data-u="d">–</b><span>Tage</span></div>
+        <div class="digit"><b data-u="h">–</b><span>Std</span></div>
+        <div class="digit"><b data-u="m">–</b><span>Min</span></div>
+        <div class="digit"><b data-u="s">–</b><span>Sek</span></div>
+      </div>
+      <p class="meet">
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="#d9ff3d" stroke-width="1.5" aria-hidden="true">
+          <path d="M8 14s5-4.6 5-8a5 5 0 0 0-10 0c0 3.4 5 8 5 8z"/><circle cx="8" cy="6" r="1.8"/>
+        </svg>
+        Treffpunkt: <b>Alstervorland, Höhe Milchstraße</b>
+      </p>
+    </div>
+  </div>
+</section>
+
+<section class="block">
+  <div class="block-head">
+    <h2>Heute unterwegs</h2>
+    <a href="#">Alle 43 Touren der nächsten 14 Tage →</a>
+  </div>
+  <div class="tonight">
+    <a class="ride live" href="#">
+      <span class="time">jetzt</span>
+      <span class="name">Lisboa<span class="place">Marquês de Pombal · seit 21:00</span></span>
+      <span class="live-dot" aria-hidden="true"></span>
+    </a>
+    <a class="ride" href="#">
+      <span class="time">17:00</span>
+      <span class="name">Falkensee<span class="place">Bahnhofsvorplatz</span></span>
+    </a>
+    <a class="ride" href="#">
+      <span class="time">18:00</span>
+      <span class="name">Düren<span class="place">Treffpunkt auf der Karte</span></span>
+    </a>
+    <a class="ride" href="#">
+      <span class="time">18:00</span>
+      <span class="name">Pittsburgh<span class="place">Dippy the Dinosaur</span></span>
+    </a>
+    <a class="ride" href="#">
+      <span class="time">19:00</span>
+      <span class="name">Düsseldorf<span class="place">Fürstenplatz</span></span>
+    </a>
+    <a class="ride" href="#">
+      <span class="time">19:00</span>
+      <span class="name">Frankfurt<span class="place">Opernplatz</span></span>
+    </a>
+    <a class="ride" href="#">
+      <span class="time">19:00</span>
+      <span class="name">Hagen<span class="place">Treffpunkt auf der Karte</span></span>
+    </a>
+    <a class="ride" href="#">
+      <span class="time">19:00</span>
+      <span class="name">Treptow-Köpenick<span class="place">Treffpunkt auf der Karte</span></span>
+    </a>
+  </div>
+</section>
+
+<section class="block">
+  <div class="block-head">
+    <h2>Nach der Fahrt</h2>
+    <a href="#">Track hochladen →</a>
+  </div>
+  <div class="dash">
+    <div class="tile hl"><div class="v">36,23<sup>km</sup></div><div class="k">Letzter Track · Berlin</div></div>
+    <div class="tile"><div class="v">3:44<sup>h</sup></div><div class="k">Fahrzeit</div></div>
+    <div class="tile"><div class="v">9,7<sup>km/h</sup></div><div class="k">Masse-Tempo</div></div>
+    <div class="tile"><div class="v">12<sup>±</sup></div><div class="k">Schätzung Norderstedt</div></div>
+    <div class="tile"><div class="v">4<sup>neu</sup></div><div class="k">Fotos aus Bonn</div></div>
+  </div>
+  <p class="dash-note">GPX- und FIT-Dateien werden direkt hochgeladen — dein Track gehört dir,
+    nicht einer Plattform. <a href="#">Mehr zur Datenhaltung</a></p>
+</section>
+
+<section class="block">
+  <div class="block-head">
+    <h2>Wo fährt die Masse?</h2>
+  </div>
+  <div class="mapteaser">
+    <svg class="dots" viewBox="0 0 1160 300" preserveAspectRatio="xMidYMid slice" aria-hidden="true">
+      <g fill="rgba(191,227,255,.65)">
+        <circle cx="520" cy="96" r="3"/><circle cx="548" cy="118" r="2.4"/><circle cx="566" cy="88" r="2"/>
+        <circle cx="538" cy="74" r="2"/><circle cx="586" cy="120" r="2.6"/><circle cx="602" cy="96" r="2"/>
+        <circle cx="498" cy="120" r="2.2"/><circle cx="556" cy="146" r="2"/><circle cx="618" cy="142" r="2"/>
+        <circle cx="470" cy="92" r="2"/><circle cx="445" cy="120" r="2.4"/><circle cx="430" cy="150" r="2"/>
+        <circle cx="252" cy="130" r="2.6"/><circle cx="208" cy="148" r="2"/><circle cx="232" cy="170" r="2"/>
+        <circle cx="180" cy="120" r="2"/><circle cx="300" cy="208" r="2.4"/><circle cx="330" cy="236" r="2"/>
+        <circle cx="840" cy="190" r="2.4"/><circle cx="884" cy="170" r="2"/><circle cx="960" cy="226" r="2.6"/>
+        <circle cx="1020" cy="250" r="2"/><circle cx="700" cy="220" r="2"/><circle cx="660" cy="250" r="2"/>
+      </g>
+      <g fill="#d9ff3d">
+        <circle cx="540" cy="100" r="4.5"><animate attributeName="opacity" values="1;.3;1" dur="2.4s" repeatCount="indefinite"/></circle>
+        <circle cx="402" cy="186" r="4.5"><animate attributeName="opacity" values=".3;1;.3" dur="2.4s" repeatCount="indefinite"/></circle>
+      </g>
+    </svg>
+    <div class="cta">
+      <a class="btn primary" href="#">Karte öffnen</a>
+      <p>612 Städte · zuletzt dazugekommen: Stirling&nbsp;(Schottland)</p>
+    </div>
+  </div>
+</section>
+
+<footer>
+  <div class="foot">
+    <nav>
+      <a href="#">Über die Critical Mass</a>
+      <a href="#">FAQ</a>
+      <a href="#">API</a>
+      <a href="#">Impressum</a>
+      <a href="#">Datenschutz</a>
+    </nav>
+    <span class="sig">karten © openstreetmap · open source · seit 2011 im sattel</span>
+  </div>
+</footer>
+
+<nav class="tabbar" aria-label="Hauptnavigation">
+  <a href="#" class="active">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="1.8"><path d="M3 11.5 12 4l9 7.5M5.5 10v9h13v-9"/></svg>
+    Start
+  </a>
+  <a href="#">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="1.8"><path d="M12 21s7-6.1 7-11a7 7 0 0 0-14 0c0 4.9 7 11 7 11z"/><circle cx="12" cy="9.6" r="2.4"/></svg>
+    Karte
+  </a>
+  <a href="#">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="1.8"><rect x="3.5" y="5" width="17" height="15.5" rx="2"/><path d="M3.5 9.5h17M8 3v4M16 3v4"/></svg>
+    Kalender
+  </a>
+  <a href="#">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="1.8"><circle cx="12" cy="8.4" r="3.4"/><path d="M5 20c.8-3.4 3.6-5.2 7-5.2s6.2 1.8 7 5.2"/></svg>
+    Konto
+  </a>
+</nav>
+
+<a class="proto-back" href="index.html">← Übersicht</a>
+
+<script>
+(function () {
+  var target = new Date("2026-06-26T19:00:00+02:00").getTime();
+  var els = {
+    d: document.querySelector('[data-u="d"]'),
+    h: document.querySelector('[data-u="h"]'),
+    m: document.querySelector('[data-u="m"]'),
+    s: document.querySelector('[data-u="s"]')
+  };
+  function pad(n) { return n < 10 ? "0" + n : "" + n; }
+  function tick() {
+    var diff = Math.max(0, target - Date.now());
+    var d = Math.floor(diff / 864e5);
+    var h = Math.floor(diff % 864e5 / 36e5);
+    var m = Math.floor(diff % 36e5 / 6e4);
+    var s = Math.floor(diff % 6e4 / 1e3);
+    els.d.textContent = d;
+    els.h.textContent = pad(h);
+    els.m.textContent = pad(m);
+    els.s.textContent = pad(s);
+  }
+  tick();
+  setInterval(tick, 1000);
+})();
+</script>
+
+</body>
+</html>

--- a/design-prototypes/03-fahrplan.html
+++ b/design-prototypes/03-fahrplan.html
@@ -1,0 +1,588 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Prototyp 3 · Fahrplan — criticalmass.in</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;500;600;700&family=Barlow+Condensed:wght@500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+:root {
+  --bg: #fcfbf7;
+  --ink: #121110;
+  --mid: #6d6a63;
+  --rule: #d9d6cc;
+  --rule-strong: #121110;
+  --green: #008f4c;     /* Signalgrün */
+  --red: #d8232a;       /* Störungsrot */
+  --board: #15181a;
+  --amber: #ffb000;
+  --sans: "Barlow", "Helvetica Neue", Arial, sans-serif;
+  --cond: "Barlow Condensed", "Arial Narrow", sans-serif;
+  --mono: "IBM Plex Mono", Menlo, monospace;
+}
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html, body { overflow-x: clip; }
+body {
+  font-family: var(--sans);
+  background: var(--bg);
+  color: var(--ink);
+  line-height: 1.5;
+  font-feature-settings: "tnum";
+}
+a { color: inherit; }
+.wrap { max-width: 1100px; margin: 0 auto; padding: 0 1.25rem; }
+
+/* ---------- Kopf ---------- */
+header.mast { padding: 1.6rem 0 .9rem; }
+.mast-top {
+  display: flex;
+  align-items: baseline;
+  gap: 1.2rem;
+  flex-wrap: wrap;
+}
+.mast h1 {
+  font-family: var(--cond);
+  font-weight: 700;
+  font-size: clamp(2.2rem, 6vw, 3.6rem);
+  text-transform: uppercase;
+  letter-spacing: .015em;
+  line-height: .95;
+}
+.mast h1 .dot { color: var(--green); }
+.mast .issue {
+  font-family: var(--mono);
+  font-size: .78rem;
+  color: var(--mid);
+  margin-left: auto;
+  text-align: right;
+}
+nav.mainnav {
+  margin-top: 1.1rem;
+  border-top: 3px solid var(--rule-strong);
+  border-bottom: 1px solid var(--rule-strong);
+  display: flex;
+  gap: 0;
+  flex-wrap: wrap;
+}
+nav.mainnav a {
+  font-family: var(--cond);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: .08em;
+  font-size: .95rem;
+  text-decoration: none;
+  padding: .55rem 1.1rem .5rem;
+  border-right: 1px solid var(--rule);
+}
+nav.mainnav a:first-child { padding-left: 0; }
+nav.mainnav a[aria-current] { color: var(--green); }
+nav.mainnav a:hover { background: #f1efe7; }
+nav.mainnav .right { margin-left: auto; border-right: 0; border-left: 1px solid var(--rule); }
+
+/* ---------- Intro-Zeile ---------- */
+.standfirst {
+  padding: 1.4rem 0 1.6rem;
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+  gap: 2rem;
+}
+.standfirst p.big {
+  font-size: clamp(1.15rem, 2.4vw, 1.45rem);
+  font-weight: 500;
+  line-height: 1.4;
+  max-width: 42rem;
+}
+.standfirst p.big b { color: var(--green); }
+.standfirst .note {
+  font-size: .85rem;
+  color: var(--mid);
+  border-left: 3px solid var(--green);
+  padding-left: .9rem;
+  align-self: center;
+}
+
+/* ---------- Abfahrtstafel ---------- */
+.board {
+  background: var(--board);
+  color: var(--amber);
+  font-family: var(--mono);
+  border-radius: 4px;
+  padding: 1.1rem 1.2rem 1.3rem;
+  overflow-x: auto;
+}
+.board .board-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: baseline;
+  color: #e8e6df;
+  font-family: var(--cond);
+  text-transform: uppercase;
+  letter-spacing: .1em;
+  font-weight: 600;
+  font-size: 1rem;
+  margin-bottom: .8rem;
+}
+.board .clock { font-family: var(--mono); font-size: .85rem; color: var(--amber); }
+.board .clock .blink { animation: blink 1s steps(1) infinite; }
+@keyframes blink { 50% { opacity: 0; } }
+@media (prefers-reduced-motion: reduce) { .board .clock .blink { animation: none; } }
+.board table { width: 100%; border-collapse: collapse; min-width: 560px; }
+.board th {
+  text-align: left;
+  font-weight: 400;
+  font-size: .68rem;
+  text-transform: uppercase;
+  letter-spacing: .16em;
+  color: #8c8f93;
+  padding: .25rem .8rem .45rem 0;
+  border-bottom: 1px solid #2a2e31;
+}
+.board td {
+  padding: .5rem .8rem .5rem 0;
+  border-bottom: 1px solid #232729;
+  font-size: .95rem;
+  white-space: nowrap;
+}
+.board td.t { font-weight: 600; width: 5.2ch; }
+.board td.city { color: #fff; font-family: var(--sans); font-weight: 600; }
+.board td.meet { color: #b9bcbf; font-family: var(--sans); font-weight: 400; font-size: .88rem; }
+.board td.info { font-size: .78rem; }
+.board td.info .ok { color: #46d17e; }
+.board td.info .warn { color: #ff5a4e; }
+.board tr:last-child td { border-bottom: 0; }
+
+/* ---------- Wochen-Fahrplan ---------- */
+section.plan { padding: 2.6rem 0 1rem; }
+.plan h2, .meldungen h2, .ticket-sec h2 {
+  font-family: var(--cond);
+  font-weight: 700;
+  text-transform: uppercase;
+  font-size: 1.5rem;
+  letter-spacing: .04em;
+  border-bottom: 3px solid var(--rule-strong);
+  padding-bottom: .35rem;
+  margin-bottom: 0;
+  display: flex;
+  align-items: baseline;
+  gap: 1rem;
+}
+.plan h2 small, .meldungen h2 small {
+  font-family: var(--sans);
+  font-weight: 500;
+  font-size: .8rem;
+  text-transform: none;
+  letter-spacing: 0;
+  color: var(--mid);
+  margin-left: auto;
+}
+.dayrow { border-bottom: 1px solid var(--rule); padding: .9rem 0; display: grid; grid-template-columns: 9.5rem 1fr; gap: 1rem; }
+.dayrow:last-of-type { border-bottom: 3px solid var(--rule-strong); }
+.dayrow .day {
+  font-family: var(--cond);
+  font-weight: 700;
+  text-transform: uppercase;
+  font-size: 1.05rem;
+  letter-spacing: .04em;
+}
+.dayrow .day small { display: block; font-family: var(--sans); font-weight: 400; font-size: .75rem; color: var(--mid); text-transform: none; letter-spacing: 0; }
+.stops { display: flex; flex-wrap: wrap; gap: .45rem .55rem; }
+.stop {
+  display: inline-flex;
+  align-items: baseline;
+  gap: .5rem;
+  border: 1px solid var(--rule);
+  background: #fff;
+  text-decoration: none;
+  padding: .32rem .6rem .32rem .5rem;
+  border-radius: 3px;
+  font-size: .9rem;
+  transition: border-color .12s ease;
+}
+.stop:hover { border-color: var(--ink); }
+.stop .cc {
+  font-family: var(--mono);
+  font-size: .62rem;
+  font-weight: 600;
+  color: #fff;
+  background: var(--ink);
+  padding: .12rem .3rem;
+  border-radius: 2px;
+  letter-spacing: .05em;
+}
+.stop .cc.at { background: var(--red); }
+.stop .cc.pt { background: var(--green); }
+.stop .cc.us { background: #1f4ea1; }
+.stop .cc.uk { background: #5b3a8c; }
+.stop b { font-weight: 600; }
+.stop .tt { font-family: var(--mono); font-size: .8rem; color: var(--mid); }
+.plan .all {
+  display: inline-block;
+  margin-top: 1.1rem;
+  font-family: var(--cond);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: .06em;
+  text-decoration: none;
+  border: 2px solid var(--ink);
+  padding: .5rem 1rem;
+  border-radius: 3px;
+}
+.plan .all:hover { background: var(--ink); color: var(--bg); }
+
+/* ---------- Fahrkarte ---------- */
+.ticket-sec { padding: 2.2rem 0; }
+.ticket {
+  margin-top: 1.4rem;
+  display: grid;
+  grid-template-columns: minmax(0, 2.2fr) minmax(170px, 1fr);
+  border: 2px solid var(--ink);
+  border-radius: 6px;
+  background: #fff;
+  max-width: 720px;
+  position: relative;
+}
+.ticket .main { padding: 1.3rem 1.5rem 1.4rem; }
+.ticket .rip {
+  border-left: 2px dashed var(--rule);
+  padding: 1.3rem 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: .7rem;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+.ticket .kopf {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  font-family: var(--cond);
+  text-transform: uppercase;
+  font-weight: 600;
+  letter-spacing: .1em;
+  font-size: .8rem;
+  color: var(--mid);
+  margin-bottom: .7rem;
+}
+.ticket .kopf b { color: var(--green); }
+.ticket .strecke {
+  font-family: var(--cond);
+  font-weight: 700;
+  font-size: clamp(1.7rem, 4.5vw, 2.4rem);
+  text-transform: uppercase;
+  line-height: 1;
+}
+.ticket .strecke span { color: var(--mid); font-size: .65em; }
+.ticket dl {
+  display: grid;
+  grid-template-columns: repeat(3, auto);
+  gap: .9rem 2rem;
+  margin-top: 1.1rem;
+  justify-content: start;
+}
+.ticket dt {
+  font-size: .62rem;
+  text-transform: uppercase;
+  letter-spacing: .14em;
+  color: var(--mid);
+}
+.ticket dd { font-family: var(--mono); font-weight: 500; font-size: .98rem; }
+.ticket .rip svg { width: 74px; height: 74px; }
+.ticket .rip .hint { font-size: .7rem; color: var(--mid); line-height: 1.45; }
+.ticket .stempel {
+  position: absolute;
+  top: -14px;
+  right: 16px;
+  background: var(--green);
+  color: #fff;
+  font-family: var(--cond);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .12em;
+  font-size: .72rem;
+  padding: .3rem .7rem;
+  border-radius: 3px;
+}
+.ticket-actions { margin-top: 1.2rem; display: flex; gap: .8rem; flex-wrap: wrap; }
+.ticket-actions a {
+  font-family: var(--cond);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: .06em;
+  font-size: .9rem;
+  text-decoration: none;
+  border: 2px solid var(--ink);
+  border-radius: 3px;
+  padding: .45rem .9rem;
+}
+.ticket-actions a.go { background: var(--green); border-color: var(--green); color: #fff; }
+.ticket-actions a:hover { opacity: .85; }
+
+/* ---------- Meldungen ---------- */
+.meldungen { padding: 1.6rem 0 3rem; }
+.meldung-list { border-bottom: 3px solid var(--rule-strong); }
+.meldung {
+  display: grid;
+  grid-template-columns: 7.5rem 1fr auto;
+  gap: 1rem;
+  padding: .7rem 0;
+  border-bottom: 1px solid var(--rule);
+  font-size: .92rem;
+  align-items: baseline;
+}
+.meldung:last-child { border-bottom: 0; }
+.meldung .ts { font-family: var(--mono); font-size: .75rem; color: var(--mid); }
+.meldung .typ {
+  font-family: var(--mono);
+  font-size: .68rem;
+  text-transform: uppercase;
+  letter-spacing: .1em;
+  color: var(--green);
+  white-space: nowrap;
+}
+.meldung .typ.foto { color: #1f4ea1; }
+.meldung .typ.zahl { color: var(--red); }
+.meldung a { font-weight: 600; }
+
+/* ---------- Fuß ---------- */
+footer {
+  border-top: 3px solid var(--rule-strong);
+  padding: 1.6rem 0 2.6rem;
+  font-size: .8rem;
+  color: var(--mid);
+}
+footer .cols { display: flex; flex-wrap: wrap; gap: 1.6rem; justify-content: space-between; }
+footer nav { display: flex; gap: 1.2rem; flex-wrap: wrap; }
+footer a { text-decoration: none; }
+footer a:hover { color: var(--ink); text-decoration: underline; }
+
+.proto-back {
+  position: fixed;
+  bottom: 14px;
+  right: 14px;
+  z-index: 50;
+  font-size: .75rem;
+  font-weight: 600;
+  text-decoration: none;
+  background: #fff;
+  border: 1px solid var(--rule);
+  border-radius: 3px;
+  padding: .35rem .7rem;
+  color: var(--mid);
+}
+
+/* ---------- Mobil ---------- */
+@media (max-width: 760px) {
+  .standfirst { grid-template-columns: 1fr; gap: 1rem; }
+  .dayrow { grid-template-columns: 1fr; gap: .5rem; }
+  .ticket { grid-template-columns: 1fr; }
+  .ticket .rip { border-left: 0; border-top: 2px dashed var(--rule); flex-direction: row; align-items: center; }
+  .ticket dl { grid-template-columns: repeat(2, minmax(0, 1fr)); gap: .9rem 1.2rem; }
+  .ticket dd { white-space: normal; }
+  .mast .issue { margin-left: 0; text-align: left; width: 100%; }
+  .meldung { grid-template-columns: 1fr; gap: .15rem; }
+}
+</style>
+</head>
+<body>
+
+<div class="wrap">
+  <header class="mast">
+    <div class="mast-top">
+      <h1>criticalmass<span class="dot">.</span>in</h1>
+      <p class="issue">Fahrplan der gemeinsamen Ausfahrten<br>Ausgabe Juni 2026 · gültig bis auf Widerruf</p>
+    </div>
+    <nav class="mainnav">
+      <a href="#" aria-current="page">Abfahrten</a>
+      <a href="#">Städte</a>
+      <a href="#">Kalender</a>
+      <a href="#">Statistik</a>
+      <a href="#">Forum</a>
+      <a class="right" href="#">Anmelden</a>
+    </nav>
+  </header>
+
+  <section class="standfirst">
+    <p class="big">Kein Betreiber, kein Tarif, keine Verspätungs&shy;entschädigung:
+      Die Critical Mass fährt trotzdem pünktlich — <b>jeden letzten Freitag im Monat</b>,
+      in über 600 Städten. Hier steht, wann und wo.</p>
+    <p class="note">Es gilt §&nbsp;27 StVO: Mehr als 15 Radfahrende dürfen als
+      geschlossener Verband fahren. Zwei nebeneinander. Die Masse ist der Verband.</p>
+  </section>
+
+  <section aria-label="Abfahrtstafel">
+    <div class="board">
+      <div class="board-head">
+        <span>Abfahrten · Freitag, 12. Juni 2026</span>
+        <span class="clock">17<span class="blink">:</span>42</span>
+      </div>
+      <table>
+        <thead>
+          <tr><th>Zeit</th><th>Stadt</th><th>Treffpunkt</th><th>Hinweis</th></tr>
+        </thead>
+        <tbody>
+          <tr><td class="t">17:00</td><td class="city">Falkensee</td><td class="meet">Bahnhofsvorplatz</td><td class="info"><span class="ok">fährt</span></td></tr>
+          <tr><td class="t">17:00</td><td class="city">Oranienburg</td><td class="meet">Schlossplatz</td><td class="info"><span class="ok">fährt</span></td></tr>
+          <tr><td class="t">18:00</td><td class="city">Bergisch Gladbach</td><td class="meet">Konrad-Adenauer-Platz</td><td class="info"><span class="ok">fährt</span></td></tr>
+          <tr><td class="t">18:00</td><td class="city">Düren</td><td class="meet">siehe Karte</td><td class="info"><span class="ok">fährt</span></td></tr>
+          <tr><td class="t">18:00</td><td class="city">Witten</td><td class="meet">Rathausplatz</td><td class="info"><span class="warn">Regen gemeldet</span></td></tr>
+          <tr><td class="t">18:30</td><td class="city">Fellbach</td><td class="meet">Guntram-Palm-Platz</td><td class="info"><span class="ok">fährt</span></td></tr>
+          <tr><td class="t">19:00</td><td class="city">Düsseldorf</td><td class="meet">Fürstenplatz</td><td class="info"><span class="ok">fährt</span></td></tr>
+          <tr><td class="t">19:00</td><td class="city">Frankfurt am Main</td><td class="meet">Opernplatz</td><td class="info"><span class="ok">fährt</span></td></tr>
+          <tr><td class="t">19:00</td><td class="city">Pittsburgh</td><td class="meet">Dippy the Dinosaur</td><td class="info"><span class="ok">fährt</span></td></tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section class="plan">
+    <h2>Die nächsten 14 Tage <small>43 Abfahrten · alle Zeiten Ortszeit</small></h2>
+
+    <div class="dayrow">
+      <div class="day">Sa, 13. Juni<small>morgen</small></div>
+      <div class="stops">
+        <a class="stop" href="#"><span class="cc">DE</span><b>Pinneberg</b><span class="tt">20:45</span></a>
+      </div>
+    </div>
+    <div class="dayrow">
+      <div class="day">Di, 16. Juni</div>
+      <div class="stops">
+        <a class="stop" href="#"><span class="cc pt">PT</span><b>Lisboa</b><span class="tt">21:00</span></a>
+      </div>
+    </div>
+    <div class="dayrow">
+      <div class="day">Fr, 19. Juni</div>
+      <div class="stops">
+        <a class="stop" href="#"><span class="cc">DE</span><b>Fürth</b><span class="tt">18:00</span></a>
+        <a class="stop" href="#"><span class="cc">DE</span><b>Hannover</b><span class="tt">20:00</span></a>
+        <a class="stop" href="#"><span class="cc us">US</span><b>Los Angeles</b><span class="tt">18:30</span></a>
+        <a class="stop" href="#"><span class="cc">DE</span><b>Mannheim</b><span class="tt">18:45</span></a>
+        <a class="stop" href="#"><span class="cc at">AT</span><b>Wien</b><span class="tt">17:00</span></a>
+        <a class="stop" href="#"><span class="cc">DE</span><b>Wiesbaden</b><span class="tt">18:30</span></a>
+      </div>
+    </div>
+    <div class="dayrow">
+      <div class="day">Sa, 20. Juni</div>
+      <div class="stops">
+        <a class="stop" href="#"><span class="cc">DE</span><b>Herrenberg</b><span class="tt">11:00</span></a>
+        <a class="stop" href="#"><span class="cc">DE</span><b>Kaiserslautern</b><span class="tt">11:00</span></a>
+        <a class="stop" href="#"><span class="cc uk">UK</span><b>Stirling</b><span class="tt">10:00</span></a>
+      </div>
+    </div>
+    <div class="dayrow">
+      <div class="day">So, 21. Juni</div>
+      <div class="stops">
+        <a class="stop" href="#"><span class="cc">DE</span><b>Köln</b><span class="tt">13:00</span></a>
+        <a class="stop" href="#"><span class="cc">DE</span><b>Stuttgart</b><span class="tt">09:00</span></a>
+      </div>
+    </div>
+    <div class="dayrow">
+      <div class="day">Fr, 26. Juni<small>letzter Freitag — der große Tag</small></div>
+      <div class="stops">
+        <a class="stop" href="#"><span class="cc">DE</span><b>Hamburg</b><span class="tt">19:00</span></a>
+        <a class="stop" href="#"><span class="cc">DE</span><b>Berlin</b><span class="tt">20:00</span></a>
+        <a class="stop" href="#"><span class="cc">DE</span><b>München</b><span class="tt">19:00</span></a>
+        <a class="stop" href="#"><span class="cc at">AT</span><b>Graz</b><span class="tt">17:00</span></a>
+        <a class="stop" href="#"><span class="cc">DE</span><b>Bonn</b><span class="tt">18:00</span></a>
+        <a class="stop" href="#"><span class="cc">DE</span><b>Dresden</b><span class="tt">18:50</span></a>
+        <a class="stop" href="#"><span class="cc">+37</span><b>weitere</b></a>
+      </div>
+    </div>
+
+    <a class="all" href="#">Vollständiger Fahrplan · Kalenderansicht</a>
+  </section>
+
+  <section class="ticket-sec">
+    <h2>Deine nächste Fahrt</h2>
+    <article class="ticket" aria-label="Tourkarte Hamburg">
+      <span class="stempel">Einsteigen ohne Fahrschein</span>
+      <div class="main">
+        <div class="kopf">
+          <span>Critical Mass · Verbandsfahrt</span>
+          <b>Gültig: 26.06.2026</b>
+        </div>
+        <p class="strecke">Hamburg <span>ab Alstervorland, Höhe Milchstraße</span></p>
+        <dl>
+          <div><dt>Abfahrt</dt><dd>19:00</dd></div>
+          <div><dt>Dauer</dt><dd>± 2 Std</dd></div>
+          <div><dt>Tempo</dt><dd>gemütlich</dd></div>
+          <div><dt>Strecke</dt><dd>entsteht unterwegs</dd></div>
+          <div><dt>Zuletzt dabei</dt><dd>~ 2.400</dd></div>
+          <div><dt>Rückfahrt</dt><dd>eigene</dd></div>
+        </dl>
+        <div class="ticket-actions">
+          <a class="go" href="#">Ich fahre mit</a>
+          <a href="#">iCal</a>
+          <a href="#">Tour ansehen</a>
+        </div>
+      </div>
+      <div class="rip">
+        <svg viewBox="0 0 74 74" aria-hidden="true">
+          <rect width="74" height="74" fill="#fff"/>
+          <g fill="#121110">
+            <rect x="4" y="4" width="18" height="18"/><rect x="8" y="8" width="10" height="10" fill="#fff"/>
+            <rect x="52" y="4" width="18" height="18"/><rect x="56" y="8" width="10" height="10" fill="#fff"/>
+            <rect x="4" y="52" width="18" height="18"/><rect x="8" y="56" width="10" height="10" fill="#fff"/>
+            <rect x="28" y="4" width="6" height="6"/><rect x="40" y="10" width="6" height="6"/>
+            <rect x="28" y="16" width="6" height="6"/><rect x="34" y="28" width="6" height="6"/>
+            <rect x="10" y="28" width="6" height="6"/><rect x="22" y="34" width="6" height="6"/>
+            <rect x="4" y="40" width="6" height="6"/><rect x="16" y="40" width="6" height="6"/>
+            <rect x="46" y="28" width="6" height="6"/><rect x="58" y="34" width="6" height="6"/>
+            <rect x="64" y="46" width="6" height="6"/><rect x="46" y="40" width="6" height="6"/>
+            <rect x="52" y="52" width="6" height="6"/><rect x="34" y="46" width="6" height="6"/>
+            <rect x="28" y="58" width="6" height="6"/><rect x="40" y="64" width="6" height="6"/>
+            <rect x="58" y="64" width="6" height="6"/><rect x="64" y="58" width="6" height="6"/>
+          </g>
+        </svg>
+        <p class="hint">Kein echter Code — Critical Mass braucht kein Ticket.
+        In den Kalender legen reicht.</p>
+      </div>
+    </article>
+  </section>
+
+  <section class="meldungen">
+    <h2>Meldungen aus dem Netz <small>Schätzungen · Tracks · Fotos</small></h2>
+    <div class="meldung-list">
+      <div class="meldung">
+        <span class="ts">vor 3 Tagen</span>
+        <span>Katrin schätzt <a href="#">12 Radfahrende</a> bei der Critical Mass Norderstedt — Mittelwert bestätigt.</span>
+        <span class="typ zahl">Schätzung</span>
+      </div>
+      <div class="meldung">
+        <span class="ts">vor 5 Tagen</span>
+        <span><a href="#">1 neues Foto</a> zur Tour Norderstedt, 5. Juni — freigegeben.</span>
+        <span class="typ foto">Foto</span>
+      </div>
+      <div class="meldung">
+        <span class="ts">vor 8 Tagen</span>
+        <span>Track zur <a href="#">Critical Mass Berlin</a> hochgeladen: 36,23 km in 3 h 44 min.</span>
+        <span class="typ">Track</span>
+      </div>
+      <div class="meldung">
+        <span class="ts">vor 10 Tagen</span>
+        <span><a href="#">4 Fotos</a> zur Tour Bonn, 29. Mai — Galerie aktualisiert.</span>
+        <span class="typ foto">Foto</span>
+      </div>
+    </div>
+  </section>
+
+  <footer>
+    <div class="cols">
+      <nav>
+        <a href="#">Über die Critical Mass</a>
+        <a href="#">FAQ</a>
+        <a href="#">API</a>
+        <a href="#">Impressum</a>
+        <a href="#">Datenschutz</a>
+      </nav>
+      <span>Karten © OpenStreetMap-Mitwirkende · Open Source · keine Werbung, kein Tracking</span>
+    </div>
+  </footer>
+</div>
+
+<a class="proto-back" href="index.html">← Übersicht</a>
+
+</body>
+</html>

--- a/design-prototypes/04-atlas.html
+++ b/design-prototypes/04-atlas.html
@@ -1,0 +1,612 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Prototyp 4 · Atlas — criticalmass.in</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300;0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;1,9..144,400&family=Archivo:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+:root {
+  --paper: #f7f2e7;
+  --paper-deep: #efe8d8;
+  --ink: #211e19;
+  --ink-soft: #5c564b;
+  --terra: #b4451f;
+  --mapblue: #2b4a7d;
+  --moss: #50653f;
+  --hair: #cfc6b2;
+  --serif: "Fraunces", Georgia, "Times New Roman", serif;
+  --sans: "Archivo", "Helvetica Neue", Arial, sans-serif;
+}
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html, body { overflow-x: clip; }
+body {
+  font-family: var(--serif);
+  background: var(--paper);
+  color: var(--ink);
+  line-height: 1.6;
+}
+a { color: inherit; }
+.wrap { max-width: 1060px; margin: 0 auto; padding: 0 1.4rem; }
+
+/* ---------- Masthead ---------- */
+header.mast {
+  text-align: center;
+  padding: 2.6rem 1rem 1.6rem;
+  border-bottom: 1px solid var(--ink);
+  position: relative;
+}
+.mast .over {
+  font-family: var(--sans);
+  font-size: .72rem;
+  text-transform: uppercase;
+  letter-spacing: .3em;
+  color: var(--ink-soft);
+}
+.mast h1 {
+  font-weight: 600;
+  font-size: clamp(2.6rem, 7vw, 4.6rem);
+  font-variation-settings: "opsz" 144;
+  letter-spacing: .01em;
+  line-height: 1.05;
+  margin: .5rem 0 .4rem;
+}
+.mast h1 em { font-style: italic; font-weight: 400; color: var(--terra); }
+.mast .issue {
+  font-family: var(--sans);
+  font-size: .75rem;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+  display: flex;
+  justify-content: center;
+  gap: 1.6rem;
+  flex-wrap: wrap;
+}
+nav.mainnav {
+  border-bottom: 1px solid var(--ink);
+  display: flex;
+  justify-content: center;
+  gap: 2.4rem;
+  padding: .7rem 1rem;
+  flex-wrap: wrap;
+  font-family: var(--sans);
+}
+nav.mainnav a {
+  text-decoration: none;
+  font-size: .82rem;
+  text-transform: uppercase;
+  letter-spacing: .14em;
+}
+nav.mainnav a:hover, nav.mainnav a[aria-current] { color: var(--terra); }
+
+/* ---------- Lead ---------- */
+.lead-sec {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(0, .85fr);
+  gap: 3rem;
+  padding: 3rem 0 2.6rem;
+  border-bottom: 1px solid var(--hair);
+}
+.kicker {
+  font-family: var(--sans);
+  font-size: .72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: .22em;
+  color: var(--terra);
+  display: block;
+  margin-bottom: .9rem;
+}
+.lead-sec h2 {
+  font-size: clamp(1.9rem, 4.4vw, 3rem);
+  font-weight: 500;
+  line-height: 1.12;
+  margin-bottom: 1.2rem;
+  font-variation-settings: "opsz" 100;
+}
+.lead-sec .body {
+  font-size: 1.04rem;
+  color: #36322a;
+}
+.lead-sec .body p + p { margin-top: .9rem; }
+.lead-sec .body p:first-child::first-letter {
+  font-size: 3.4em;
+  float: left;
+  line-height: .82;
+  padding: .06em .12em 0 0;
+  font-weight: 600;
+  color: var(--terra);
+}
+.lead-sec .more {
+  display: inline-block;
+  margin-top: 1.4rem;
+  font-family: var(--sans);
+  font-size: .82rem;
+  font-weight: 600;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  text-decoration: none;
+  border-bottom: 2px solid var(--terra);
+  padding-bottom: .2rem;
+}
+
+/* Nächste-Fahrt-Kasten */
+.nextbox {
+  border: 1px solid var(--ink);
+  background: var(--paper-deep);
+  padding: 1.6rem 1.6rem 1.4rem;
+  align-self: start;
+  position: relative;
+}
+.nextbox::after {
+  content: "";
+  position: absolute;
+  inset: 6px;
+  border: 1px solid rgba(33,30,25,.25);
+  pointer-events: none;
+}
+.nextbox .rubrik {
+  font-family: var(--sans);
+  font-size: .68rem;
+  font-weight: 600;
+  letter-spacing: .24em;
+  text-transform: uppercase;
+  text-align: center;
+  color: var(--ink-soft);
+  margin-bottom: 1rem;
+}
+.nextbox h3 {
+  text-align: center;
+  font-size: 2rem;
+  font-weight: 600;
+  line-height: 1.05;
+}
+.nextbox .when {
+  text-align: center;
+  font-style: italic;
+  font-size: 1.05rem;
+  color: var(--terra);
+  margin: .5rem 0 1.1rem;
+}
+.nextbox dl {
+  font-family: var(--sans);
+  font-size: .88rem;
+  border-top: 1px solid var(--hair);
+}
+.nextbox dl div {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: .5rem 0;
+  border-bottom: 1px solid var(--hair);
+}
+.nextbox dt { color: var(--ink-soft); }
+.nextbox dd { font-weight: 600; text-align: right; }
+.nextbox .acts { display: flex; gap: .7rem; margin-top: 1.2rem; }
+.nextbox .acts a {
+  flex: 1;
+  text-align: center;
+  font-family: var(--sans);
+  font-size: .8rem;
+  font-weight: 600;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  text-decoration: none;
+  padding: .6rem .4rem;
+  border: 1px solid var(--ink);
+}
+.nextbox .acts a.first { background: var(--ink); color: var(--paper); }
+.nextbox .acts a:hover { opacity: .8; }
+
+/* ---------- Tafel (Kartenplatte) ---------- */
+.plate-sec { padding: 3rem 0; border-bottom: 1px solid var(--hair); }
+.plate-sec .sechead, .gaz .sechead, .plates .sechead {
+  display: flex;
+  align-items: baseline;
+  gap: .4rem 1.2rem;
+  margin-bottom: 1.8rem;
+  flex-wrap: wrap;
+}
+.sechead h2 {
+  font-size: 1.7rem;
+  font-weight: 600;
+}
+.sechead .nr {
+  font-family: var(--sans);
+  font-size: .72rem;
+  letter-spacing: .2em;
+  text-transform: uppercase;
+  color: var(--terra);
+}
+.sechead .lnk {
+  margin-left: auto;
+  font-family: var(--sans);
+  font-size: .8rem;
+  text-decoration: none;
+  border-bottom: 1px solid var(--hair);
+}
+.sechead .lnk:hover { border-color: var(--terra); color: var(--terra); }
+.plate {
+  display: grid;
+  grid-template-columns: minmax(0, 1.5fr) minmax(0, 1fr);
+  gap: 0;
+  border: 1px solid var(--ink);
+  background: #fbf8f0;
+}
+.plate .map {
+  padding: 1.2rem;
+  border-right: 1px solid var(--ink);
+}
+.plate .map svg { width: 100%; height: auto; display: block; }
+.plate .legend {
+  padding: 1.6rem 1.6rem 1.4rem;
+  display: flex;
+  flex-direction: column;
+}
+.plate .legend h3 { font-size: 1.45rem; font-weight: 600; line-height: 1.15; }
+.plate .legend .sub { font-style: italic; color: var(--ink-soft); margin: .4rem 0 1.2rem; }
+.plate table {
+  font-family: var(--sans);
+  font-size: .85rem;
+  border-collapse: collapse;
+  width: 100%;
+}
+.plate td { padding: .45rem 0; border-bottom: 1px solid var(--hair); }
+.plate td:last-child { text-align: right; font-weight: 600; font-feature-settings: "tnum"; }
+.plate .legend .quelle {
+  margin-top: auto;
+  padding-top: 1.2rem;
+  font-size: .72rem;
+  font-family: var(--sans);
+  color: var(--ink-soft);
+}
+
+/* ---------- Register / Gazetteer ---------- */
+.gaz { padding: 3rem 0; border-bottom: 1px solid var(--hair); }
+.gaz-cols {
+  columns: 3;
+  column-gap: 3rem;
+  column-rule: 1px solid var(--hair);
+  font-family: var(--sans);
+  font-size: .9rem;
+}
+.gaz-group { break-inside: avoid; margin-bottom: 1.5rem; }
+.gaz-group h4 {
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 500;
+  font-size: 1rem;
+  color: var(--terra);
+  margin-bottom: .5rem;
+}
+.gaz-row {
+  display: flex;
+  align-items: baseline;
+  gap: .4rem;
+  padding: .22rem 0;
+  text-decoration: none;
+}
+.gaz-row .city { font-weight: 500; white-space: nowrap; }
+.gaz-row .dots {
+  flex: 1;
+  border-bottom: 2px dotted var(--hair);
+  transform: translateY(-3px);
+  min-width: 1rem;
+}
+.gaz-row .when { font-feature-settings: "tnum"; color: var(--ink-soft); white-space: nowrap; font-size: .85rem; }
+.gaz-row:hover .city { color: var(--terra); }
+.gaz-foot {
+  margin-top: 1.6rem;
+  font-family: var(--sans);
+  font-size: .8rem;
+  color: var(--ink-soft);
+}
+.gaz-foot a { color: var(--terra); }
+
+/* ---------- Bildtafeln ---------- */
+.plates { padding: 3rem 0; }
+.plate-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 2rem;
+}
+.figure { text-decoration: none; }
+.figure .img {
+  aspect-ratio: 4 / 3;
+  border: 1px solid var(--ink);
+  position: relative;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 20% 30%, rgba(180,69,31,.5), transparent 60%),
+    radial-gradient(circle at 75% 70%, rgba(43,74,125,.55), transparent 55%),
+    linear-gradient(160deg, #d8c9a8, #8e9b8a);
+}
+.figure .img::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: radial-gradient(rgba(33,30,25,.5) 1px, transparent 1.4px);
+  background-size: 5px 5px;
+  mix-blend-mode: overlay;
+}
+.figure .img .tag {
+  position: absolute;
+  left: 10px;
+  bottom: 10px;
+  font-family: var(--sans);
+  font-size: .66rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: .16em;
+  background: var(--paper);
+  border: 1px solid var(--ink);
+  padding: .25rem .5rem;
+}
+.figure figcaption {
+  font-size: .88rem;
+  margin-top: .6rem;
+  color: var(--ink-soft);
+}
+.figure figcaption b { color: var(--ink); font-weight: 600; }
+
+/* ---------- Kolophon ---------- */
+footer {
+  border-top: 1px solid var(--ink);
+  margin-top: 1rem;
+  padding: 2.2rem 0 3rem;
+  text-align: center;
+}
+footer .sig { font-style: italic; color: var(--ink-soft); margin-bottom: 1.1rem; }
+footer nav {
+  display: flex;
+  justify-content: center;
+  gap: 1.8rem;
+  flex-wrap: wrap;
+  font-family: var(--sans);
+  font-size: .78rem;
+  text-transform: uppercase;
+  letter-spacing: .12em;
+}
+footer nav a { text-decoration: none; }
+footer nav a:hover { color: var(--terra); }
+footer .colophon {
+  margin-top: 1.4rem;
+  font-family: var(--sans);
+  font-size: .7rem;
+  color: var(--ink-soft);
+}
+
+.proto-back {
+  position: fixed;
+  bottom: 14px;
+  right: 14px;
+  z-index: 50;
+  font-family: var(--sans);
+  font-size: .75rem;
+  text-decoration: none;
+  background: #fff;
+  border: 1px solid var(--hair);
+  padding: .35rem .7rem;
+  color: var(--ink-soft);
+}
+
+/* ---------- Mobil ---------- */
+@media (max-width: 900px) {
+  .gaz-cols { columns: 2; }
+}
+@media (max-width: 720px) {
+  .lead-sec { grid-template-columns: 1fr; gap: 2rem; }
+  .plate { grid-template-columns: 1fr; }
+  .plate .map { border-right: 0; border-bottom: 1px solid var(--ink); }
+  .gaz-cols { columns: 1; }
+  nav.mainnav { gap: 1.2rem; }
+}
+</style>
+</head>
+<body>
+
+<header class="mast">
+  <span class="over">Seit 2011 · Eine Karte der gemeinsamen Fahrt</span>
+  <h1>Critical <em>Mass</em></h1>
+  <p class="issue"><span>criticalmass.in</span><span>№ 178 — Juni 2026</span><span>612 Städte, 5 Kontinente</span></p>
+</header>
+<nav class="mainnav">
+  <a href="#" aria-current="page">Atlas</a>
+  <a href="#">Städte</a>
+  <a href="#">Kalender</a>
+  <a href="#">Tafeln</a>
+  <a href="#">Statistik</a>
+  <a href="#">Anmelden</a>
+</nav>
+
+<div class="wrap">
+
+  <section class="lead-sec">
+    <article>
+      <span class="kicker">Aus den Städten · Hamburg</span>
+      <h2>Breiter, länger, weiter: eine Stadt geizt nicht mit Superlativen</h2>
+      <div class="body">
+        <p>Immer am letzten Freitag im Monat geht's in Hamburg auf die Räder, ganz unabhängig
+        vom berühmten hanseatischen Wetter. Bei Schnee und Eis düsen fünfhundert Radfahrer
+        durch die Hansestadt, an sommerlichen Abenden beinahe sechstausend. Das kann dann
+        schon eine Weile dauern, bis alle über die Kreuzung rüber sind.</p>
+        <p>Als erste schriftlich überlieferte Masse gilt der 31. März 2000, an dem sich
+        15 Radfahrer vor der U-Bahn-Station St.&nbsp;Pauli zu einer gemeinsamen Radtour trafen —
+        damals reichte es selten für die notwendigen 16, um als Verband auf der Fahrbahn zu fahren.</p>
+      </div>
+      <a class="more" href="#">Die ganze Stadtgeschichte lesen</a>
+    </article>
+
+    <aside class="nextbox" aria-label="Nächste Fahrt">
+      <p class="rubrik">Nächste Fahrt</p>
+      <h3>Hamburg</h3>
+      <p class="when">Freitag, der 26. Juni 2026, um 19 Uhr</p>
+      <dl>
+        <div><dt>Treffpunkt</dt><dd>Alstervorland, Höhe Milchstraße</dd></div>
+        <div><dt>Zuletzt dabei</dt><dd>rund 2.400 Räder</dd></div>
+        <div><dt>Wetter</dt><dd>18°, trocken</dd></div>
+        <div><dt>Mitfahren</dt><dd>einfach hinkommen</dd></div>
+      </dl>
+      <div class="acts">
+        <a class="first" href="#">Ich bin dabei</a>
+        <a href="#">In den Kalender</a>
+      </div>
+    </aside>
+  </section>
+
+  <section class="plate-sec">
+    <div class="sechead">
+      <span class="nr">Tafel XLII</span>
+      <h2>Die Route der letzten Berliner Masse</h2>
+      <a class="lnk" href="#">Alle Tracks ansehen</a>
+    </div>
+    <figure class="plate">
+      <div class="map">
+        <svg viewBox="0 0 560 360" role="img" aria-label="Stilisierte Routenkarte der Critical Mass Berlin">
+          <defs>
+            <pattern id="wasser" width="7" height="7" patternUnits="userSpaceOnUse" patternTransform="rotate(45)">
+              <line x1="0" y1="0" x2="0" y2="7" stroke="#b9c6dd" stroke-width="1.2"/>
+            </pattern>
+          </defs>
+          <rect width="560" height="360" fill="#fbf8f0"/>
+          <!-- Spree -->
+          <path d="M0,210 C90,195 150,235 230,225 C320,214 360,170 440,175 C490,178 530,160 560,150 L560,196 C520,206 480,222 430,220 C350,217 320,260 230,268 C150,275 80,240 0,252 Z"
+            fill="url(#wasser)" stroke="#9eb0cf" stroke-width="1"/>
+          <!-- Stadtraster, angedeutet -->
+          <g stroke="#ddd5c2" stroke-width="1">
+            <line x1="60" y1="0" x2="60" y2="360"/><line x1="140" y1="0" x2="140" y2="360"/>
+            <line x1="240" y1="0" x2="240" y2="360"/><line x1="330" y1="0" x2="330" y2="360"/>
+            <line x1="430" y1="0" x2="430" y2="360"/><line x1="500" y1="0" x2="500" y2="360"/>
+            <line x1="0" y1="60" x2="560" y2="60"/><line x1="0" y1="130" x2="560" y2="130"/>
+            <line x1="0" y1="300" x2="560" y2="300"/>
+          </g>
+          <!-- Route -->
+          <path d="M285,190 L240,170 L190,185 L150,150 L120,95 L175,70 L260,85 L330,60 L400,90 L455,75 L490,120 L440,150 L390,140 L350,185 L395,235 L350,290 L270,300 L210,275 L170,300 L120,275 L160,230 L220,240 L285,190"
+            fill="none" stroke="#2b4a7d" stroke-width="3" stroke-linejoin="round" stroke-linecap="round"/>
+          <path d="M285,190 L240,170 L190,185 L150,150 L120,95"
+            fill="none" stroke="#b4451f" stroke-width="3" stroke-dasharray="1 7" stroke-linecap="round"/>
+          <!-- Start -->
+          <g transform="translate(285,190)">
+            <circle r="7" fill="#b4451f"/>
+            <circle r="11" fill="none" stroke="#b4451f" stroke-width="1.4"/>
+          </g>
+          <text x="297" y="186" font-family="Archivo, sans-serif" font-size="11" fill="#211e19" font-weight="600">Mariannenplatz, 20:00</text>
+          <!-- Nordpfeil -->
+          <g transform="translate(522,38)">
+            <path d="M0,14 L5,-14 L10,14 L5,8 Z" fill="#211e19"/>
+            <text x="1" y="30" font-family="Archivo, sans-serif" font-size="11" fill="#211e19">N</text>
+          </g>
+          <!-- Maßstab -->
+          <g transform="translate(24,330)">
+            <line x1="0" y1="0" x2="90" y2="0" stroke="#211e19" stroke-width="2"/>
+            <line x1="0" y1="-5" x2="0" y2="5" stroke="#211e19" stroke-width="2"/>
+            <line x1="45" y1="-4" x2="45" y2="4" stroke="#211e19" stroke-width="1.4"/>
+            <line x1="90" y1="-5" x2="90" y2="5" stroke="#211e19" stroke-width="2"/>
+            <text x="100" y="4" font-family="Archivo, sans-serif" font-size="11" fill="#211e19">2 km</text>
+          </g>
+        </svg>
+      </div>
+      <figcaption class="legend">
+        <h3>Berlin, 27. Juni 2025</h3>
+        <p class="sub">Aufgezeichnet von birnenblau, geprüft und beschnitten.</p>
+        <table>
+          <tr><td>Strecke</td><td>36,23 km</td></tr>
+          <tr><td>Fahrzeit</td><td>3 h 44 min</td></tr>
+          <tr><td>Masse-Tempo</td><td>9,7 km/h</td></tr>
+          <tr><td>Stationen</td><td>Kreuzberg · Mitte · Tiergarten</td></tr>
+          <tr><td>Dateiformat</td><td>GPX, selbst hochgeladen</td></tr>
+        </table>
+        <p class="quelle">Grundkarte © OpenStreetMap-Mitwirkende. Die Route entsteht
+        bei jeder Masse neu — niemand kennt sie vorher.</p>
+      </figcaption>
+    </figure>
+  </section>
+
+  <section class="gaz">
+    <div class="sechead">
+      <span class="nr">Register</span>
+      <h2>Wo demnächst gefahren wird</h2>
+      <a class="lnk" href="#">Vollständiges Register · Karte</a>
+    </div>
+    <div class="gaz-cols">
+      <div class="gaz-group">
+        <h4>Freitag, 12. Juni</h4>
+        <a class="gaz-row" href="#"><span class="city">Bergisch Gladbach</span><span class="dots"></span><span class="when">18:00</span></a>
+        <a class="gaz-row" href="#"><span class="city">Darmstadt</span><span class="dots"></span><span class="when">19:00</span></a>
+        <a class="gaz-row" href="#"><span class="city">Düsseldorf</span><span class="dots"></span><span class="when">19:00</span></a>
+        <a class="gaz-row" href="#"><span class="city">Essen</span><span class="dots"></span><span class="when">19:00</span></a>
+        <a class="gaz-row" href="#"><span class="city">Frankfurt am Main</span><span class="dots"></span><span class="when">19:00</span></a>
+        <a class="gaz-row" href="#"><span class="city">Pittsburgh</span><span class="dots"></span><span class="when">18:00</span></a>
+        <a class="gaz-row" href="#"><span class="city">Witten</span><span class="dots"></span><span class="when">18:00</span></a>
+      </div>
+      <div class="gaz-group">
+        <h4>Di–Sa, 16.–20. Juni</h4>
+        <a class="gaz-row" href="#"><span class="city">Lisboa</span><span class="dots"></span><span class="when">Di 21:00</span></a>
+        <a class="gaz-row" href="#"><span class="city">Hannover</span><span class="dots"></span><span class="when">Fr 20:00</span></a>
+        <a class="gaz-row" href="#"><span class="city">Los Angeles</span><span class="dots"></span><span class="when">Fr 18:30</span></a>
+        <a class="gaz-row" href="#"><span class="city">Mannheim</span><span class="dots"></span><span class="when">Fr 18:45</span></a>
+        <a class="gaz-row" href="#"><span class="city">Wien</span><span class="dots"></span><span class="when">Fr 17:00</span></a>
+        <a class="gaz-row" href="#"><span class="city">Stirling</span><span class="dots"></span><span class="when">Sa 10:00</span></a>
+      </div>
+      <div class="gaz-group">
+        <h4>Der große Freitag, 26. Juni</h4>
+        <a class="gaz-row" href="#"><span class="city">Berlin</span><span class="dots"></span><span class="when">20:00</span></a>
+        <a class="gaz-row" href="#"><span class="city">Bonn</span><span class="dots"></span><span class="when">18:00</span></a>
+        <a class="gaz-row" href="#"><span class="city">Dresden</span><span class="dots"></span><span class="when">18:50</span></a>
+        <a class="gaz-row" href="#"><span class="city">Graz</span><span class="dots"></span><span class="when">17:00</span></a>
+        <a class="gaz-row" href="#"><span class="city">Hamburg</span><span class="dots"></span><span class="when">19:00</span></a>
+        <a class="gaz-row" href="#"><span class="city">München</span><span class="dots"></span><span class="when">19:00</span></a>
+        <a class="gaz-row" href="#"><span class="city">… und 37 weitere</span><span class="dots"></span><span class="when">→</span></a>
+      </div>
+    </div>
+    <p class="gaz-foot">Alle Zeiten Ortszeit. Keine Stadt dabei, in der du wohnst?
+      <a href="#">Trag deine Masse ein</a> — drei Felder genügen.</p>
+  </section>
+
+  <section class="plates">
+    <div class="sechead">
+      <span class="nr">Tafeln XLIII–XLV</span>
+      <h2>Zuletzt eingegangene Bilder</h2>
+      <a class="lnk" href="#">Alle Galerien</a>
+    </div>
+    <div class="plate-grid">
+      <figure class="figure">
+        <a href="#"><div class="img"><span class="tag">Tafel XLIII</span></div></a>
+        <figcaption><b>Bonn, 29. Mai 2026.</b> Vier Aufnahmen vom Sammeln
+        am Rheinufer, eingereicht von CM&nbsp;Bonn.</figcaption>
+      </figure>
+      <figure class="figure">
+        <a href="#"><div class="img"><span class="tag">Tafel XLIV</span></div></a>
+        <figcaption><b>Norderstedt, 5. Juni 2026.</b> Zwölf Räder vor dem Rathaus —
+        klein, aber regelmäßig.</figcaption>
+      </figure>
+      <figure class="figure">
+        <a href="#"><div class="img"><span class="tag">Tafel XLV</span></div></a>
+        <figcaption><b>Berlin, 28. November 2025.</b> Wintermasse bei 2 Grad,
+        25,58 km durch Mitte und Kreuzberg.</figcaption>
+      </figure>
+    </div>
+  </section>
+
+</div>
+
+<footer>
+  <p class="sig">„Wir behindern nicht den Verkehr — wir sind der Verkehr."</p>
+  <nav>
+    <a href="#">Über die Critical Mass</a>
+    <a href="#">FAQ</a>
+    <a href="#">API</a>
+    <a href="#">Impressum</a>
+    <a href="#">Datenschutz</a>
+  </nav>
+  <p class="colophon">Gesetzt in Fraunces und Archivo · Karten © OpenStreetMap-Mitwirkende ·
+  Open Source seit Tag eins</p>
+</footer>
+
+<a class="proto-back" href="index.html">← Übersicht</a>
+
+</body>
+</html>

--- a/design-prototypes/05-feed-hell.html
+++ b/design-prototypes/05-feed-hell.html
@@ -1,0 +1,840 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Prototyp 5 · Feed Community — criticalmass.in</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+:root {
+  --bg: #faf9f6;
+  --card: #ffffff;
+  --line: #e7e3da;
+  --ink: #211f1b;
+  --dim: #79746a;
+  --accent: #d9492c;        /* Klingel-Rot */
+  --accent-soft: #fbeae6;
+  --track: #2e7d54;
+  --foto: #3563a8;
+  --tour: #d9492c;
+  --stadt: #7a4fa3;
+  --forum: #0f7e84;
+  --sans: "Hanken Grotesk", "Helvetica Neue", Arial, sans-serif;
+}
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html, body { overflow-x: clip; }
+body {
+  font-family: var(--sans);
+  background: var(--bg);
+  color: var(--ink);
+  line-height: 1.5;
+  font-size: 15px;
+}
+a { color: inherit; text-decoration: none; }
+button { font-family: inherit; cursor: pointer; }
+
+.shell {
+  max-width: 1240px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: 240px minmax(0, 620px) 320px;
+  gap: 28px;
+  padding: 0 20px;
+  align-items: start;
+}
+
+/* ---------- Linke Navigation ---------- */
+.sidenav {
+  position: sticky;
+  top: 0;
+  height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  padding: 22px 0 18px;
+}
+.logo {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  font-weight: 800;
+  font-size: 1.12rem;
+  letter-spacing: -.01em;
+  margin: 0 10px 22px;
+}
+.logo .mark {
+  width: 30px; height: 30px;
+  border-radius: 9px;
+  background: var(--accent);
+  display: grid;
+  place-items: center;
+  color: #fff;
+}
+.sidenav nav { display: flex; flex-direction: column; gap: 2px; }
+.sidenav nav a {
+  display: flex;
+  align-items: center;
+  gap: 13px;
+  padding: 10px 12px;
+  border-radius: 11px;
+  font-weight: 600;
+  font-size: .98rem;
+  color: #3c3933;
+}
+.sidenav nav a svg { flex: none; stroke: currentColor; }
+.sidenav nav a:hover { background: #f1eee7; }
+.sidenav nav a.active { color: var(--ink); background: #f1eee7; font-weight: 800; }
+.sidenav nav a .pill {
+  margin-left: auto;
+  background: var(--accent);
+  color: #fff;
+  font-size: .68rem;
+  font-weight: 700;
+  border-radius: 99px;
+  padding: 1px 7px;
+}
+.contribute {
+  margin: 18px 8px 0;
+  background: var(--accent);
+  color: #fff;
+  border: 0;
+  border-radius: 12px;
+  padding: 12px;
+  font-size: .98rem;
+  font-weight: 700;
+}
+.contribute:hover { filter: brightness(1.05); }
+.me {
+  margin-top: auto;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 12px;
+}
+.me:hover { background: #f1eee7; }
+.me small { color: var(--dim); display: block; font-weight: 500; }
+.me b { font-size: .92rem; }
+
+/* ---------- Avatare ---------- */
+.ava {
+  width: 42px; height: 42px;
+  border-radius: 12px;
+  flex: none;
+  display: grid;
+  place-items: center;
+  font-weight: 800;
+  font-size: .92rem;
+  color: #fff;
+}
+.ava.s { width: 34px; height: 34px; border-radius: 10px; font-size: .8rem; }
+.ava.kk { background: #0f7e84; }
+.ava.bb { background: #5a4fa0; }
+.ava.cb { background: #b76fc4; }
+.ava.lk { background: #c98024; }
+.ava.st { background: #2e7d54; }
+.ava.mh { background: #444; }
+
+/* ---------- Mitte: Feed ---------- */
+.feed { padding: 22px 0 90px; display: flex; flex-direction: column; gap: 16px; }
+.feed-tabs {
+  display: flex;
+  gap: 4px;
+  background: #f1eee7;
+  border-radius: 12px;
+  padding: 4px;
+  position: sticky;
+  top: 10px;
+  z-index: 20;
+  box-shadow: 0 6px 18px rgba(33,31,27,.06);
+}
+.feed-tabs button {
+  flex: 1;
+  border: 0;
+  background: transparent;
+  border-radius: 9px;
+  padding: 8px 10px;
+  font-weight: 700;
+  font-size: .9rem;
+  color: var(--dim);
+}
+.feed-tabs button.on { background: var(--card); color: var(--ink); box-shadow: 0 1px 3px rgba(33,31,27,.12); }
+
+.compose {
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  padding: 14px 16px;
+}
+.compose .row { display: flex; gap: 12px; align-items: center; }
+.compose input {
+  flex: 1;
+  border: 0;
+  background: #f4f1ea;
+  border-radius: 99px;
+  padding: 11px 18px;
+  font: inherit;
+  color: var(--ink);
+}
+.compose input::placeholder { color: var(--dim); }
+.compose .types { display: flex; gap: 6px; margin-top: 12px; padding-left: 54px; flex-wrap: wrap; }
+.compose .types button {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  border: 1px solid var(--line);
+  background: transparent;
+  border-radius: 99px;
+  padding: 6px 13px;
+  font-size: .85rem;
+  font-weight: 600;
+  color: #3c3933;
+}
+.compose .types button:hover { border-color: #cfc9bc; background: #faf8f3; }
+.compose .types svg { stroke: var(--accent); }
+
+/* ---------- Beitrag ---------- */
+.post {
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  padding: 16px 16px 10px;
+}
+.post.pinned { border-color: #f0c9bf; box-shadow: 0 1px 0 #f0c9bf; }
+.pin-note {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--accent);
+  font-size: .78rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: .08em;
+  margin-bottom: 10px;
+}
+.post-head { display: flex; gap: 12px; align-items: flex-start; }
+.post-head .who { font-size: .95rem; line-height: 1.35; }
+.post-head .who b { font-weight: 800; }
+.post-head .who .what { color: #3c3933; }
+.post-head .who .meta { color: var(--dim); font-size: .82rem; display: flex; gap: 6px; align-items: center; flex-wrap: wrap; }
+.tchip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: .72rem;
+  font-weight: 800;
+  border-radius: 6px;
+  padding: 1.5px 7px;
+  text-transform: uppercase;
+  letter-spacing: .05em;
+}
+.tchip.track { background: #e7f3ec; color: var(--track); }
+.tchip.foto { background: #e9eff9; color: var(--foto); }
+.tchip.zahl { background: var(--accent-soft); color: var(--accent); }
+.tchip.stadt { background: #f1e9f8; color: var(--stadt); }
+.tchip.forum { background: #e4f2f3; color: var(--forum); }
+.post-body { margin: 12px 0 4px 54px; }
+.post-body p.txt { color: #34312b; margin-bottom: 10px; }
+
+/* Inhaltstypen */
+.ridebox {
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  overflow: hidden;
+}
+.ridebox .top { display: flex; gap: 16px; padding: 14px 16px; align-items: center; }
+.datebadge {
+  flex: none;
+  width: 62px;
+  border: 2px solid var(--ink);
+  border-radius: 12px;
+  text-align: center;
+  overflow: hidden;
+}
+.datebadge .m { background: var(--ink); color: #fff; font-size: .66rem; font-weight: 800; letter-spacing: .12em; padding: 3px 0; text-transform: uppercase; }
+.datebadge .d { font-size: 1.5rem; font-weight: 800; padding: 4px 0 5px; }
+.ridebox h3 { font-size: 1.12rem; font-weight: 800; letter-spacing: -.01em; }
+.ridebox .sub { color: var(--dim); font-size: .88rem; margin-top: 2px; }
+.ridebox .joinbar {
+  display: flex;
+  gap: 8px;
+  padding: 12px 16px;
+  border-top: 1px solid var(--line);
+  background: #fcfbf8;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.joinbar .counts { font-size: .84rem; color: var(--dim); margin-right: auto; }
+.joinbar .counts b { color: var(--ink); }
+.btn {
+  border: 1px solid var(--line);
+  background: var(--card);
+  border-radius: 99px;
+  padding: 7px 15px;
+  font-weight: 700;
+  font-size: .86rem;
+}
+.btn:hover { border-color: #cfc9bc; }
+.btn.yes { background: var(--accent); border-color: var(--accent); color: #fff; }
+.btn.yes:hover { filter: brightness(1.06); }
+
+.trackbox { border: 1px solid var(--line); border-radius: 14px; overflow: hidden; }
+.trackbox svg.map { display: block; width: 100%; height: auto; background: #eef0e9; }
+.statrow { display: flex; border-top: 1px solid var(--line); }
+.statrow div { flex: 1; padding: 10px 14px; }
+.statrow div + div { border-left: 1px solid var(--line); }
+.statrow .v { font-weight: 800; font-size: 1.05rem; font-feature-settings: "tnum"; }
+.statrow .k { font-size: .74rem; color: var(--dim); text-transform: uppercase; letter-spacing: .06em; }
+
+.fotogrid { display: grid; grid-template-columns: 1fr 1fr; gap: 6px; border-radius: 14px; overflow: hidden; }
+.fotogrid .ph { aspect-ratio: 16/10; position: relative; }
+.fotogrid .ph::after { content: ""; position: absolute; inset: 0; background-image: radial-gradient(rgba(33,31,27,.35) 1px, transparent 1.4px); background-size: 4px 4px; opacity: .5; }
+.ph.a { background: linear-gradient(140deg, #c9d6b8, #6f8f6a); }
+.ph.b { background: linear-gradient(160deg, #e3c9a8, #ad7647); }
+.ph.c { background: linear-gradient(150deg, #b8c6d6, #5a7d99); }
+.ph.d { background: linear-gradient(130deg, #d6b8c4, #99607d); }
+
+.zahlbox {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 14px 16px;
+}
+.zahlbox .flip { display: inline-flex; gap: 3px; }
+.zahlbox .flip b {
+  background: var(--ink);
+  color: #fff;
+  border-radius: 6px;
+  font-size: 1.45rem;
+  font-weight: 800;
+  padding: 4px 9px;
+  font-feature-settings: "tnum";
+}
+.zahlbox .lbl { font-size: .9rem; color: #34312b; }
+.zahlbox .lbl b { font-weight: 800; }
+.zahlbox .agree { margin-left: auto; }
+
+.cityedit {
+  border-left: 3px solid var(--stadt);
+  background: #faf7fd;
+  border-radius: 0 12px 12px 0;
+  padding: 10px 14px;
+  font-size: .92rem;
+  color: #4a4456;
+}
+.cityedit b { font-weight: 700; }
+
+.quote {
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 13px 16px;
+  font-size: .95rem;
+  color: #34312b;
+}
+.quote .board { font-size: .78rem; color: var(--forum); font-weight: 800; text-transform: uppercase; letter-spacing: .06em; margin-bottom: 5px; }
+.quote .answers { color: var(--dim); font-size: .84rem; margin-top: 8px; }
+
+/* Aktionen */
+.actions {
+  display: flex;
+  gap: 4px;
+  margin: 8px 0 2px 42px;
+}
+.actions button {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  border: 0;
+  background: transparent;
+  color: var(--dim);
+  font-weight: 700;
+  font-size: .86rem;
+  border-radius: 99px;
+  padding: 7px 13px;
+}
+.actions button:hover { background: #f4f1ea; color: var(--ink); }
+.actions button svg { stroke: currentColor; }
+.actions button.rang { color: var(--accent); }
+.actions button.rang svg { fill: var(--accent); stroke: var(--accent); }
+
+/* ---------- Rechte Spalte ---------- */
+.rail { position: sticky; top: 0; padding: 22px 0; display: flex; flex-direction: column; gap: 16px; max-height: 100dvh; overflow-y: auto; }
+.widget {
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  padding: 16px;
+}
+.widget h4 { font-size: .98rem; font-weight: 800; margin-bottom: 10px; display: flex; align-items: baseline; }
+.widget h4 a { margin-left: auto; font-size: .78rem; color: var(--accent); font-weight: 700; }
+.dayhead { font-size: .74rem; font-weight: 800; color: var(--dim); text-transform: uppercase; letter-spacing: .08em; margin: 10px 0 4px; }
+.upline { display: flex; align-items: baseline; gap: 8px; padding: 5px 0; border-radius: 8px; }
+.upline:hover { background: #faf8f3; }
+.upline .t { font-feature-settings: "tnum"; font-weight: 800; font-size: .88rem; width: 44px; flex: none; }
+.upline .c { font-weight: 600; font-size: .92rem; }
+.upline .p { color: var(--dim); font-size: .8rem; margin-left: auto; text-align: right; }
+.upline.live .t { color: var(--accent); }
+.livedot { width: 7px; height: 7px; border-radius: 99px; background: var(--accent); display: inline-block; margin-right: 4px; animation: blink 1.6s ease infinite; }
+@keyframes blink { 50% { opacity: .25; } }
+@media (prefers-reduced-motion: reduce) { .livedot { animation: none; } }
+.citytag {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid var(--line);
+  border-radius: 99px;
+  padding: 5px 12px 5px 7px;
+  font-size: .84rem;
+  font-weight: 700;
+  margin: 3px 4px 3px 0;
+}
+.citytag i {
+  width: 18px; height: 18px;
+  border-radius: 99px;
+  font-style: normal;
+  font-size: .62rem;
+  font-weight: 800;
+  color: #fff;
+  display: grid;
+  place-items: center;
+}
+.rail .fine { font-size: .76rem; color: var(--dim); line-height: 1.6; padding: 0 4px; }
+.rail .fine a { text-decoration: underline; text-decoration-color: #d8d2c5; }
+
+/* ---------- Topbar + Tabbar (mobil) ---------- */
+.topbar, .tabbar { display: none; }
+
+.proto-back {
+  position: fixed;
+  bottom: 14px;
+  right: 14px;
+  z-index: 60;
+  font-size: .75rem;
+  font-weight: 700;
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 99px;
+  padding: 6px 12px;
+  color: var(--dim);
+}
+
+/* ---------- Responsive ---------- */
+@media (max-width: 1100px) {
+  .shell { grid-template-columns: 220px minmax(0, 1fr); }
+  .rail { display: none; }
+}
+@media (max-width: 900px) {
+  .shell { grid-template-columns: minmax(0, 1fr); padding: 0 12px; }
+  .sidenav { display: none; }
+  .topbar {
+    display: flex;
+    position: sticky;
+    top: 0;
+    z-index: 40;
+    background: rgba(250,249,246,.93);
+    backdrop-filter: blur(10px);
+    border-bottom: 1px solid var(--line);
+    padding: 10px 16px;
+    align-items: center;
+    gap: 10px;
+    margin: 0 -12px;
+  }
+  .topbar .logo { margin: 0; font-size: 1.02rem; }
+  .topbar .right { margin-left: auto; display: flex; gap: 14px; align-items: center; }
+  .feed-tabs { top: 56px; }
+  .tabbar {
+    display: flex;
+    position: fixed;
+    bottom: 0; left: 0; right: 0;
+    z-index: 50;
+    background: rgba(255,255,255,.95);
+    backdrop-filter: blur(10px);
+    border-top: 1px solid var(--line);
+    padding: 6px 8px calc(6px + env(safe-area-inset-bottom));
+  }
+  .tabbar a {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+    font-size: .62rem;
+    font-weight: 700;
+    color: var(--dim);
+    padding: 4px 0;
+  }
+  .tabbar a svg { stroke: currentColor; }
+  .tabbar a.on { color: var(--accent); }
+  .tabbar .plus {
+    flex: none;
+    width: 46px; height: 46px;
+    margin-top: -16px;
+    border-radius: 16px;
+    background: var(--accent);
+    color: #fff;
+    display: grid;
+    place-items: center;
+    box-shadow: 0 6px 16px rgba(217,73,44,.4);
+  }
+  .post-body { margin-left: 0; }
+  .actions { margin-left: -6px; }
+  .compose .types { padding-left: 0; }
+}
+</style>
+</head>
+<body>
+
+<header class="topbar">
+  <span class="logo"><span class="mark">
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.4"><path d="M12 4a5.5 5.5 0 0 0-5.5 5.5c0 4-1.6 5.4-2.5 6h16c-.9-.6-2.5-2-2.5-6A5.5 5.5 0 0 0 12 4z"/><path d="M10 19a2 2 0 0 0 4 0"/></svg>
+  </span>criticalmass.in</span>
+  <span class="right">
+    <svg width="21" height="21" viewBox="0 0 24 24" fill="none" stroke="#211f1b" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="m20 20-4-4"/></svg>
+    <span class="ava s mh">MH</span>
+  </span>
+</header>
+
+<div class="shell">
+
+  <!-- Linke Spalte -->
+  <aside class="sidenav">
+    <a class="logo" href="#"><span class="mark">
+      <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.4"><path d="M12 4a5.5 5.5 0 0 0-5.5 5.5c0 4-1.6 5.4-2.5 6h16c-.9-.6-2.5-2-2.5-6A5.5 5.5 0 0 0 12 4z"/><path d="M10 19a2 2 0 0 0 4 0"/></svg>
+    </span>criticalmass.in</a>
+    <nav>
+      <a class="active" href="#">
+        <svg width="21" height="21" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M3 11.2 12 4l9 7.2M5.5 9.8V20h13V9.8"/></svg>
+        Timeline
+      </a>
+      <a href="#">
+        <svg width="21" height="21" viewBox="0 0 24 24" fill="none" stroke-width="2"><circle cx="12" cy="12" r="8.5"/><path d="m15.5 8.5-2 5-5 2 2-5z"/></svg>
+        Entdecken
+      </a>
+      <a href="#">
+        <svg width="21" height="21" viewBox="0 0 24 24" fill="none" stroke-width="2"><rect x="3.5" y="5" width="17" height="15.5" rx="2.5"/><path d="M3.5 9.5h17M8 3v4M16 3v4"/></svg>
+        Kalender
+      </a>
+      <a href="#">
+        <svg width="21" height="21" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M12 21s7-6 7-11a7 7 0 0 0-14 0c0 5 7 11 7 11z"/><circle cx="12" cy="9.8" r="2.4"/></svg>
+        Städte
+      </a>
+      <a href="#">
+        <svg width="21" height="21" viewBox="0 0 24 24" fill="none" stroke-width="2"><rect x="3.5" y="5.5" width="17" height="13.5" rx="2.5"/><circle cx="9" cy="10.5" r="1.6"/><path d="m4.5 17 4.5-4 3.5 3 3-2.5 4 3.5"/></svg>
+        Fotos
+      </a>
+      <a href="#">
+        <svg width="21" height="21" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M20 12a8 8 0 1 0-3.1 6.3L20 19.5l-.8-3A8 8 0 0 0 20 12z"/></svg>
+        Forum
+      </a>
+      <a href="#">
+        <svg width="21" height="21" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M12 4a5.5 5.5 0 0 0-5.5 5.5c0 4-1.6 5.4-2.5 6h16c-.9-.6-2.5-2-2.5-6A5.5 5.5 0 0 0 12 4z"/><path d="M10 19a2 2 0 0 0 4 0"/></svg>
+        Mitteilungen
+        <span class="pill">3</span>
+      </a>
+    </nav>
+    <button class="contribute">Beitragen</button>
+    <a class="me" href="#">
+      <span class="ava s mh">MH</span>
+      <span><b>malte</b><small>Hamburg · 34 Massen</small></span>
+    </a>
+  </aside>
+
+  <!-- Mitte -->
+  <main class="feed">
+    <div class="feed-tabs" role="tablist">
+      <button class="on">Alles</button>
+      <button>Deine Städte</button>
+      <button>Touren</button>
+      <button>Fotos &amp; Tracks</button>
+    </div>
+
+    <div class="compose">
+      <div class="row">
+        <span class="ava mh">MH</span>
+        <input type="text" placeholder="Was rollt bei dir, malte?">
+      </div>
+      <div class="types">
+        <button>
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke-width="2"><rect x="3.5" y="5.5" width="17" height="13.5" rx="2.5"/><circle cx="9" cy="10.5" r="1.6"/><path d="m4.5 17 4.5-4 3.5 3 3-2.5 4 3.5"/></svg>
+          Foto
+        </button>
+        <button>
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M4 17c3-1 4-7 7-7s3 5 6 5 3-3 3-3"/><circle cx="4" cy="17" r="1.6"/><circle cx="20" cy="12" r="1.6"/></svg>
+          Track (GPX/FIT)
+        </button>
+        <button>
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M5 20V9M12 20V4M19 20v-7"/></svg>
+          Schätzung
+        </button>
+      </div>
+    </div>
+
+    <!-- Angepinnt: Tour der Woche -->
+    <article class="post pinned">
+      <span class="pin-note">
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M12 17v5M7 4h10l-1.5 7.5 3 3.5H5.5l3-3.5z"/></svg>
+        Tour der Woche · letzter Freitag im Monat
+      </span>
+      <div class="ridebox">
+        <div class="top">
+          <div class="datebadge"><div class="m">Juni</div><div class="d">26</div></div>
+          <div>
+            <h3>Critical Mass Hamburg</h3>
+            <p class="sub">Freitag · 19:00 Uhr · Alstervorland, Höhe Milchstraße</p>
+          </div>
+        </div>
+        <div class="joinbar">
+          <span class="counts"><b>132</b> dabei · <b>41</b> vielleicht · zuletzt ~ 2.400 Räder</span>
+          <button class="btn yes">Dabei!</button>
+          <button class="btn">Vielleicht</button>
+          <button class="btn">iCal</button>
+        </div>
+      </div>
+    </article>
+
+    <!-- Forum-Thread -->
+    <article class="post">
+      <div class="post-head">
+        <span class="ava lk">LK</span>
+        <div class="who">
+          <b>Lotte</b> <span class="what">hat ein Thema gestartet</span>
+          <div class="meta"><span class="tchip forum">Forum</span> Board Hamburg · vor 5 Std</div>
+        </div>
+      </div>
+      <div class="post-body">
+        <a class="quote" href="#" style="display:block">
+          <div class="board">Critical Mass Hamburg</div>
+          „Route im Juni mal Richtung Hafen? Beim letzten Mal war auf der Kennedybrücke
+          ordentlich was los — Vorschläge für den Treffpunkt danach?"
+          <div class="answers">14 Antworten · zuletzt vor 40 Minuten</div>
+        </a>
+      </div>
+      <div class="actions">
+        <button>
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M12 4a5.5 5.5 0 0 0-5.5 5.5c0 4-1.6 5.4-2.5 6h16c-.9-.6-2.5-2-2.5-6A5.5 5.5 0 0 0 12 4z"/><path d="M10 19a2 2 0 0 0 4 0"/></svg>
+          7
+        </button>
+        <button>
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M20 12a8 8 0 1 0-3.1 6.3L20 19.5l-.8-3A8 8 0 0 0 20 12z"/></svg>
+          Antworten
+        </button>
+        <button>
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M14 9V5l7 7-7 7v-4c-7 0-10 2-11 5 0-7 4-11 11-11z"/></svg>
+          Teilen
+        </button>
+      </div>
+    </article>
+
+    <!-- Schätzung -->
+    <article class="post">
+      <div class="post-head">
+        <span class="ava kk">KK</span>
+        <div class="who">
+          <b>Katrin Kiesel</b> <span class="what">hat die Masse in Norderstedt geschätzt</span>
+          <div class="meta"><span class="tchip zahl">Schätzung</span> Tour vom 5. Juni · vor 3 Tagen</div>
+        </div>
+      </div>
+      <div class="post-body">
+        <div class="zahlbox">
+          <span class="flip"><b>0</b><b>0</b><b>1</b><b>2</b></span>
+          <span class="lbl"><b>12 Radfahrende</b> bei der Critical Mass Norderstedt.<br>
+          Klein, aber jeden Monat pünktlich.</span>
+          <button class="btn agree">Auch schätzen</button>
+        </div>
+      </div>
+      <div class="actions">
+        <button class="rang">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M12 4a5.5 5.5 0 0 0-5.5 5.5c0 4-1.6 5.4-2.5 6h16c-.9-.6-2.5-2-2.5-6A5.5 5.5 0 0 0 12 4z"/><path d="M10 19a2 2 0 0 0 4 0"/></svg>
+          3 · geklingelt
+        </button>
+        <button>
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M20 12a8 8 0 1 0-3.1 6.3L20 19.5l-.8-3A8 8 0 0 0 20 12z"/></svg>
+          1
+        </button>
+        <button>
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M14 9V5l7 7-7 7v-4c-7 0-10 2-11 5 0-7 4-11 11-11z"/></svg>
+          Teilen
+        </button>
+      </div>
+    </article>
+
+    <!-- Track -->
+    <article class="post">
+      <div class="post-head">
+        <span class="ava bb">b</span>
+        <div class="who">
+          <b>birnenblau</b> <span class="what">hat einen Track nachgetragen</span>
+          <div class="meta"><span class="tchip track">Track</span> Critical Mass Berlin · 28.11.2025 · vor 8 Tagen</div>
+        </div>
+      </div>
+      <div class="post-body">
+        <div class="trackbox">
+          <svg class="map" viewBox="0 0 600 210" aria-hidden="true">
+            <rect width="600" height="210" fill="#edf0e7"/>
+            <g stroke="#dde3d2" stroke-width="1.5">
+              <line x1="70" y1="0" x2="70" y2="210"/><line x1="160" y1="0" x2="160" y2="210"/>
+              <line x1="260" y1="0" x2="260" y2="210"/><line x1="370" y1="0" x2="370" y2="210"/>
+              <line x1="480" y1="0" x2="480" y2="210"/>
+              <line x1="0" y1="55" x2="600" y2="55"/><line x1="0" y1="115" x2="600" y2="115"/>
+              <line x1="0" y1="170" x2="600" y2="170"/>
+            </g>
+            <path d="M60,160 L130,150 L170,100 L250,90 L310,120 L390,105 L450,60 L520,80 L560,50"
+              fill="none" stroke="#2e7d54" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round"/>
+            <circle cx="60" cy="160" r="6" fill="#d9492c"/>
+            <circle cx="560" cy="50" r="6" fill="#211f1b"/>
+          </svg>
+          <div class="statrow">
+            <div><div class="v">25,58 km</div><div class="k">Strecke</div></div>
+            <div><div class="v">2:14 h</div><div class="k">Fahrzeit</div></div>
+            <div><div class="v">11,4 km/h</div><div class="k">Masse-Tempo</div></div>
+          </div>
+        </div>
+      </div>
+      <div class="actions">
+        <button class="rang">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M12 4a5.5 5.5 0 0 0-5.5 5.5c0 4-1.6 5.4-2.5 6h16c-.9-.6-2.5-2-2.5-6A5.5 5.5 0 0 0 12 4z"/><path d="M10 19a2 2 0 0 0 4 0"/></svg>
+          9 · geklingelt
+        </button>
+        <button>
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M20 12a8 8 0 1 0-3.1 6.3L20 19.5l-.8-3A8 8 0 0 0 20 12z"/></svg>
+          2
+        </button>
+        <button>
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M14 9V5l7 7-7 7v-4c-7 0-10 2-11 5 0-7 4-11 11-11z"/></svg>
+          Teilen
+        </button>
+      </div>
+    </article>
+
+    <!-- Fotos -->
+    <article class="post">
+      <div class="post-head">
+        <span class="ava cb">CB</span>
+        <div class="who">
+          <b>CM Bonn</b> <span class="what">hat 4 Fotos hochgeladen</span>
+          <div class="meta"><span class="tchip foto">Fotos</span> Tour vom 29. Mai · vor 1 Woche</div>
+        </div>
+      </div>
+      <div class="post-body">
+        <div class="fotogrid">
+          <a class="ph a" href="#"></a>
+          <a class="ph b" href="#"></a>
+          <a class="ph c" href="#"></a>
+          <a class="ph d" href="#"></a>
+        </div>
+      </div>
+      <div class="actions">
+        <button>
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M12 4a5.5 5.5 0 0 0-5.5 5.5c0 4-1.6 5.4-2.5 6h16c-.9-.6-2.5-2-2.5-6A5.5 5.5 0 0 0 12 4z"/><path d="M10 19a2 2 0 0 0 4 0"/></svg>
+          14 · geklingelt
+        </button>
+        <button>
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M20 12a8 8 0 1 0-3.1 6.3L20 19.5l-.8-3A8 8 0 0 0 20 12z"/></svg>
+          3
+        </button>
+        <button>
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M14 9V5l7 7-7 7v-4c-7 0-10 2-11 5 0-7 4-11 11-11z"/></svg>
+          Teilen
+        </button>
+      </div>
+    </article>
+
+    <!-- Neue Stadt -->
+    <article class="post">
+      <div class="post-head">
+        <span class="ava st">S</span>
+        <div class="who">
+          <b>Stirling</b> <span class="what">ist neu auf criticalmass.in</span>
+          <div class="meta"><span class="tchip stadt">Neue Stadt</span> Schottland · vor 2 Tagen</div>
+        </div>
+      </div>
+      <div class="post-body">
+        <div class="cityedit" style="border-color:#2e7d54;background:#f3faf5;color:#3c5446">
+          Erste Masse: <b>Samstag, 20. Juni, 10:00 Uhr</b> — Treffpunkt The Thistles.
+          Willkommen im Netz der 612 Städte!
+        </div>
+      </div>
+      <div class="actions">
+        <button>
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M12 4a5.5 5.5 0 0 0-5.5 5.5c0 4-1.6 5.4-2.5 6h16c-.9-.6-2.5-2-2.5-6A5.5 5.5 0 0 0 12 4z"/><path d="M10 19a2 2 0 0 0 4 0"/></svg>
+          21 · geklingelt
+        </button>
+        <button>
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M12 5v14M5 12h14"/></svg>
+          Stadt folgen
+        </button>
+      </div>
+    </article>
+
+  </main>
+
+  <!-- Rechte Spalte -->
+  <aside class="rail">
+    <div class="widget">
+      <h4>Bald unterwegs <a href="#">Kalender →</a></h4>
+      <div class="dayhead">Heute · Freitag, 12. Juni</div>
+      <a class="upline live" href="#"><span class="t"><span class="livedot"></span>jetzt</span><span class="c">Lisboa</span><span class="p">seit 21:00</span></a>
+      <a class="upline" href="#"><span class="t">17:00</span><span class="c">Falkensee</span><span class="p">Bahnhof</span></a>
+      <a class="upline" href="#"><span class="t">18:00</span><span class="c">Düren</span><span class="p">Karte</span></a>
+      <a class="upline" href="#"><span class="t">18:00</span><span class="c">Pittsburgh</span><span class="p">Dippy</span></a>
+      <a class="upline" href="#"><span class="t">19:00</span><span class="c">Düsseldorf</span><span class="p">Fürstenplatz</span></a>
+      <a class="upline" href="#"><span class="t">19:00</span><span class="c">Frankfurt</span><span class="p">Opernplatz</span></a>
+      <div class="dayhead">Fr, 19. Juni</div>
+      <a class="upline" href="#"><span class="t">17:00</span><span class="c">Wien</span><span class="p">Schwarzenbergpl.</span></a>
+      <a class="upline" href="#"><span class="t">18:30</span><span class="c">Los Angeles</span><span class="p">Karte</span></a>
+      <a class="upline" href="#"><span class="t">20:00</span><span class="c">Hannover</span><span class="p">Karte</span></a>
+      <div class="dayhead">Fr, 26. Juni — der große Freitag</div>
+      <a class="upline" href="#"><span class="t">19:00</span><span class="c">Hamburg</span><span class="p">Alstervorland</span></a>
+      <a class="upline" href="#"><span class="t">20:00</span><span class="c">Berlin</span><span class="p">Mariannenplatz</span></a>
+      <a class="upline" href="#"><span class="t">+41</span><span class="c">weitere Städte</span><span class="p">→</span></a>
+    </div>
+
+    <div class="widget">
+      <h4>Städte folgen</h4>
+      <a class="citytag" href="#"><i style="background:#d9492c">HH</i>Hamburg</a>
+      <a class="citytag" href="#"><i style="background:#5a4fa0">B</i>Berlin</a>
+      <a class="citytag" href="#"><i style="background:#0f7e84">K</i>Köln</a>
+      <a class="citytag" href="#"><i style="background:#c98024">W</i>Wien</a>
+      <a class="citytag" href="#"><i style="background:#2e7d54">ST</i>Stirling</a>
+      <a class="citytag" href="#"><i style="background:#3563a8">LX</i>Lisboa</a>
+    </div>
+
+    <p class="fine">
+      <a href="#">Über die Critical Mass</a> · <a href="#">FAQ</a> · <a href="#">API</a> ·
+      <a href="#">Impressum</a> · <a href="#">Datenschutz</a><br>
+      Karten © OpenStreetMap · Open Source · kein Tracking, nur Fahrradspuren
+    </p>
+  </aside>
+
+</div>
+
+<!-- Mobile Tabbar -->
+<nav class="tabbar">
+  <a class="on" href="#">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M3 11.2 12 4l9 7.2M5.5 9.8V20h13V9.8"/></svg>
+    Start
+  </a>
+  <a href="#">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><circle cx="12" cy="12" r="8.5"/><path d="m15.5 8.5-2 5-5 2 2-5z"/></svg>
+    Entdecken
+  </a>
+  <a class="plus" href="#" aria-label="Beitragen">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.4"><path d="M12 5v14M5 12h14"/></svg>
+  </a>
+  <a href="#">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><rect x="3.5" y="5" width="17" height="15.5" rx="2.5"/><path d="M3.5 9.5h17M8 3v4M16 3v4"/></svg>
+    Kalender
+  </a>
+  <a href="#">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><circle cx="12" cy="8.4" r="3.4"/><path d="M5 20c.8-3.4 3.6-5.2 7-5.2s6.2 1.8 7 5.2"/></svg>
+    Profil
+  </a>
+</nav>
+
+<a class="proto-back" href="index.html">← Übersicht</a>
+
+</body>
+</html>

--- a/design-prototypes/06-feed-aktiv.html
+++ b/design-prototypes/06-feed-aktiv.html
@@ -1,0 +1,626 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Prototyp 6 · Feed Aktivität — criticalmass.in</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@500;600&display=swap" rel="stylesheet">
+<style>
+:root {
+  --bg: #f2f3f5;
+  --card: #ffffff;
+  --line: #e3e5e8;
+  --ink: #16181c;
+  --dim: #707684;
+  --accent: #f4581c;       /* Warnwesten-Orange */
+  --accent-deep: #d8450e;
+  --green: #1e7d4f;
+  --sans: "Archivo", "Helvetica Neue", Arial, sans-serif;
+  --mono: "IBM Plex Mono", Menlo, monospace;
+}
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html, body { overflow-x: clip; }
+body {
+  font-family: var(--sans);
+  background: var(--bg);
+  color: var(--ink);
+  line-height: 1.5;
+  font-size: 15px;
+  padding-bottom: 70px;
+}
+a { color: inherit; text-decoration: none; }
+button { font-family: inherit; cursor: pointer; }
+
+/* ---------- Topbar ---------- */
+.top {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: var(--card);
+  border-bottom: 1px solid var(--line);
+}
+.top-inner {
+  max-width: 1080px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 22px;
+  padding: 0 16px;
+  height: 56px;
+}
+.brand { display: flex; align-items: center; gap: 9px; font-weight: 800; font-size: 1.05rem; letter-spacing: -.01em; }
+.brand .mark {
+  width: 28px; height: 28px;
+  border-radius: 8px;
+  background: var(--accent);
+  display: grid;
+  place-items: center;
+}
+.top nav { display: flex; gap: 4px; }
+.top nav a {
+  font-weight: 600;
+  font-size: .92rem;
+  color: var(--dim);
+  padding: 6px 12px;
+  border-radius: 8px;
+}
+.top nav a:hover { background: #f2f3f5; color: var(--ink); }
+.top nav a.on { color: var(--ink); background: #f2f3f5; font-weight: 700; }
+.top .grow { flex: 1; }
+.search {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: #f2f3f5;
+  border-radius: 9px;
+  padding: 7px 12px;
+  color: var(--dim);
+  font-size: .88rem;
+  min-width: 180px;
+}
+.upload-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--accent);
+  color: #fff;
+  border: 0;
+  border-radius: 9px;
+  font-weight: 700;
+  font-size: .9rem;
+  padding: 8px 14px;
+}
+.upload-btn:hover { background: var(--accent-deep); }
+.ava {
+  width: 34px; height: 34px;
+  border-radius: 99px;
+  flex: none;
+  display: grid;
+  place-items: center;
+  font-weight: 800;
+  font-size: .78rem;
+  color: #fff;
+}
+.ava.l { width: 44px; height: 44px; font-size: .95rem; }
+.ava.xs { width: 24px; height: 24px; font-size: .6rem; border: 2px solid #fff; }
+.ava.kk { background: #0e7c82; }
+.ava.bb { background: #5a4fa0; }
+.ava.cb { background: #b76fc4; }
+.ava.lk { background: #c98024; }
+.ava.mh { background: #3d4350; }
+.ava.an { background: #1e7d4f; }
+
+/* ---------- Layout ---------- */
+.shell {
+  max-width: 1080px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 340px;
+  gap: 24px;
+  padding: 22px 16px 40px;
+  align-items: start;
+}
+
+/* ---------- Hinweisleiste ---------- */
+.next-strip {
+  grid-column: 1 / -1;
+  background: linear-gradient(95deg, #1c2026, #2b323c);
+  color: #f3f5f8;
+  border-radius: 14px;
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  padding: 14px 20px;
+  flex-wrap: wrap;
+}
+.next-strip .lbl {
+  font-family: var(--mono);
+  font-size: .7rem;
+  text-transform: uppercase;
+  letter-spacing: .16em;
+  color: #ffb38f;
+}
+.next-strip b { font-size: 1.05rem; font-weight: 700; }
+.next-strip .when { color: #aeb6c2; font-size: .92rem; }
+.next-strip .cta {
+  margin-left: auto;
+  display: flex;
+  gap: 8px;
+}
+.next-strip .cta .btn { border-color: rgba(255,255,255,.25); color: #fff; background: transparent; }
+.next-strip .cta .btn.solid { background: var(--accent); border-color: var(--accent); }
+
+/* ---------- Aktivitätskarte ---------- */
+.feedcol { display: flex; flex-direction: column; gap: 18px; }
+.activity {
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  overflow: hidden;
+}
+.act-head { display: flex; gap: 12px; padding: 14px 18px 10px; align-items: center; }
+.act-head .who { line-height: 1.3; }
+.act-head .who b { font-weight: 700; }
+.act-head .who .sub { color: var(--dim); font-size: .82rem; }
+.act-head .badge {
+  margin-left: auto;
+  font-family: var(--mono);
+  font-size: .68rem;
+  text-transform: uppercase;
+  letter-spacing: .1em;
+  color: var(--dim);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 3px 8px;
+  white-space: nowrap;
+}
+.act-title { padding: 0 18px 12px; }
+.act-title h3 { font-size: 1.18rem; font-weight: 800; letter-spacing: -.015em; }
+.act-title .where { color: var(--dim); font-size: .86rem; margin-top: 2px; }
+.actmap { display: block; width: 100%; height: auto; }
+.statband {
+  display: flex;
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+  background: #fafbfc;
+}
+.statband > div { flex: 1; padding: 12px 18px; }
+.statband > div + div { border-left: 1px solid var(--line); }
+.statband .v { font-family: var(--mono); font-weight: 600; font-size: 1.25rem; }
+.statband .v small { font-size: .68em; color: var(--dim); margin-left: 2px; }
+.statband .k { font-size: .72rem; color: var(--dim); text-transform: uppercase; letter-spacing: .08em; margin-top: 1px; }
+.kudosbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 11px 18px;
+}
+.facepile { display: flex; }
+.facepile .ava.xs + .ava.xs { margin-left: -7px; }
+.kudosbar .note { color: var(--dim); font-size: .84rem; }
+.kudosbar .note b { color: var(--ink); }
+.kudosbar .spacer { flex: 1; }
+.kbtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  border: 1px solid var(--line);
+  background: var(--card);
+  border-radius: 9px;
+  padding: 7px 13px;
+  font-weight: 700;
+  font-size: .86rem;
+  color: var(--ink);
+}
+.kbtn:hover { border-color: #c9cdd3; }
+.kbtn.rung { border-color: var(--accent); color: var(--accent); background: #fff4ee; }
+.kbtn svg { stroke: currentColor; }
+.comment-preview {
+  border-top: 1px solid var(--line);
+  padding: 11px 18px 13px;
+  display: flex;
+  gap: 10px;
+  font-size: .89rem;
+  color: #3c4048;
+  align-items: baseline;
+}
+.comment-preview b { font-weight: 700; }
+.comment-preview .more { color: var(--dim); font-size: .8rem; margin-left: auto; white-space: nowrap; }
+
+/* Fotos in Karte */
+.photoband { display: grid; grid-template-columns: 2fr 1fr; gap: 4px; }
+.photoband .ph { position: relative; min-height: 150px; }
+.photoband .ph::after { content: ""; position: absolute; inset: 0; background-image: radial-gradient(rgba(22,24,28,.35) 1px, transparent 1.4px); background-size: 4px 4px; opacity: .45; }
+.photoband .col { display: grid; grid-template-rows: 1fr 1fr; gap: 4px; }
+.ph.p1 { background: linear-gradient(140deg, #c2d3ba, #5d8262); }
+.ph.p2 { background: linear-gradient(150deg, #e0c8a6, #a96f42); }
+.ph.p3 { background: linear-gradient(150deg, #b6c4d8, #58789c); }
+.ph.more { display: grid; place-items: center; background: #20242a; color: #fff; font-weight: 800; font-size: 1.2rem; }
+.ph.more::after { display: none; }
+
+/* Schätzungs-Karte */
+.estimate-line {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 4px 18px 14px;
+}
+.bignum {
+  font-family: var(--mono);
+  font-weight: 600;
+  font-size: 2.2rem;
+  letter-spacing: .02em;
+  background: #16181c;
+  color: #fff;
+  border-radius: 10px;
+  padding: 2px 14px;
+}
+.estimate-line .expl { font-size: .92rem; color: #3c4048; }
+.estimate-line .expl b { font-weight: 700; }
+
+/* ---------- Rechte Spalte ---------- */
+.rail { display: flex; flex-direction: column; gap: 18px; position: sticky; top: 76px; }
+.box {
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 16px 18px;
+}
+.box h4 { font-size: .95rem; font-weight: 800; display: flex; align-items: baseline; margin-bottom: 12px; }
+.box h4 small { margin-left: auto; font-weight: 600; color: var(--dim); font-size: .76rem; }
+.rank { display: flex; flex-direction: column; gap: 4px; }
+.rankrow {
+  display: grid;
+  grid-template-columns: 22px 1fr auto;
+  gap: 10px;
+  align-items: center;
+  padding: 6px 8px;
+  border-radius: 8px;
+  font-size: .92rem;
+}
+.rankrow:hover { background: #f6f7f8; }
+.rankrow .nr { font-family: var(--mono); font-size: .8rem; color: var(--dim); }
+.rankrow .city { font-weight: 700; }
+.rankrow .bar { height: 4px; border-radius: 4px; background: #ffd9c4; position: relative; margin-top: 4px; }
+.rankrow .bar i { position: absolute; inset: 0 auto 0 0; border-radius: 4px; background: var(--accent); }
+.rankrow .n { font-family: var(--mono); font-size: .84rem; font-weight: 600; }
+.rank .note { font-size: .74rem; color: var(--dim); margin-top: 10px; }
+.uprow { display: flex; gap: 10px; align-items: baseline; padding: 6px 8px; border-radius: 8px; font-size: .9rem; }
+.uprow:hover { background: #f6f7f8; }
+.uprow .t { font-family: var(--mono); font-size: .8rem; font-weight: 600; width: 52px; flex: none; }
+.uprow .c { font-weight: 700; }
+.uprow .p { margin-left: auto; color: var(--dim); font-size: .78rem; }
+.uprow.live .t { color: var(--accent); }
+.dayhead { font-size: .7rem; font-weight: 800; color: var(--dim); text-transform: uppercase; letter-spacing: .1em; margin: 8px 8px 2px; }
+.fine { font-size: .75rem; color: var(--dim); line-height: 1.6; padding: 0 6px; }
+.fine a { text-decoration: underline; text-decoration-color: #d4d7db; }
+
+/* ---------- Mobil ---------- */
+.tabbar { display: none; }
+.proto-back {
+  position: fixed;
+  bottom: 14px;
+  right: 14px;
+  z-index: 60;
+  font-size: .75rem;
+  font-weight: 700;
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 99px;
+  padding: 6px 12px;
+  color: var(--dim);
+}
+@media (max-width: 1000px) {
+  .shell { grid-template-columns: minmax(0, 1fr); }
+  .rail { position: static; }
+  .top nav, .search { display: none; }
+  .next-strip .cta { margin-left: 0; }
+  .tabbar {
+    display: flex;
+    position: fixed;
+    bottom: 0; left: 0; right: 0;
+    z-index: 55;
+    background: rgba(255,255,255,.96);
+    backdrop-filter: blur(10px);
+    border-top: 1px solid var(--line);
+    padding: 6px 8px calc(6px + env(safe-area-inset-bottom));
+  }
+  .tabbar a {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+    font-size: .62rem;
+    font-weight: 700;
+    color: var(--dim);
+    padding: 4px 0;
+  }
+  .tabbar a svg { stroke: currentColor; }
+  .tabbar a.on { color: var(--accent); }
+  .statband .v { font-size: 1.05rem; }
+  .proto-back { bottom: 76px; }
+}
+</style>
+</head>
+<body>
+
+<header class="top">
+  <div class="top-inner">
+    <a class="brand" href="#">
+      <span class="mark">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.4"><circle cx="6" cy="17" r="3.2"/><circle cx="18" cy="17" r="3.2"/><path d="M6 17 9.5 9H8m1.5 0h5L18 17M12 17l-1.5-6"/></svg>
+      </span>
+      criticalmass.in
+    </a>
+    <nav>
+      <a class="on" href="#">Timeline</a>
+      <a href="06e-karte.html">Karte</a>
+      <a href="06c-kalender.html">Kalender</a>
+      <a href="06l-verzeichnis.html">Städte</a>
+      <a href="06f-forum.html">Forum</a>
+    </nav>
+    <span class="grow"></span>
+    <a class="search" href="06j-suche.html">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="m20 20-4-4"/></svg>
+      Stadt oder Tour suchen
+    </a>
+    <a class="upload-btn" href="06h-hochladen.html">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.2"><path d="M12 16V5m0 0 -4 4m4-4 4 4M5 19h14"/></svg>
+      Hochladen
+    </a>
+    <a class="ava mh" href="06d-profil.html">MH</a>
+  </div>
+</header>
+
+<div class="shell">
+
+  <!-- Nächste Tour Leiste -->
+  <div class="next-strip">
+    <span class="lbl">Nächste Masse</span>
+    <a href="06a-tour.html"><b style="border-bottom:1px solid rgba(255,255,255,.3)">Critical Mass Hamburg</b></a>
+    <span class="when">Fr, 26. Juni · 19:00 · Alstervorland, Höhe Milchstraße · in 14 Tagen</span>
+    <span class="cta">
+      <button class="kbtn btn solid" style="color:#fff">Dabei!</button>
+      <button class="kbtn btn">iCal</button>
+    </span>
+  </div>
+
+  <!-- Feed -->
+  <main class="feedcol">
+
+    <!-- Track-Aktivität -->
+    <article class="activity">
+      <div class="act-head">
+        <span class="ava l bb">b</span>
+        <div class="who">
+          <b>birnenblau</b>
+          <div class="sub">vor 8 Tagen · GPX-Upload · Berlin</div>
+        </div>
+        <span class="badge">Track</span>
+      </div>
+      <div class="act-title">
+        <h3>Critical Mass Berlin — Novemberrunde</h3>
+        <div class="where">Tour vom 28.11.2025 · Start Mariannenplatz</div>
+      </div>
+      <svg class="actmap" viewBox="0 0 760 280" aria-hidden="true">
+        <rect width="760" height="280" fill="#e9ecef"/>
+        <g stroke="#d9dde2" stroke-width="1.5">
+          <line x1="90" y1="0" x2="90" y2="280"/><line x1="200" y1="0" x2="200" y2="280"/>
+          <line x1="330" y1="0" x2="330" y2="280"/><line x1="470" y1="0" x2="470" y2="280"/>
+          <line x1="610" y1="0" x2="610" y2="280"/>
+          <line x1="0" y1="70" x2="760" y2="70"/><line x1="0" y1="150" x2="760" y2="150"/>
+          <line x1="0" y1="220" x2="760" y2="220"/>
+        </g>
+        <path d="M0,180 C120,165 200,200 320,190 C460,178 520,130 640,138 C690,141 730,128 760,120 L760,160 C700,172 640,180 560,178 C440,175 380,225 260,232 C160,238 70,210 0,222 Z" fill="#dde4ea"/>
+        <path d="M120,210 L185,195 L225,140 L310,125 L385,160 L470,142 L540,85 L625,110 L685,70"
+          fill="none" stroke="#f4581c" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+        <path d="M120,210 L185,195 L225,140" fill="none" stroke="#16181c" stroke-width="4" stroke-linecap="round" stroke-dasharray="1 9"/>
+        <circle cx="120" cy="210" r="7" fill="#16181c"/>
+        <circle cx="685" cy="70" r="7" fill="#f4581c"/>
+        <text x="134" y="214" font-family="Archivo" font-size="12" font-weight="700" fill="#16181c">Start 20:00</text>
+      </svg>
+      <div class="statband">
+        <div><div class="v">25,58<small>km</small></div><div class="k">Strecke</div></div>
+        <div><div class="v">2:14<small>h</small></div><div class="k">Fahrzeit</div></div>
+        <div><div class="v">11,4<small>km/h</small></div><div class="k">Masse-Tempo</div></div>
+        <div><div class="v">2°<small>C</small></div><div class="k">Wetter</div></div>
+      </div>
+      <div class="kudosbar">
+        <span class="facepile">
+          <span class="ava xs kk">K</span><span class="ava xs cb">C</span><span class="ava xs lk">L</span><span class="ava xs an">A</span>
+        </span>
+        <span class="note"><b>9× geklingelt</b> — auch von Katrin und CM Bonn</span>
+        <span class="spacer"></span>
+        <button class="kbtn rung">
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke-width="2.2"><path d="M12 4a5.5 5.5 0 0 0-5.5 5.5c0 4-1.6 5.4-2.5 6h16c-.9-.6-2.5-2-2.5-6A5.5 5.5 0 0 0 12 4z"/><path d="M10 19a2 2 0 0 0 4 0"/></svg>
+          Geklingelt
+        </button>
+        <button class="kbtn">
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M20 12a8 8 0 1 0-3.1 6.3L20 19.5l-.8-3A8 8 0 0 0 20 12z"/></svg>
+          2
+        </button>
+      </div>
+      <div class="comment-preview">
+        <b>Katrin:</b> „Respekt bei dem Wetter — wir waren nach einer Stunde durchgefroren."
+        <span class="more">Antworten →</span>
+      </div>
+    </article>
+
+    <!-- Foto-Aktivität -->
+    <article class="activity">
+      <div class="act-head">
+        <span class="ava l cb">CB</span>
+        <div class="who">
+          <b>CM Bonn</b>
+          <div class="sub">vor 1 Woche · 4 Fotos · Bonn</div>
+        </div>
+        <span class="badge">Galerie</span>
+      </div>
+      <div class="act-title">
+        <h3>Maimasse am Rheinufer</h3>
+        <div class="where">Tour vom 29.05.2026 · ~ 350 Räder</div>
+      </div>
+      <div class="photoband">
+        <a class="ph p1" href="#"></a>
+        <div class="col">
+          <a class="ph p2" href="#"></a>
+          <a class="ph more" href="#">+2</a>
+        </div>
+      </div>
+      <div class="kudosbar">
+        <span class="facepile">
+          <span class="ava xs bb">b</span><span class="ava xs mh">M</span><span class="ava xs an">A</span>
+        </span>
+        <span class="note"><b>14× geklingelt</b></span>
+        <span class="spacer"></span>
+        <button class="kbtn">
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke-width="2.2"><path d="M12 4a5.5 5.5 0 0 0-5.5 5.5c0 4-1.6 5.4-2.5 6h16c-.9-.6-2.5-2-2.5-6A5.5 5.5 0 0 0 12 4z"/><path d="M10 19a2 2 0 0 0 4 0"/></svg>
+          Klingeln
+        </button>
+        <button class="kbtn">
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M20 12a8 8 0 1 0-3.1 6.3L20 19.5l-.8-3A8 8 0 0 0 20 12z"/></svg>
+          3
+        </button>
+      </div>
+    </article>
+
+    <!-- Schätzung -->
+    <article class="activity">
+      <div class="act-head">
+        <span class="ava l kk">KK</span>
+        <div class="who">
+          <b>Katrin Kiesel</b>
+          <div class="sub">vor 3 Tagen · Schätzung · Norderstedt</div>
+        </div>
+        <span class="badge">Zählung</span>
+      </div>
+      <div class="estimate-line">
+        <span class="bignum">0012</span>
+        <span class="expl"><b>12 Radfahrende</b> bei der Critical Mass Norderstedt am 5. Juni.
+        Der Mittelwert aller Schätzungen wird zur offiziellen Zahl der Tour.</span>
+      </div>
+      <div class="kudosbar" style="border-top:1px solid var(--line)">
+        <span class="note"><b>3× geklingelt</b></span>
+        <span class="spacer"></span>
+        <button class="kbtn">
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke-width="2.2"><path d="M12 4a5.5 5.5 0 0 0-5.5 5.5c0 4-1.6 5.4-2.5 6h16c-.9-.6-2.5-2-2.5-6A5.5 5.5 0 0 0 12 4z"/><path d="M10 19a2 2 0 0 0 4 0"/></svg>
+          Klingeln
+        </button>
+        <button class="kbtn">Selbst schätzen</button>
+      </div>
+    </article>
+
+    <!-- Forum -->
+    <article class="activity">
+      <div class="act-head">
+        <span class="ava l lk">LK</span>
+        <div class="who">
+          <b>Lotte</b>
+          <div class="sub">vor 5 Std · Board Hamburg</div>
+        </div>
+        <span class="badge">Forum</span>
+      </div>
+      <div class="act-title" style="padding-bottom:16px">
+        <h3 style="font-size:1.05rem">„Route im Juni mal Richtung Hafen?"</h3>
+        <div class="where" style="margin-top:6px">Beim letzten Mal war auf der Kennedybrücke ordentlich was los —
+        Vorschläge für den Treffpunkt danach? · <b style="color:var(--ink)">14 Antworten</b></div>
+      </div>
+    </article>
+
+  </main>
+
+  <!-- Rechte Spalte -->
+  <aside class="rail">
+    <div class="box">
+      <h4>Mai-Bilanz der Städte <small>geschätzte Räder</small></h4>
+      <div class="rank">
+        <a class="rankrow" href="06b-stadt.html">
+          <span class="nr">1</span>
+          <span><span class="city">Hamburg</span><span class="bar"><i style="width:100%"></i></span></span>
+          <span class="n">2.400</span>
+        </a>
+        <a class="rankrow" href="#">
+          <span class="nr">2</span>
+          <span><span class="city">Berlin</span><span class="bar"><i style="width:79%"></i></span></span>
+          <span class="n">1.900</span>
+        </a>
+        <a class="rankrow" href="#">
+          <span class="nr">3</span>
+          <span><span class="city">München</span><span class="bar"><i style="width:46%"></i></span></span>
+          <span class="n">1.100</span>
+        </a>
+        <a class="rankrow" href="#">
+          <span class="nr">4</span>
+          <span><span class="city">Köln</span><span class="bar"><i style="width:35%"></i></span></span>
+          <span class="n">850</span>
+        </a>
+        <a class="rankrow" href="#">
+          <span class="nr">5</span>
+          <span><span class="city">Wien</span><span class="bar"><i style="width:29%"></i></span></span>
+          <span class="n">700</span>
+        </a>
+        <a class="rankrow" href="#">
+          <span class="nr">6</span>
+          <span><span class="city">Lisboa</span><span class="bar"><i style="width:27%"></i></span></span>
+          <span class="n">650</span>
+        </a>
+        <p class="note">Aus Teilnahme-Schätzungen der Community · <a href="06i-statistik.html" style="text-decoration:underline">ganze Statistik</a></p>
+      </div>
+    </div>
+
+    <div class="box">
+      <h4>Bald unterwegs <small>43 Touren / 14 Tage</small></h4>
+      <div class="dayhead">Heute</div>
+      <a class="uprow live" href="#"><span class="t">jetzt</span><span class="c">Lisboa</span><span class="p">seit 21:00</span></a>
+      <a class="uprow" href="#"><span class="t">17:00</span><span class="c">Falkensee</span><span class="p">Bahnhof</span></a>
+      <a class="uprow" href="#"><span class="t">19:00</span><span class="c">Düsseldorf</span><span class="p">Fürstenplatz</span></a>
+      <a class="uprow" href="#"><span class="t">19:00</span><span class="c">Frankfurt</span><span class="p">Opernplatz</span></a>
+      <div class="dayhead">Fr, 19. Juni</div>
+      <a class="uprow" href="#"><span class="t">17:00</span><span class="c">Wien</span><span class="p">Schwarzenbergplatz</span></a>
+      <a class="uprow" href="#"><span class="t">18:30</span><span class="c">Los Angeles</span><span class="p">Karte</span></a>
+      <div class="dayhead">Fr, 26. Juni</div>
+      <a class="uprow" href="06a-tour.html"><span class="t">19:00</span><span class="c">Hamburg</span><span class="p">Alstervorland</span></a>
+      <a class="uprow" href="#"><span class="t">20:00</span><span class="c">Berlin</span><span class="p">Mariannenplatz</span></a>
+      <a class="uprow" href="#"><span class="t">+41</span><span class="c">weitere</span><span class="p">→</span></a>
+    </div>
+
+    <p class="fine">
+      <a href="#">Über die Critical Mass</a> · <a href="#">FAQ</a> · <a href="#">API</a> ·
+      <a href="#">Impressum</a> · <a href="#">Datenschutz</a><br>
+      Karten © OpenStreetMap-Mitwirkende · Open Source · Tracks gehören dir
+    </p>
+  </aside>
+
+</div>
+
+<!-- Mobile Tabbar -->
+<nav class="tabbar">
+  <a class="on" href="#">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M3 11.2 12 4l9 7.2M5.5 9.8V20h13V9.8"/></svg>
+    Timeline
+  </a>
+  <a href="06e-karte.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M12 21s7-6 7-11a7 7 0 0 0-14 0c0 5 7 11 7 11z"/><circle cx="12" cy="9.8" r="2.4"/></svg>
+    Karte
+  </a>
+  <a href="06h-hochladen.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M12 16V5m0 0-4 4m4-4 4 4M5 19h14"/></svg>
+    Hochladen
+  </a>
+  <a href="06c-kalender.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><rect x="3.5" y="5" width="17" height="15.5" rx="2.5"/><path d="M3.5 9.5h17M8 3v4M16 3v4"/></svg>
+    Kalender
+  </a>
+  <a href="06d-profil.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><circle cx="12" cy="8.4" r="3.4"/><path d="M5 20c.8-3.4 3.6-5.2 7-5.2s6.2 1.8 7 5.2"/></svg>
+    Profil
+  </a>
+</nav>
+
+<a class="proto-back" href="index.html">← Übersicht</a>
+
+</body>
+</html>

--- a/design-prototypes/06a-tour.html
+++ b/design-prototypes/06a-tour.html
@@ -1,0 +1,458 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Critical Mass Hamburg · 26.06.2026 — Prototyp 6 · criticalmass.in</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@500;600&display=swap" rel="stylesheet">
+<style>
+:root {
+  --bg: #f2f3f5;
+  --card: #ffffff;
+  --line: #e3e5e8;
+  --ink: #16181c;
+  --dim: #707684;
+  --accent: #f4581c;
+  --accent-deep: #d8450e;
+  --green: #1e7d4f;
+  --sans: "Archivo", "Helvetica Neue", Arial, sans-serif;
+  --mono: "IBM Plex Mono", Menlo, monospace;
+}
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html, body { overflow-x: clip; }
+body {
+  font-family: var(--sans);
+  background: var(--bg);
+  color: var(--ink);
+  line-height: 1.5;
+  font-size: 15px;
+  padding-bottom: 70px;
+}
+a { color: inherit; text-decoration: none; }
+button { font-family: inherit; cursor: pointer; }
+
+/* ---------- Topbar (wie Feed) ---------- */
+.top { position: sticky; top: 0; z-index: 50; background: var(--card); border-bottom: 1px solid var(--line); }
+.top-inner { max-width: 1080px; margin: 0 auto; display: flex; align-items: center; gap: 22px; padding: 0 16px; height: 56px; }
+.brand { display: flex; align-items: center; gap: 9px; font-weight: 800; font-size: 1.05rem; letter-spacing: -.01em; }
+.brand .mark { width: 28px; height: 28px; border-radius: 8px; background: var(--accent); display: grid; place-items: center; }
+.top nav { display: flex; gap: 4px; }
+.top nav a { font-weight: 600; font-size: .92rem; color: var(--dim); padding: 6px 12px; border-radius: 8px; }
+.top nav a:hover { background: #f2f3f5; color: var(--ink); }
+.top nav a.on { color: var(--ink); background: #f2f3f5; font-weight: 700; }
+.top .grow { flex: 1; }
+.search { display: flex; align-items: center; gap: 8px; background: #f2f3f5; border-radius: 9px; padding: 7px 12px; color: var(--dim); font-size: .88rem; min-width: 180px; }
+.upload-btn { display: inline-flex; align-items: center; gap: 8px; background: var(--accent); color: #fff; border: 0; border-radius: 9px; font-weight: 700; font-size: .9rem; padding: 8px 14px; }
+.upload-btn:hover { background: var(--accent-deep); }
+.ava { width: 34px; height: 34px; border-radius: 99px; flex: none; display: grid; place-items: center; font-weight: 800; font-size: .78rem; color: #fff; }
+.ava.xs { width: 26px; height: 26px; font-size: .6rem; border: 2px solid #fff; }
+.ava.kk { background: #0e7c82; }
+.ava.bb { background: #5a4fa0; }
+.ava.cb { background: #b76fc4; }
+.ava.lk { background: #c98024; }
+.ava.mh { background: #3d4350; }
+.ava.an { background: #1e7d4f; }
+.ava.vh { background: #2b6cb0; }
+
+/* ---------- Layout ---------- */
+.shell { max-width: 1080px; margin: 0 auto; display: grid; grid-template-columns: minmax(0, 1fr) 340px; gap: 24px; padding: 22px 16px 40px; align-items: start; }
+.maincol { display: flex; flex-direction: column; gap: 18px; min-width: 0; }
+.crumbs { grid-column: 1 / -1; font-size: .84rem; color: var(--dim); display: flex; gap: 7px; flex-wrap: wrap; }
+.crumbs a:hover { color: var(--ink); text-decoration: underline; }
+.crumbs b { color: var(--ink); font-weight: 600; }
+
+/* ---------- Tour-Hero ---------- */
+.hero { background: var(--card); border: 1px solid var(--line); border-radius: 14px; overflow: hidden; }
+.heromap { display: block; width: 100%; height: auto; }
+.hero-body { padding: 16px 18px 0; }
+.hero-head { display: flex; gap: 14px; align-items: flex-start; flex-wrap: wrap; }
+.hero-head .when {
+  font-family: var(--mono);
+  font-size: .72rem;
+  text-transform: uppercase;
+  letter-spacing: .14em;
+  color: var(--accent);
+  font-weight: 600;
+}
+.hero-head h1 { font-size: 1.55rem; font-weight: 800; letter-spacing: -.02em; line-height: 1.15; }
+.hero-head .sub { color: var(--dim); font-size: .92rem; margin-top: 3px; }
+.hero-head .sub a { font-weight: 600; color: var(--ink); }
+.hero-head .sub a:hover { color: var(--accent); }
+.countchip {
+  margin-left: auto;
+  flex: none;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 8px 14px;
+  text-align: center;
+}
+.countchip .n { font-family: var(--mono); font-weight: 600; font-size: 1.15rem; }
+.countchip .k { font-size: .68rem; color: var(--dim); text-transform: uppercase; letter-spacing: .08em; }
+.joinrow { display: flex; gap: 8px; align-items: center; padding: 14px 0 16px; flex-wrap: wrap; }
+.kbtn {
+  display: inline-flex; align-items: center; gap: 7px;
+  border: 1px solid var(--line); background: var(--card);
+  border-radius: 9px; padding: 8px 15px;
+  font-weight: 700; font-size: .88rem; color: var(--ink);
+}
+.kbtn:hover { border-color: #c9cdd3; }
+.kbtn.solid { background: var(--accent); border-color: var(--accent); color: #fff; }
+.kbtn.solid:hover { background: var(--accent-deep); }
+.kbtn svg { stroke: currentColor; }
+.joinrow .who { display: flex; align-items: center; gap: 8px; margin-left: auto; }
+.facepile { display: flex; }
+.facepile .ava.xs + .ava.xs { margin-left: -8px; }
+.joinrow .who .note { font-size: .82rem; color: var(--dim); }
+.joinrow .who .note b { color: var(--ink); }
+.statband { display: flex; border-top: 1px solid var(--line); background: #fafbfc; }
+.statband > div { flex: 1; padding: 12px 18px; }
+.statband > div + div { border-left: 1px solid var(--line); }
+.statband .v { font-family: var(--mono); font-weight: 600; font-size: 1.15rem; }
+.statband .v small { font-size: .68em; color: var(--dim); margin-left: 2px; }
+.statband .k { font-size: .7rem; color: var(--dim); text-transform: uppercase; letter-spacing: .08em; margin-top: 1px; }
+
+/* ---------- Tabs ---------- */
+.tabs { display: flex; gap: 2px; background: var(--card); border: 1px solid var(--line); border-radius: 12px; padding: 4px; overflow-x: auto; }
+.tabs a {
+  flex: 1;
+  text-align: center;
+  font-weight: 700;
+  font-size: .88rem;
+  color: var(--dim);
+  border-radius: 9px;
+  padding: 8px 12px;
+  white-space: nowrap;
+}
+.tabs a.on { background: #f2f3f5; color: var(--ink); }
+.tabs a:hover:not(.on) { color: var(--ink); }
+.tabs a .n { font-family: var(--mono); font-size: .72rem; color: var(--dim); margin-left: 4px; }
+
+/* ---------- Inhaltskarten ---------- */
+.box { background: var(--card); border: 1px solid var(--line); border-radius: 14px; padding: 18px; }
+.box h2 { font-size: 1.02rem; font-weight: 800; margin-bottom: 12px; display: flex; align-items: baseline; }
+.box h2 small { margin-left: auto; font-weight: 600; color: var(--dim); font-size: .76rem; }
+.lovestory { display: grid; gap: 10px; }
+.rule { display: flex; gap: 12px; align-items: baseline; }
+.rule .nr {
+  flex: none;
+  font-family: var(--mono);
+  font-size: .76rem;
+  font-weight: 600;
+  color: var(--accent);
+  border: 1px solid #ffd4bf;
+  background: #fff4ee;
+  border-radius: 7px;
+  padding: 2px 8px;
+}
+.rule p { font-size: .94rem; color: #3c4048; }
+.rule p b { color: var(--ink); }
+.lovestory .src { font-size: .78rem; color: var(--dim); margin-top: 4px; }
+
+/* Kommentare */
+.comment { display: flex; gap: 11px; padding: 12px 0; border-top: 1px solid var(--line); }
+.comment:first-of-type { border-top: 0; padding-top: 0; }
+.comment .body { min-width: 0; }
+.comment .meta { font-size: .82rem; color: var(--dim); }
+.comment .meta b { color: var(--ink); font-size: .92rem; }
+.comment p { font-size: .93rem; color: #3c4048; margin-top: 2px; }
+.comment .r { font-size: .78rem; color: var(--dim); margin-top: 5px; display: flex; gap: 14px; }
+.comment .r a:hover { color: var(--accent); }
+.writebox { display: flex; gap: 10px; margin-top: 6px; padding-top: 14px; border-top: 1px solid var(--line); }
+.writebox input { flex: 1; border: 1px solid var(--line); background: #fafbfc; border-radius: 99px; padding: 9px 16px; font: inherit; min-width: 0; }
+.writebox input::placeholder { color: var(--dim); }
+
+/* ---------- Rechte Spalte ---------- */
+.rail { display: flex; flex-direction: column; gap: 18px; position: sticky; top: 76px; }
+.rail .box { padding: 16px 18px; }
+.meetrow { display: flex; gap: 12px; }
+.meetrow .pin { flex: none; width: 38px; height: 38px; border-radius: 10px; background: #fff4ee; display: grid; place-items: center; }
+.meetrow b { font-size: .95rem; }
+.meetrow .d { font-size: .82rem; color: var(--dim); }
+.transit { display: flex; gap: 6px; flex-wrap: wrap; margin-top: 12px; }
+.tline {
+  font-family: var(--mono);
+  font-size: .72rem;
+  font-weight: 600;
+  color: #fff;
+  border-radius: 5px;
+  padding: 3px 8px;
+}
+.tline.u1 { background: #0b5ca2; }
+.tline.bus { background: #e7873a; }
+.tline.s11 { background: #149533; }
+.transit .walk { font-size: .78rem; color: var(--dim); align-self: center; }
+.pastrow { display: flex; gap: 10px; align-items: baseline; padding: 8px 6px; border-radius: 8px; font-size: .9rem; }
+.pastrow:hover { background: #f6f7f8; }
+.pastrow .d { font-family: var(--mono); font-size: .8rem; color: var(--dim); width: 78px; flex: none; }
+.pastrow .n { font-weight: 700; }
+.pastrow .x { margin-left: auto; color: var(--dim); font-size: .78rem; text-align: right; }
+.wetter { display: flex; align-items: center; gap: 14px; }
+.wetter .t { font-family: var(--mono); font-weight: 600; font-size: 1.6rem; }
+.wetter .d { font-size: .84rem; color: var(--dim); }
+.fine { font-size: .75rem; color: var(--dim); line-height: 1.6; padding: 0 6px; }
+.fine a { text-decoration: underline; text-decoration-color: #d4d7db; }
+
+/* ---------- Mobil ---------- */
+.tabbar { display: none; }
+.proto-back { position: fixed; bottom: 14px; right: 14px; z-index: 60; font-size: .75rem; font-weight: 700; background: var(--card); border: 1px solid var(--line); border-radius: 99px; padding: 6px 12px; color: var(--dim); }
+@media (max-width: 1000px) {
+  .shell { grid-template-columns: minmax(0, 1fr); }
+  .rail { position: static; }
+  .top nav, .search { display: none; }
+  .statband { flex-wrap: wrap; }
+  .statband > div { flex: 1 1 40%; border-top: 1px solid var(--line); margin-top: -1px; }
+  .countchip { margin-left: 0; }
+  .joinrow .who { margin-left: 0; }
+  .tabbar {
+    display: flex; position: fixed; bottom: 0; left: 0; right: 0; z-index: 55;
+    background: rgba(255,255,255,.96); backdrop-filter: blur(10px);
+    border-top: 1px solid var(--line);
+    padding: 6px 8px calc(6px + env(safe-area-inset-bottom));
+  }
+  .tabbar a { flex: 1; display: flex; flex-direction: column; align-items: center; gap: 2px; font-size: .62rem; font-weight: 700; color: var(--dim); padding: 4px 0; }
+  .tabbar a svg { stroke: currentColor; }
+  .tabbar a.on { color: var(--accent); }
+  .proto-back { bottom: 76px; }
+}
+</style>
+</head>
+<body>
+
+<header class="top">
+  <div class="top-inner">
+    <a class="brand" href="06-feed-aktiv.html">
+      <span class="mark">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.4"><circle cx="6" cy="17" r="3.2"/><circle cx="18" cy="17" r="3.2"/><path d="M6 17 9.5 9H8m1.5 0h5L18 17M12 17l-1.5-6"/></svg>
+      </span>
+      criticalmass.in
+    </a>
+    <nav>
+      <a href="06-feed-aktiv.html">Timeline</a>
+      <a href="06e-karte.html">Karte</a>
+      <a class="on" href="06c-kalender.html">Kalender</a>
+      <a href="06l-verzeichnis.html">Städte</a>
+      <a href="06f-forum.html">Forum</a>
+    </nav>
+    <span class="grow"></span>
+    <a class="search" href="06j-suche.html">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke-width="2" stroke="currentColor"><circle cx="11" cy="11" r="7"/><path d="m20 20-4-4"/></svg>
+      Stadt oder Tour suchen
+    </a>
+    <a class="upload-btn" href="06h-hochladen.html">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.2"><path d="M12 16V5m0 0 -4 4m4-4 4 4M5 19h14"/></svg>
+      Hochladen
+    </a>
+    <a class="ava mh" href="06d-profil.html">MH</a>
+  </div>
+</header>
+
+<div class="shell">
+
+  <p class="crumbs">
+    <a href="06-feed-aktiv.html">Timeline</a> ›
+    <a href="06b-stadt.html">Hamburg</a> ›
+    <b>Critical Mass · 26. Juni 2026</b>
+  </p>
+
+  <!-- Hauptspalte -->
+  <main class="maincol">
+
+    <section class="hero">
+      <svg class="heromap" viewBox="0 0 760 280" aria-hidden="true">
+        <rect width="760" height="280" fill="#e9ecef"/>
+        <g stroke="#d9dde2" stroke-width="1.5">
+          <line x1="100" y1="0" x2="100" y2="280"/><line x1="220" y1="0" x2="220" y2="280"/>
+          <line x1="350" y1="0" x2="350" y2="280"/><line x1="500" y1="0" x2="500" y2="280"/>
+          <line x1="640" y1="0" x2="640" y2="280"/>
+          <line x1="0" y1="60" x2="760" y2="60"/><line x1="0" y1="140" x2="760" y2="140"/>
+          <line x1="0" y1="215" x2="760" y2="215"/>
+        </g>
+        <!-- Außenalster -->
+        <path d="M430,40 C500,30 560,60 575,120 C588,172 560,225 500,240 C450,252 408,230 395,185 C382,140 385,80 430,40 Z" fill="#d4e0ea" stroke="#bccddd" stroke-width="1.5"/>
+        <text x="468" y="148" font-family="Archivo" font-size="12" fill="#8aa0b4" font-style="italic">Außenalster</text>
+        <!-- Parkstreifen Alstervorland -->
+        <path d="M388,60 C376,110 376,170 398,222 L362,232 C340,175 342,105 360,52 Z" fill="#dde7d6"/>
+        <!-- Treffpunkt-Pin -->
+        <g transform="translate(380,128)">
+          <circle r="26" fill="rgba(244,88,28,.14)">
+            <animate attributeName="r" values="20;30;20" dur="3s" repeatCount="indefinite"/>
+          </circle>
+          <path d="M0,12 C-9,1 -12,-5 -12,-12 A12,12 0 1 1 12,-12 C12,-5 9,1 0,12 Z" fill="#f4581c"/>
+          <circle cy="-11" r="4.5" fill="#fff"/>
+        </g>
+        <g transform="translate(403,103)">
+          <rect x="0" y="0" width="186" height="26" rx="7" fill="#16181c"/>
+          <text x="12" y="17" font-family="Archivo" font-size="12" font-weight="700" fill="#fff">Treffpunkt · Alstervorland</text>
+        </g>
+      </svg>
+      <div class="hero-body">
+        <div class="hero-head">
+          <div>
+            <span class="when">Freitag · 26. Juni 2026 · 19:00 Uhr</span>
+            <h1>Critical Mass Hamburg</h1>
+            <p class="sub">Alstervorland, Höhe Milchstraße · <a href="06b-stadt.html">Stadtseite Hamburg →</a></p>
+          </div>
+          <span class="countchip"><span class="n">in 14 Tg</span><span class="k">Countdown</span></span>
+        </div>
+        <div class="joinrow">
+          <button class="kbtn solid">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.4"><path d="m4.5 12.5 5 5 10-11"/></svg>
+            Dabei!
+          </button>
+          <button class="kbtn">Vielleicht</button>
+          <button class="kbtn">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke-width="2"><rect x="3.5" y="5" width="17" height="15.5" rx="2.5"/><path d="M3.5 9.5h17M8 3v4M16 3v4"/></svg>
+            iCal
+          </button>
+          <button class="kbtn">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M14 9V5l7 7-7 7v-4c-7 0-10 2-11 5 0-7 4-11 11-11z"/></svg>
+            Teilen
+          </button>
+          <span class="who">
+            <span class="facepile">
+              <span class="ava xs kk">K</span><span class="ava xs bb">b</span><span class="ava xs lk">L</span><span class="ava xs vh">V</span><span class="ava xs an">A</span>
+            </span>
+            <span class="note"><b>132 dabei</b> · 41 vielleicht</span>
+          </span>
+        </div>
+      </div>
+      <div class="statband">
+        <div><div class="v">~ 2.400</div><div class="k">Räder zuletzt (Mai)</div></div>
+        <div><div class="v">19,4<small>km</small></div><div class="k">Ø Strecke</div></div>
+        <div><div class="v">2:05<small>h</small></div><div class="k">Ø Dauer</div></div>
+        <div><div class="v">178.</div><div class="k">Masse seit 2011</div></div>
+      </div>
+    </section>
+
+    <nav class="tabs">
+      <a class="on" href="#">Details</a>
+      <a href="#">Kommentare<span class="n">3</span></a>
+      <a href="#">Mini-Masses<span class="n">0</span></a>
+      <a href="06g-galerie.html">Galerie<span class="n">–</span></a>
+      <a href="#">Tracks<span class="n">–</span></a>
+    </nav>
+
+    <section class="box">
+      <h2>Critical Love Story <small>so rollt die Masse</small></h2>
+      <div class="lovestory">
+        <div class="rule"><span class="nr">01</span><p><b>Bleibt stets freundlich und respektvoll</b> — gegenüber allen, auch denen im Auto.</p></div>
+        <div class="rule"><span class="nr">02</span><p><b>Zum Schutz der Masse an Kreuzungen corken:</b> Querverkehr kurz aufhalten, bis alle durch sind.</p></div>
+        <div class="rule"><span class="nr">03</span><p><b>Bleibt zusammen.</b> Die Masse fährt so schnell wie ihre Langsamsten — vorne langsam, hinten lückenlos.</p></div>
+        <div class="rule"><span class="nr">04</span><p><b>Rettungsgasse geht vor.</b> Blaulicht hat immer Vorfahrt, Masse hin oder her.</p></div>
+        <p class="src">Es gilt § 27 StVO: Ab 16 Radfahrenden fahren wir als geschlossener Verband — zwei nebeneinander.</p>
+      </div>
+    </section>
+
+    <section class="box">
+      <h2>Kommentare <small>3 Beiträge</small></h2>
+      <div class="comment">
+        <span class="ava lk">LK</span>
+        <div class="body">
+          <p class="meta"><b>Lotte</b> · vor 5 Std</p>
+          <p>Route im Juni mal Richtung Hafen? Beim letzten Mal war auf der Kennedybrücke ordentlich was los.</p>
+          <p class="r"><a href="#">Antworten</a><a href="#">Klingeln · 4</a></p>
+        </div>
+      </div>
+      <div class="comment">
+        <span class="ava an">A</span>
+        <div class="body">
+          <p class="meta"><b>Anna</b> · vor 3 Std</p>
+          <p>Gibt's wieder eine Familien-Gruppe weiter hinten? Wir kommen mit Lastenrad und zwei Kindern.</p>
+          <p class="r"><a href="#">Antworten</a><a href="#">Klingeln · 2</a></p>
+        </div>
+      </div>
+      <div class="comment">
+        <span class="ava bb">b</span>
+        <div class="body">
+          <p class="meta"><b>birnenblau</b> · vor 1 Std</p>
+          <p>@Anna klar — sammeln hinten links, Tempo ist dort entspannt. Einfach nach den Anhängern Ausschau halten.</p>
+          <p class="r"><a href="#">Antworten</a><a href="#">Klingeln · 5</a></p>
+        </div>
+      </div>
+      <div class="writebox">
+        <span class="ava mh">MH</span>
+        <input type="text" placeholder="Frag die Masse …">
+      </div>
+    </section>
+
+  </main>
+
+  <!-- Rechte Spalte -->
+  <aside class="rail">
+    <div class="box">
+      <h2 style="margin-bottom:14px">Treffpunkt</h2>
+      <div class="meetrow">
+        <span class="pin">
+          <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="#f4581c" stroke-width="2.2"><path d="M12 21s7-6 7-11a7 7 0 0 0-14 0c0 5 7 11 7 11z"/><circle cx="12" cy="9.8" r="2.4"/></svg>
+        </span>
+        <div>
+          <b>Alstervorland, Höhe Milchstraße</b>
+          <p class="d">Wiese am Westufer der Außenalster — sammeln ab 18:30, Abfahrt pünktlich 19:00.</p>
+        </div>
+      </div>
+      <div class="transit">
+        <span class="tline u1">U1 Hallerstraße</span>
+        <span class="tline s11">S11 Dammtor</span>
+        <span class="tline bus">Bus 109</span>
+        <span class="walk">+ 5 min mit dem Rad</span>
+      </div>
+    </div>
+
+    <div class="box">
+      <h2 style="margin-bottom:10px">Wetter zur Abfahrt</h2>
+      <div class="wetter">
+        <svg width="42" height="42" viewBox="0 0 24 24" fill="none" stroke="#f4a51c" stroke-width="1.8"><circle cx="12" cy="12" r="4.5"/><path d="M12 3v2.5M12 18.5V21M3 12h2.5M18.5 12H21M5.6 5.6l1.8 1.8M16.6 16.6l1.8 1.8M18.4 5.6l-1.8 1.8M7.4 16.6l-1.8 1.8"/></svg>
+        <div>
+          <span class="t">18°C</span>
+          <p class="d">leicht bewölkt, trocken · Wind 12 km/h aus West</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="box">
+      <h2 style="margin-bottom:8px">Letzte Massen in Hamburg <small><a href="06b-stadt.html" style="text-decoration:underline">alle →</a></small></h2>
+      <a class="pastrow" href="#"><span class="d">29.05.2026</span><span class="n">~ 2.400</span><span class="x">4 Tracks · 23 Fotos</span></a>
+      <a class="pastrow" href="#"><span class="d">24.04.2026</span><span class="n">~ 1.900</span><span class="x">3 Tracks · 11 Fotos</span></a>
+      <a class="pastrow" href="#"><span class="d">27.03.2026</span><span class="n">~ 1.200</span><span class="x">2 Tracks · 8 Fotos</span></a>
+      <a class="pastrow" href="#"><span class="d">27.02.2026</span><span class="n">~ 1.100</span><span class="x">1 Track · 4 Fotos</span></a>
+    </div>
+
+    <p class="fine">
+      Critical Mass hat keinen Veranstalter — diese Seite pflegt die Community.
+      <a href="#">Tour bearbeiten</a> · <a href="#">Fehler melden</a><br><br>
+      Karten © OpenStreetMap-Mitwirkende · Wetter: OpenWeatherMap
+    </p>
+  </aside>
+
+</div>
+
+<!-- Mobile Tabbar -->
+<nav class="tabbar">
+  <a href="06-feed-aktiv.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M3 11.2 12 4l9 7.2M5.5 9.8V20h13V9.8"/></svg>
+    Timeline
+  </a>
+  <a href="06e-karte.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M12 21s7-6 7-11a7 7 0 0 0-14 0c0 5 7 11 7 11z"/><circle cx="12" cy="9.8" r="2.4"/></svg>
+    Karte
+  </a>
+  <a href="06h-hochladen.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M12 16V5m0 0-4 4m4-4 4 4M5 19h14"/></svg>
+    Hochladen
+  </a>
+  <a class="on" href="06c-kalender.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><rect x="3.5" y="5" width="17" height="15.5" rx="2.5"/><path d="M3.5 9.5h17M8 3v4M16 3v4"/></svg>
+    Kalender
+  </a>
+  <a href="06d-profil.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><circle cx="12" cy="8.4" r="3.4"/><path d="M5 20c.8-3.4 3.6-5.2 7-5.2s6.2 1.8 7 5.2"/></svg>
+    Profil
+  </a>
+</nav>
+
+<a class="proto-back" href="index.html">← Übersicht</a>
+
+</body>
+</html>

--- a/design-prototypes/06b-stadt.html
+++ b/design-prototypes/06b-stadt.html
@@ -1,0 +1,569 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Critical Mass Hamburg — Prototyp 6 · criticalmass.in</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@500;600&display=swap" rel="stylesheet">
+<style>
+:root {
+  --bg: #f2f3f5;
+  --card: #ffffff;
+  --line: #e3e5e8;
+  --ink: #16181c;
+  --dim: #707684;
+  --accent: #f4581c;
+  --accent-deep: #d8450e;
+  --green: #1e7d4f;
+  --sans: "Archivo", "Helvetica Neue", Arial, sans-serif;
+  --mono: "IBM Plex Mono", Menlo, monospace;
+}
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html, body { overflow-x: clip; }
+body {
+  font-family: var(--sans);
+  background: var(--bg);
+  color: var(--ink);
+  line-height: 1.5;
+  font-size: 15px;
+  padding-bottom: 70px;
+}
+a { color: inherit; text-decoration: none; }
+button { font-family: inherit; cursor: pointer; }
+
+/* ---------- Topbar ---------- */
+.top { position: sticky; top: 0; z-index: 50; background: var(--card); border-bottom: 1px solid var(--line); }
+.top-inner { max-width: 1080px; margin: 0 auto; display: flex; align-items: center; gap: 22px; padding: 0 16px; height: 56px; }
+.brand { display: flex; align-items: center; gap: 9px; font-weight: 800; font-size: 1.05rem; letter-spacing: -.01em; }
+.brand .mark { width: 28px; height: 28px; border-radius: 8px; background: var(--accent); display: grid; place-items: center; }
+.top nav { display: flex; gap: 4px; }
+.top nav a { font-weight: 600; font-size: .92rem; color: var(--dim); padding: 6px 12px; border-radius: 8px; }
+.top nav a:hover { background: #f2f3f5; color: var(--ink); }
+.top nav a.on { color: var(--ink); background: #f2f3f5; font-weight: 700; }
+.top .grow { flex: 1; }
+.search { display: flex; align-items: center; gap: 8px; background: #f2f3f5; border-radius: 9px; padding: 7px 12px; color: var(--dim); font-size: .88rem; min-width: 180px; }
+.upload-btn { display: inline-flex; align-items: center; gap: 8px; background: var(--accent); color: #fff; border: 0; border-radius: 9px; font-weight: 700; font-size: .9rem; padding: 8px 14px; }
+.upload-btn:hover { background: var(--accent-deep); }
+.ava { width: 34px; height: 34px; border-radius: 99px; flex: none; display: grid; place-items: center; font-weight: 800; font-size: .78rem; color: #fff; }
+.ava.l { width: 44px; height: 44px; font-size: .95rem; }
+.ava.xs { width: 24px; height: 24px; font-size: .6rem; border: 2px solid #fff; }
+.ava.kk { background: #0e7c82; }
+.ava.bb { background: #5a4fa0; }
+.ava.cb { background: #b76fc4; }
+.ava.lk { background: #c98024; }
+.ava.mh { background: #3d4350; }
+.ava.an { background: #1e7d4f; }
+.ava.vh { background: #2b6cb0; }
+.ava.sj { background: #8c5e2a; }
+.ava.hh { background: #f4581c; }
+
+/* ---------- Layout ---------- */
+.shell { max-width: 1080px; margin: 0 auto; display: grid; grid-template-columns: minmax(0, 1fr) 340px; gap: 24px; padding: 22px 16px 40px; align-items: start; }
+.maincol { display: flex; flex-direction: column; gap: 18px; min-width: 0; }
+.crumbs { grid-column: 1 / -1; font-size: .84rem; color: var(--dim); display: flex; gap: 7px; flex-wrap: wrap; }
+.crumbs a:hover { color: var(--ink); text-decoration: underline; }
+.crumbs b { color: var(--ink); font-weight: 600; }
+
+/* ---------- Stadt-Hero ---------- */
+.cityhero { background: var(--card); border: 1px solid var(--line); border-radius: 14px; overflow: hidden; }
+.cityhero .cover {
+  height: 86px;
+  background:
+    linear-gradient(100deg, rgba(244,88,28,.16), transparent 55%),
+    repeating-linear-gradient(115deg, #eef0f2 0 22px, #e7eaee 22px 23px),
+    #eef0f2;
+  position: relative;
+}
+.cityhero .cover svg { position: absolute; inset: 0; width: 100%; height: 100%; }
+.cityhero .head { display: flex; gap: 16px; padding: 0 18px 14px; margin-top: -26px; align-items: flex-end; flex-wrap: wrap; }
+.citymark {
+  width: 64px; height: 64px;
+  border-radius: 18px;
+  background: var(--ink);
+  color: #fff;
+  display: grid;
+  place-items: center;
+  font-weight: 800;
+  font-size: 1.3rem;
+  border: 3px solid var(--card);
+  flex: none;
+}
+.cityhero .head .t { padding-bottom: 2px; min-width: 0; }
+.cityhero h1 { font-size: 1.5rem; font-weight: 800; letter-spacing: -.02em; line-height: 1.1; display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+.cc { font-family: var(--mono); font-size: .64rem; font-weight: 600; color: #fff; background: var(--ink); border-radius: 5px; padding: 2.5px 7px; letter-spacing: .05em; }
+.cityhero .punch { color: var(--dim); font-size: .92rem; margin-top: 2px; }
+.cityhero .acts { margin-left: auto; display: flex; gap: 8px; padding-bottom: 4px; flex-wrap: wrap; }
+.kbtn { display: inline-flex; align-items: center; gap: 7px; border: 1px solid var(--line); background: var(--card); border-radius: 9px; padding: 8px 15px; font-weight: 700; font-size: .88rem; color: var(--ink); }
+.kbtn:hover { border-color: #c9cdd3; }
+.kbtn.solid { background: var(--accent); border-color: var(--accent); color: #fff; }
+.kbtn.solid:hover { background: var(--accent-deep); }
+.kbtn svg { stroke: currentColor; }
+.followers { display: flex; align-items: center; gap: 8px; padding: 0 18px 14px; }
+.facepile { display: flex; }
+.facepile .ava.xs + .ava.xs { margin-left: -8px; }
+.followers .note { font-size: .82rem; color: var(--dim); }
+.followers .note b { color: var(--ink); }
+.statband { display: flex; border-top: 1px solid var(--line); background: #fafbfc; }
+.statband > div { flex: 1; padding: 12px 18px; }
+.statband > div + div { border-left: 1px solid var(--line); }
+.statband .v { font-family: var(--mono); font-weight: 600; font-size: 1.15rem; }
+.statband .v small { font-size: .68em; color: var(--dim); margin-left: 2px; }
+.statband .k { font-size: .7rem; color: var(--dim); text-transform: uppercase; letter-spacing: .08em; margin-top: 1px; }
+
+/* ---------- Tabs ---------- */
+.tabs { display: flex; gap: 2px; background: var(--card); border: 1px solid var(--line); border-radius: 12px; padding: 4px; overflow-x: auto; }
+.tabs a { flex: 1; text-align: center; font-weight: 700; font-size: .88rem; color: var(--dim); border-radius: 9px; padding: 8px 12px; white-space: nowrap; }
+.tabs a.on { background: #f2f3f5; color: var(--ink); }
+.tabs a:hover:not(.on) { color: var(--ink); }
+
+/* ---------- Aktivitätskarten ---------- */
+.activity { background: var(--card); border: 1px solid var(--line); border-radius: 14px; overflow: hidden; }
+.act-head { display: flex; gap: 12px; padding: 14px 18px 10px; align-items: center; }
+.act-head .who { line-height: 1.3; min-width: 0; }
+.act-head .who b { font-weight: 700; }
+.act-head .who .sub { color: var(--dim); font-size: .82rem; }
+.act-head .badge { margin-left: auto; font-family: var(--mono); font-size: .68rem; text-transform: uppercase; letter-spacing: .1em; color: var(--dim); border: 1px solid var(--line); border-radius: 6px; padding: 3px 8px; white-space: nowrap; }
+.act-title { padding: 0 18px 12px; }
+.act-title h3 { font-size: 1.12rem; font-weight: 800; letter-spacing: -.015em; }
+.act-title .where { color: var(--dim); font-size: .86rem; margin-top: 2px; }
+.actmap { display: block; width: 100%; height: auto; }
+.statrow { display: flex; border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); background: #fafbfc; }
+.statrow > div { flex: 1; padding: 11px 18px; }
+.statrow > div + div { border-left: 1px solid var(--line); }
+.statrow .v { font-family: var(--mono); font-weight: 600; font-size: 1.1rem; }
+.statrow .v small { font-size: .68em; color: var(--dim); margin-left: 2px; }
+.statrow .k { font-size: .7rem; color: var(--dim); text-transform: uppercase; letter-spacing: .08em; }
+.kudosbar { display: flex; align-items: center; gap: 10px; padding: 11px 18px; flex-wrap: wrap; }
+.kudosbar .note { color: var(--dim); font-size: .84rem; }
+.kudosbar .note b { color: var(--ink); }
+.kudosbar .spacer { flex: 1; }
+.kbtn.rung { border-color: var(--accent); color: var(--accent); background: #fff4ee; }
+.kbtn.sm { padding: 7px 13px; font-size: .85rem; }
+
+.photoband { display: grid; grid-template-columns: 2fr 1fr; gap: 4px; }
+.photoband .ph { position: relative; min-height: 150px; }
+.photoband .ph::after { content: ""; position: absolute; inset: 0; background-image: radial-gradient(rgba(22,24,28,.35) 1px, transparent 1.4px); background-size: 4px 4px; opacity: .45; }
+.photoband .col2 { display: grid; grid-template-rows: 1fr 1fr; gap: 4px; }
+.ph.p1 { background: linear-gradient(140deg, #b9cdd8, #54707f); }
+.ph.p2 { background: linear-gradient(150deg, #d8cba8, #97804c); }
+.ph.more { display: grid; place-items: center; background: #20242a; color: #fff; font-weight: 800; font-size: 1.2rem; }
+.ph.more::after { display: none; }
+
+.ridecard { border: 1px solid var(--line); border-radius: 12px; margin: 0 18px 16px; overflow: hidden; }
+.ridecard .row { display: flex; gap: 14px; padding: 13px 16px; align-items: center; }
+.datebadge { flex: none; width: 56px; border: 2px solid var(--ink); border-radius: 11px; text-align: center; overflow: hidden; }
+.datebadge .m { background: var(--ink); color: #fff; font-size: .62rem; font-weight: 800; letter-spacing: .12em; padding: 2.5px 0; text-transform: uppercase; }
+.datebadge .d { font-size: 1.35rem; font-weight: 800; padding: 3px 0 4px; }
+.ridecard h4 { font-size: 1.02rem; font-weight: 800; }
+.ridecard .sub { color: var(--dim); font-size: .84rem; }
+.ridecard .joinbar { display: flex; gap: 8px; padding: 11px 16px; border-top: 1px solid var(--line); background: #fafbfc; align-items: center; flex-wrap: wrap; }
+.ridecard .joinbar .counts { font-size: .82rem; color: var(--dim); margin-right: auto; }
+.ridecard .joinbar .counts b { color: var(--ink); }
+
+.bignum-line { display: flex; align-items: center; gap: 14px; padding: 2px 18px 14px; flex-wrap: wrap; }
+.bignum { font-family: var(--mono); font-weight: 600; font-size: 2rem; background: #16181c; color: #fff; border-radius: 10px; padding: 2px 14px; }
+.bignum-line .expl { font-size: .9rem; color: #3c4048; flex: 1; min-width: 200px; }
+.bignum-line .expl b { font-weight: 700; }
+
+/* ---------- Rechte Spalte ---------- */
+.rail { display: flex; flex-direction: column; gap: 18px; position: sticky; top: 76px; }
+.box { background: var(--card); border: 1px solid var(--line); border-radius: 14px; padding: 16px 18px; }
+.box h4 { font-size: .95rem; font-weight: 800; display: flex; align-items: baseline; margin-bottom: 12px; }
+.box h4 small { margin-left: auto; font-weight: 600; color: var(--dim); font-size: .76rem; }
+.chart { width: 100%; height: auto; display: block; }
+.chart-note { font-size: .74rem; color: var(--dim); margin-top: 8px; }
+.meetlist { display: flex; flex-direction: column; }
+.meetlist a { display: flex; gap: 10px; align-items: center; padding: 7px 8px; border-radius: 8px; font-size: .9rem; font-weight: 600; }
+.meetlist a:hover { background: #f6f7f8; }
+.meetlist svg { flex: none; stroke: var(--accent); }
+.meetlist .cur { margin-left: auto; font-size: .68rem; font-weight: 700; color: var(--green); background: #e8f3ed; border-radius: 99px; padding: 2px 8px; }
+.meet-note { font-size: .76rem; color: var(--dim); margin-top: 8px; }
+.soclinks { display: flex; gap: 6px; flex-wrap: wrap; }
+.soclinks a {
+  display: inline-flex; align-items: center; gap: 7px;
+  border: 1px solid var(--line); border-radius: 9px;
+  padding: 7px 12px; font-size: .84rem; font-weight: 600;
+}
+.soclinks a:hover { border-color: #c9cdd3; }
+.soclinks .ic { width: 16px; height: 16px; border-radius: 4px; display: grid; place-items: center; color: #fff; font-size: .58rem; font-weight: 800; font-style: normal; }
+.nearby { display: flex; flex-direction: column; }
+.nearby a { display: flex; gap: 10px; align-items: baseline; padding: 7px 8px; border-radius: 8px; font-size: .9rem; }
+.nearby a:hover { background: #f6f7f8; }
+.nearby b { font-weight: 700; }
+.nearby .x { margin-left: auto; color: var(--dim); font-size: .78rem; }
+.fine { font-size: .75rem; color: var(--dim); line-height: 1.6; padding: 0 6px; }
+.fine a { text-decoration: underline; text-decoration-color: #d4d7db; }
+
+/* ---------- Mobil ---------- */
+.tabbar { display: none; }
+.proto-back { position: fixed; bottom: 14px; right: 14px; z-index: 60; font-size: .75rem; font-weight: 700; background: var(--card); border: 1px solid var(--line); border-radius: 99px; padding: 6px 12px; color: var(--dim); }
+@media (max-width: 1000px) {
+  .shell { grid-template-columns: minmax(0, 1fr); }
+  .rail { position: static; }
+  .top nav, .search { display: none; }
+  .statband { flex-wrap: wrap; }
+  .statband > div { flex: 1 1 40%; border-top: 1px solid var(--line); margin-top: -1px; }
+  .cityhero .acts { margin-left: 0; }
+  .tabbar {
+    display: flex; position: fixed; bottom: 0; left: 0; right: 0; z-index: 55;
+    background: rgba(255,255,255,.96); backdrop-filter: blur(10px);
+    border-top: 1px solid var(--line);
+    padding: 6px 8px calc(6px + env(safe-area-inset-bottom));
+  }
+  .tabbar a { flex: 1; display: flex; flex-direction: column; align-items: center; gap: 2px; font-size: .62rem; font-weight: 700; color: var(--dim); padding: 4px 0; }
+  .tabbar a svg { stroke: currentColor; }
+  .tabbar a.on { color: var(--accent); }
+  .proto-back { bottom: 76px; }
+}
+</style>
+</head>
+<body>
+
+<header class="top">
+  <div class="top-inner">
+    <a class="brand" href="06-feed-aktiv.html">
+      <span class="mark">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.4"><circle cx="6" cy="17" r="3.2"/><circle cx="18" cy="17" r="3.2"/><path d="M6 17 9.5 9H8m1.5 0h5L18 17M12 17l-1.5-6"/></svg>
+      </span>
+      criticalmass.in
+    </a>
+    <nav>
+      <a href="06-feed-aktiv.html">Timeline</a>
+      <a href="06e-karte.html">Karte</a>
+      <a href="06c-kalender.html">Kalender</a>
+      <a class="on" href="#">Städte</a>
+      <a href="06f-forum.html">Forum</a>
+    </nav>
+    <span class="grow"></span>
+    <a class="search" href="06j-suche.html">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="m20 20-4-4"/></svg>
+      Stadt oder Tour suchen
+    </a>
+    <a class="upload-btn" href="06h-hochladen.html">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.2"><path d="M12 16V5m0 0 -4 4m4-4 4 4M5 19h14"/></svg>
+      Hochladen
+    </a>
+    <a class="ava mh" href="06d-profil.html">MH</a>
+  </div>
+</header>
+
+<div class="shell">
+
+  <p class="crumbs">
+    <a href="06-feed-aktiv.html">Timeline</a> ›
+    <a href="06l-verzeichnis.html">Städte</a> ›
+    <b>Hamburg</b>
+  </p>
+
+  <!-- Hauptspalte -->
+  <main class="maincol">
+
+    <section class="cityhero">
+      <div class="cover">
+        <svg viewBox="0 0 760 86" preserveAspectRatio="xMidYMid slice" aria-hidden="true">
+          <path d="M-10,70 L120,62 L210,38 L330,52 L430,22 L560,40 L660,16 L780,30"
+            fill="none" stroke="rgba(244,88,28,.5)" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="1 8"/>
+          <path d="M-10,78 L140,70 L240,48 L360,60 L470,32 L600,48 L780,22"
+            fill="none" stroke="rgba(22,24,28,.18)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </div>
+      <div class="head">
+        <span class="citymark">HH</span>
+        <div class="t">
+          <h1>Critical Mass Hamburg <span class="cc">DE · HAMBURG</span></h1>
+          <p class="punch">Breiter, länger, weiter — Hamburgs Radfahrende geizen nicht mit Superlativen.</p>
+        </div>
+        <span class="acts">
+          <button class="kbtn solid">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.2"><path d="M12 5v14M5 12h14"/></svg>
+            Folgen
+          </button>
+          <a class="kbtn" href="06a-tour.html">Nächste Tour →</a>
+        </span>
+      </div>
+      <div class="followers">
+        <span class="facepile">
+          <span class="ava xs kk">K</span><span class="ava xs bb">b</span><span class="ava xs an">A</span><span class="ava xs vh">V</span><span class="ava xs lk">L</span>
+        </span>
+        <span class="note"><b>1.024 folgen</b> dieser Stadt · du kennst Katrin und birnenblau</span>
+      </div>
+      <div class="statband">
+        <div><div class="v">Fr 26.06.</div><div class="k">Nächste Masse · 19:00</div></div>
+        <div><div class="v">~ 2.400</div><div class="k">Räder zuletzt</div></div>
+        <div><div class="v">178</div><div class="k">Massen seit 2011</div></div>
+        <div><div class="v">19,4<small>km</small></div><div class="k">Ø Strecke</div></div>
+      </div>
+    </section>
+
+    <nav class="tabs">
+      <a class="on" href="#">Feed</a>
+      <a href="06a-tour.html">Touren</a>
+      <a href="06i-statistik.html">Statistik</a>
+      <a href="#">Infos</a>
+    </nav>
+
+    <!-- Junitour -->
+    <article class="activity">
+      <div class="act-head">
+        <span class="ava l hh">HH</span>
+        <div class="who">
+          <b>Critical Mass Hamburg</b>
+          <div class="sub">vor 2 Wochen · Tour angelegt</div>
+        </div>
+        <span class="badge">Tour</span>
+      </div>
+      <div class="ridecard">
+        <a class="row" href="06a-tour.html">
+          <span class="datebadge"><span class="m">Juni</span><span class="d">26</span></span>
+          <span>
+            <h4>Die Junitour steht</h4>
+            <p class="sub">Freitag · 19:00 · Alstervorland, Höhe Milchstraße</p>
+          </span>
+        </a>
+        <div class="joinbar">
+          <span class="counts"><b>132</b> dabei · <b>41</b> vielleicht</span>
+          <button class="kbtn sm solid">Dabei!</button>
+          <a class="kbtn sm" href="06a-tour.html">Zur Tour</a>
+        </div>
+      </div>
+    </article>
+
+    <!-- Track zur Maimasse -->
+    <article class="activity">
+      <div class="act-head">
+        <span class="ava l vh">VH</span>
+        <div class="who">
+          <b>velohanseat</b>
+          <div class="sub">vor 2 Wochen · GPX-Upload · Maimasse</div>
+        </div>
+        <span class="badge">Track</span>
+      </div>
+      <div class="act-title">
+        <h3>Maimasse — einmal um die Alster und durch die Schanze</h3>
+        <div class="where">Tour vom 29.05.2026 · Start Alstervorland</div>
+      </div>
+      <svg class="actmap" viewBox="0 0 760 240" aria-hidden="true">
+        <rect width="760" height="240" fill="#e9ecef"/>
+        <g stroke="#d9dde2" stroke-width="1.5">
+          <line x1="100" y1="0" x2="100" y2="240"/><line x1="220" y1="0" x2="220" y2="240"/>
+          <line x1="350" y1="0" x2="350" y2="240"/><line x1="500" y1="0" x2="500" y2="240"/>
+          <line x1="640" y1="0" x2="640" y2="240"/>
+          <line x1="0" y1="60" x2="760" y2="60"/><line x1="0" y1="130" x2="760" y2="130"/>
+          <line x1="0" y1="195" x2="760" y2="195"/>
+        </g>
+        <path d="M470,30 C530,24 575,52 585,100 C594,142 572,186 522,198 C478,208 444,188 434,152 C424,116 430,62 470,30 Z" fill="#d4e0ea" stroke="#bccddd" stroke-width="1.5"/>
+        <path d="M455,95 L495,60 L555,75 L575,125 L545,175 L490,185 L450,150 L400,165 L330,140 L255,160 L185,135 L150,90 L210,70 L290,95 L360,75 L420,110 L455,95"
+          fill="none" stroke="#f4581c" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+        <circle cx="455" cy="95" r="7" fill="#16181c"/>
+        <text x="468" y="91" font-family="Archivo" font-size="12" font-weight="700" fill="#16181c">Start</text>
+      </svg>
+      <div class="statrow">
+        <div><div class="v">21,7<small>km</small></div><div class="k">Strecke</div></div>
+        <div><div class="v">1:58<small>h</small></div><div class="k">Fahrzeit</div></div>
+        <div><div class="v">11,0<small>km/h</small></div><div class="k">Masse-Tempo</div></div>
+      </div>
+      <div class="kudosbar">
+        <span class="facepile">
+          <span class="ava xs kk">K</span><span class="ava xs mh">M</span><span class="ava xs an">A</span>
+        </span>
+        <span class="note"><b>17× geklingelt</b></span>
+        <span class="spacer"></span>
+        <button class="kbtn sm rung">
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke-width="2.2"><path d="M12 4a5.5 5.5 0 0 0-5.5 5.5c0 4-1.6 5.4-2.5 6h16c-.9-.6-2.5-2-2.5-6A5.5 5.5 0 0 0 12 4z"/><path d="M10 19a2 2 0 0 0 4 0"/></svg>
+          Geklingelt
+        </button>
+        <button class="kbtn sm">
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M20 12a8 8 0 1 0-3.1 6.3L20 19.5l-.8-3A8 8 0 0 0 20 12z"/></svg>
+          4
+        </button>
+      </div>
+    </article>
+
+    <!-- Fotos -->
+    <article class="activity">
+      <div class="act-head">
+        <span class="ava l sj">SR</span>
+        <div class="who">
+          <b>stadtrand</b>
+          <div class="sub">vor 2 Wochen · 6 Fotos · Maimasse</div>
+        </div>
+        <span class="badge">Galerie</span>
+      </div>
+      <div class="act-title">
+        <h3><a href="06g-galerie.html">Abendlicht überm Jungfernstieg</a></h3>
+        <div class="where">Tour vom 29.05.2026</div>
+      </div>
+      <div class="photoband">
+        <a class="ph p1" href="#"></a>
+        <div class="col2">
+          <a class="ph p2" href="#"></a>
+          <a class="ph more" href="06g-galerie.html">+4</a>
+        </div>
+      </div>
+      <div class="kudosbar">
+        <span class="note"><b>23× geklingelt</b> · 5 Kommentare</span>
+        <span class="spacer"></span>
+        <button class="kbtn sm">
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke-width="2.2"><path d="M12 4a5.5 5.5 0 0 0-5.5 5.5c0 4-1.6 5.4-2.5 6h16c-.9-.6-2.5-2-2.5-6A5.5 5.5 0 0 0 12 4z"/><path d="M10 19a2 2 0 0 0 4 0"/></svg>
+          Klingeln
+        </button>
+      </div>
+    </article>
+
+    <!-- Schätzungs-Mittelwert -->
+    <article class="activity">
+      <div class="act-head">
+        <span class="ava l hh">HH</span>
+        <div class="who">
+          <b>Critical Mass Hamburg</b>
+          <div class="sub">vor 12 Tagen · Auswertung · Maimasse</div>
+        </div>
+        <span class="badge">Zählung</span>
+      </div>
+      <div class="act-title" style="padding-bottom:10px">
+        <h3>Die Maimasse ist ausgezählt</h3>
+      </div>
+      <div class="bignum-line">
+        <span class="bignum">2.400</span>
+        <span class="expl"><b>Mittelwert aus 7 Schätzungen.</b> Damit war der Mai die
+        bislang größte Masse des Jahres — die Sommertouren kommen erst noch.</span>
+      </div>
+      <div class="kudosbar" style="border-top:1px solid var(--line)">
+        <span class="note"><b>31× geklingelt</b></span>
+        <span class="spacer"></span>
+        <button class="kbtn sm">
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke-width="2.2"><path d="M12 4a5.5 5.5 0 0 0-5.5 5.5c0 4-1.6 5.4-2.5 6h16c-.9-.6-2.5-2-2.5-6A5.5 5.5 0 0 0 12 4z"/><path d="M10 19a2 2 0 0 0 4 0"/></svg>
+          Klingeln
+        </button>
+      </div>
+    </article>
+
+    <!-- Forum -->
+    <article class="activity">
+      <div class="act-head">
+        <span class="ava l lk">LK</span>
+        <div class="who">
+          <b>Lotte</b>
+          <div class="sub">vor 5 Std · Board Hamburg</div>
+        </div>
+        <span class="badge">Forum</span>
+      </div>
+      <div class="act-title" style="padding-bottom:16px">
+        <h3 style="font-size:1.05rem">„Route im Juni mal Richtung Hafen?"</h3>
+        <div class="where" style="margin-top:6px">Beim letzten Mal war auf der Kennedybrücke ordentlich was los —
+        Vorschläge für den Treffpunkt danach? · <b style="color:var(--ink)">14 Antworten</b></div>
+      </div>
+    </article>
+
+  </main>
+
+  <!-- Rechte Spalte -->
+  <aside class="rail">
+
+    <div class="box">
+      <h4>Räder pro Masse <small>Jul 25 – Jun 26</small></h4>
+      <svg class="chart" viewBox="0 0 304 150" aria-label="Teilnehmende pro Monat">
+        <g font-family="IBM Plex Mono, monospace" font-size="9" fill="#707684" text-anchor="middle">
+          <rect x="2"   y="19" width="18" height="111" rx="3" fill="#e3e5e8"/><text x="11" y="146">J</text>
+          <rect x="27"  y="10" width="18" height="120" rx="3" fill="#e3e5e8"/><text x="36" y="146">A</text>
+          <rect x="52"  y="40" width="18" height="90"  rx="3" fill="#e3e5e8"/><text x="61" y="146">S</text>
+          <rect x="77"  y="70" width="18" height="60"  rx="3" fill="#e3e5e8"/><text x="86" y="146">O</text>
+          <rect x="102" y="98" width="18" height="32"  rx="3" fill="#e3e5e8"/><text x="111" y="146">N</text>
+          <rect x="127" y="109" width="18" height="21" rx="3" fill="#e3e5e8"/><text x="136" y="146">D</text>
+          <rect x="152" y="112" width="18" height="18" rx="3" fill="#e3e5e8"/><text x="161" y="146">J</text>
+          <rect x="177" y="105" width="18" height="25" rx="3" fill="#e3e5e8"/><text x="186" y="146">F</text>
+          <rect x="202" y="93"  width="18" height="37" rx="3" fill="#e3e5e8"/><text x="211" y="146">M</text>
+          <rect x="227" y="82"  width="18" height="48" rx="3" fill="#e3e5e8"/><text x="236" y="146">A</text>
+          <rect x="252" y="75"  width="18" height="55" rx="3" fill="#f4581c"/><text x="261" y="146">M</text>
+          <rect x="277" y="75"  width="18" height="55" rx="3" fill="none" stroke="#c9cdd3" stroke-dasharray="3 3"/><text x="286" y="146">J</text>
+        </g>
+        <text x="261" y="68" font-family="IBM Plex Mono, monospace" font-size="9.5" font-weight="600" fill="#f4581c" text-anchor="middle">2.400</text>
+        <text x="36" y="4" font-family="IBM Plex Mono, monospace" font-size="9.5" fill="#707684" text-anchor="middle" dominant-baseline="hanging">5.200</text>
+      </svg>
+      <p class="chart-note">Mittelwerte der Community-Schätzungen · Juni noch offen</p>
+    </div>
+
+    <div class="box">
+      <h4>Treffpunkte <small>rotierend</small></h4>
+      <div class="meetlist">
+        <a href="06a-tour.html">
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke-width="2.2"><path d="M12 21s7-6 7-11a7 7 0 0 0-14 0c0 5 7 11 7 11z"/><circle cx="12" cy="9.8" r="2.4"/></svg>
+          Alstervorland <span class="cur">Juni</span>
+        </a>
+        <a href="#">
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke-width="2.2"><path d="M12 21s7-6 7-11a7 7 0 0 0-14 0c0 5 7 11 7 11z"/><circle cx="12" cy="9.8" r="2.4"/></svg>
+          Heiligengeistfeld
+        </a>
+        <a href="#">
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke-width="2.2"><path d="M12 21s7-6 7-11a7 7 0 0 0-14 0c0 5 7 11 7 11z"/><circle cx="12" cy="9.8" r="2.4"/></svg>
+          Jungfernstieg
+        </a>
+        <a href="#">
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke-width="2.2"><path d="M12 21s7-6 7-11a7 7 0 0 0-14 0c0 5 7 11 7 11z"/><circle cx="12" cy="9.8" r="2.4"/></svg>
+          Fischmarkt
+        </a>
+        <a href="#">
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke-width="2.2"><path d="M12 21s7-6 7-11a7 7 0 0 0-14 0c0 5 7 11 7 11z"/><circle cx="12" cy="9.8" r="2.4"/></svg>
+          Magellan-Terrassen
+        </a>
+      </div>
+      <p class="meet-note">Der aktuelle Treffpunkt steht immer an der Tour — im Zweifel: Alstervorland.</p>
+    </div>
+
+    <div class="box">
+      <h4>Im Netz</h4>
+      <div class="soclinks">
+        <a href="#"><i class="ic" style="background:#16181c">X</i>@cmhamburg</a>
+        <a href="#"><i class="ic" style="background:#3b5998">f</i>Facebook</a>
+        <a href="#"><i class="ic" style="background:#c13584">IG</i>Instagram</a>
+        <a href="#"><i class="ic" style="background:#1e7d4f">W</i>Homepage</a>
+      </div>
+    </div>
+
+    <div class="box">
+      <h4>In der Nähe</h4>
+      <div class="nearby">
+        <a href="#"><b>Norderstedt</b><span class="x">zuletzt 12 Räder</span></a>
+        <a href="#"><b>Pinneberg</b><span class="x">Sa 13.06. · 20:45</span></a>
+        <a href="#"><b>Lüneburg</b><span class="x">Fr 26.06. · 18:00</span></a>
+      </div>
+    </div>
+
+    <p class="fine">
+      Diese Stadtseite pflegt die Community — <a href="#">mitmachen</a>.<br>
+      Karten © OpenStreetMap-Mitwirkende · Open Source
+    </p>
+  </aside>
+
+</div>
+
+<!-- Mobile Tabbar -->
+<nav class="tabbar">
+  <a href="06-feed-aktiv.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M3 11.2 12 4l9 7.2M5.5 9.8V20h13V9.8"/></svg>
+    Timeline
+  </a>
+  <a href="06e-karte.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M12 21s7-6 7-11a7 7 0 0 0-14 0c0 5 7 11 7 11z"/><circle cx="12" cy="9.8" r="2.4"/></svg>
+    Karte
+  </a>
+  <a href="06h-hochladen.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M12 16V5m0 0-4 4m4-4 4 4M5 19h14"/></svg>
+    Hochladen
+  </a>
+  <a href="06c-kalender.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><rect x="3.5" y="5" width="17" height="15.5" rx="2.5"/><path d="M3.5 9.5h17M8 3v4M16 3v4"/></svg>
+    Kalender
+  </a>
+  <a class="on" href="#">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M12 21s7-6 7-11a7 7 0 0 0-14 0c0 5 7 11 7 11z"/><circle cx="12" cy="9.8" r="2.4"/></svg>
+    Städte
+  </a>
+</nav>
+
+<a class="proto-back" href="index.html">← Übersicht</a>
+
+</body>
+</html>

--- a/design-prototypes/06c-kalender.html
+++ b/design-prototypes/06c-kalender.html
@@ -1,0 +1,409 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Kalender · Juni 2026 — Prototyp 6 · criticalmass.in</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@500;600&display=swap" rel="stylesheet">
+<style>
+:root {
+  --bg: #f2f3f5;
+  --card: #ffffff;
+  --line: #e3e5e8;
+  --ink: #16181c;
+  --dim: #707684;
+  --accent: #f4581c;
+  --accent-deep: #d8450e;
+  --green: #1e7d4f;
+  --sans: "Archivo", "Helvetica Neue", Arial, sans-serif;
+  --mono: "IBM Plex Mono", Menlo, monospace;
+}
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html, body { overflow-x: clip; }
+body {
+  font-family: var(--sans);
+  background: var(--bg);
+  color: var(--ink);
+  line-height: 1.5;
+  font-size: 15px;
+  padding-bottom: 70px;
+}
+a { color: inherit; text-decoration: none; }
+button { font-family: inherit; cursor: pointer; }
+
+/* ---------- Topbar ---------- */
+.top { position: sticky; top: 0; z-index: 50; background: var(--card); border-bottom: 1px solid var(--line); }
+.top-inner { max-width: 1080px; margin: 0 auto; display: flex; align-items: center; gap: 22px; padding: 0 16px; height: 56px; }
+.brand { display: flex; align-items: center; gap: 9px; font-weight: 800; font-size: 1.05rem; letter-spacing: -.01em; }
+.brand .mark { width: 28px; height: 28px; border-radius: 8px; background: var(--accent); display: grid; place-items: center; }
+.top nav { display: flex; gap: 4px; }
+.top nav a { font-weight: 600; font-size: .92rem; color: var(--dim); padding: 6px 12px; border-radius: 8px; }
+.top nav a:hover { background: #f2f3f5; color: var(--ink); }
+.top nav a.on { color: var(--ink); background: #f2f3f5; font-weight: 700; }
+.top .grow { flex: 1; }
+.search { display: flex; align-items: center; gap: 8px; background: #f2f3f5; border-radius: 9px; padding: 7px 12px; color: var(--dim); font-size: .88rem; min-width: 180px; }
+.upload-btn { display: inline-flex; align-items: center; gap: 8px; background: var(--accent); color: #fff; border: 0; border-radius: 9px; font-weight: 700; font-size: .9rem; padding: 8px 14px; }
+.upload-btn:hover { background: var(--accent-deep); }
+.ava { width: 34px; height: 34px; border-radius: 99px; flex: none; display: grid; place-items: center; font-weight: 800; font-size: .78rem; color: #fff; }
+.ava.mh { background: #3d4350; }
+
+/* ---------- Layout ---------- */
+.shell { max-width: 1080px; margin: 0 auto; padding: 22px 16px 40px; }
+.calhead { display: flex; align-items: center; gap: 14px; flex-wrap: wrap; margin-bottom: 16px; }
+.calhead h1 { font-size: 1.45rem; font-weight: 800; letter-spacing: -.02em; }
+.calhead .nav { display: flex; gap: 6px; }
+.navbtn {
+  width: 36px; height: 36px;
+  border: 1px solid var(--line);
+  background: var(--card);
+  border-radius: 9px;
+  display: grid;
+  place-items: center;
+  color: var(--ink);
+}
+.navbtn:hover { border-color: #c9cdd3; }
+.calhead .legend { margin-left: auto; display: flex; gap: 14px; font-size: .8rem; color: var(--dim); flex-wrap: wrap; }
+.calhead .legend i { display: inline-block; width: 11px; height: 11px; border-radius: 4px; margin-right: 5px; vertical-align: -1px; }
+.calhead .month-stat { font-family: var(--mono); font-size: .78rem; color: var(--dim); }
+.calhead .month-stat b { color: var(--accent); font-weight: 600; }
+
+/* ---------- Monatsraster (Desktop) ---------- */
+.cal-grid {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 6px;
+}
+.dow {
+  font-size: .72rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: .1em;
+  color: var(--dim);
+  padding: 4px 8px 6px;
+}
+.dow.we { color: #a0a6b1; }
+.day {
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  min-height: 104px;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.day .nr { font-family: var(--mono); font-size: .8rem; font-weight: 600; color: var(--dim); display: flex; align-items: center; gap: 6px; }
+.day .nr .tag { font-family: var(--sans); font-size: .62rem; font-weight: 800; text-transform: uppercase; letter-spacing: .06em; border-radius: 99px; padding: 1px 7px; }
+.day.past { background: #f7f8f9; }
+.day.past .nr { color: #b4b9c2; }
+.day.empty { background: transparent; border: 0; }
+.day.today { border-color: var(--accent); border-width: 2px; padding: 7px; }
+.day.today .nr { color: var(--accent); }
+.day.today .nr .tag { background: var(--accent); color: #fff; }
+.day.big { background: #fff4ee; border-color: #f8c4ab; }
+.day.big .nr { color: var(--accent-deep); }
+.day.big .nr .tag { background: #16181c; color: #fff; }
+.chip {
+  display: flex;
+  gap: 5px;
+  align-items: baseline;
+  font-size: .76rem;
+  background: #f2f3f5;
+  border-radius: 6px;
+  padding: 3px 7px;
+  min-width: 0;
+}
+.chip:hover { background: #e8eaee; }
+.chip .t { font-family: var(--mono); font-size: .68rem; font-weight: 600; color: var(--dim); flex: none; }
+.chip b { font-weight: 700; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.chip.done { background: #e8f3ed; }
+.chip.done .t { color: var(--green); }
+.chip.hh { background: #16181c; }
+.chip.hh b, .chip.hh .t { color: #fff; }
+.more { font-size: .72rem; font-weight: 700; color: var(--accent); padding: 1px 7px; }
+.day.past .chip { opacity: .75; }
+
+/* ---------- Agenda (Mobil) ---------- */
+.cal-list { display: none; }
+
+/* ---------- Fuß ---------- */
+.fine { max-width: 1080px; margin: 18px auto 0; padding: 0 16px; font-size: .75rem; color: var(--dim); }
+.fine a { text-decoration: underline; text-decoration-color: #d4d7db; }
+
+/* ---------- Mobil ---------- */
+.tabbar { display: none; }
+.proto-back { position: fixed; bottom: 14px; right: 14px; z-index: 60; font-size: .75rem; font-weight: 700; background: var(--card); border: 1px solid var(--line); border-radius: 99px; padding: 6px 12px; color: var(--dim); }
+@media (max-width: 860px) {
+  .top nav, .search { display: none; }
+  .cal-grid { display: none; }
+  .cal-list { display: block; }
+  .cal-list .dayblock { background: var(--card); border: 1px solid var(--line); border-radius: 14px; margin-bottom: 12px; overflow: hidden; }
+  .cal-list .dayblock.today { border-color: var(--accent); border-width: 2px; }
+  .cal-list .dayblock.big { background: #fff4ee; border-color: #f8c4ab; }
+  .cal-list .dh {
+    display: flex; gap: 10px; align-items: baseline;
+    padding: 11px 16px 9px;
+    border-bottom: 1px solid var(--line);
+    font-weight: 800; font-size: .95rem;
+  }
+  .cal-list .dh .wd { font-family: var(--mono); font-size: .74rem; font-weight: 600; color: var(--dim); }
+  .cal-list .dh .tag { margin-left: auto; font-size: .64rem; font-weight: 800; text-transform: uppercase; letter-spacing: .06em; border-radius: 99px; padding: 2px 8px; background: var(--accent); color: #fff; }
+  .cal-list .dh .tag.dark { background: #16181c; }
+  .cal-list .row { display: flex; gap: 10px; align-items: baseline; padding: 9px 16px; border-bottom: 1px solid var(--line); font-size: .92rem; }
+  .cal-list .row:last-child { border-bottom: 0; }
+  .cal-list .row .t { font-family: var(--mono); font-size: .8rem; font-weight: 600; width: 48px; flex: none; color: var(--dim); }
+  .cal-list .row b { font-weight: 700; }
+  .cal-list .row .p { margin-left: auto; color: var(--dim); font-size: .78rem; text-align: right; }
+  .cal-list .row.done .t { color: var(--green); }
+  .tabbar {
+    display: flex; position: fixed; bottom: 0; left: 0; right: 0; z-index: 55;
+    background: rgba(255,255,255,.96); backdrop-filter: blur(10px);
+    border-top: 1px solid var(--line);
+    padding: 6px 8px calc(6px + env(safe-area-inset-bottom));
+  }
+  .tabbar a { flex: 1; display: flex; flex-direction: column; align-items: center; gap: 2px; font-size: .62rem; font-weight: 700; color: var(--dim); padding: 4px 0; }
+  .tabbar a svg { stroke: currentColor; }
+  .tabbar a.on { color: var(--accent); }
+  .proto-back { bottom: 76px; }
+}
+</style>
+</head>
+<body>
+
+<header class="top">
+  <div class="top-inner">
+    <a class="brand" href="06-feed-aktiv.html">
+      <span class="mark">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.4"><circle cx="6" cy="17" r="3.2"/><circle cx="18" cy="17" r="3.2"/><path d="M6 17 9.5 9H8m1.5 0h5L18 17M12 17l-1.5-6"/></svg>
+      </span>
+      criticalmass.in
+    </a>
+    <nav>
+      <a href="06-feed-aktiv.html">Timeline</a>
+      <a href="06e-karte.html">Karte</a>
+      <a class="on" href="#">Kalender</a>
+      <a href="06l-verzeichnis.html">Städte</a>
+      <a href="06f-forum.html">Forum</a>
+    </nav>
+    <span class="grow"></span>
+    <a class="search" href="06j-suche.html">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="m20 20-4-4"/></svg>
+      Stadt oder Tour suchen
+    </a>
+    <a class="upload-btn" href="06h-hochladen.html">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.2"><path d="M12 16V5m0 0 -4 4m4-4 4 4M5 19h14"/></svg>
+      Hochladen
+    </a>
+    <a class="ava mh" href="06d-profil.html">MH</a>
+  </div>
+</header>
+
+<div class="shell">
+
+  <div class="calhead">
+    <span class="nav">
+      <button class="navbtn" aria-label="Mai 2026">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="m14.5 5-7 7 7 7"/></svg>
+      </button>
+      <button class="navbtn" aria-label="Juli 2026">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="m9.5 5 7 7-7 7"/></svg>
+      </button>
+    </span>
+    <h1>Juni 2026</h1>
+    <span class="month-stat"><b>58 Touren</b> weltweit · davon 43 am großen Freitag</span>
+    <span class="legend">
+      <span><i style="background:#fff4ee;border:1px solid #f8c4ab"></i>letzter Freitag</span>
+      <span><i style="background:#e8f3ed"></i>gefahren</span>
+      <span><i style="border:2px solid var(--accent)"></i>heute</span>
+    </span>
+  </div>
+
+  <!-- Desktop: Monatsraster -->
+  <div class="cal-grid">
+    <div class="dow">Mo</div><div class="dow">Di</div><div class="dow">Mi</div><div class="dow">Do</div><div class="dow">Fr</div><div class="dow we">Sa</div><div class="dow we">So</div>
+
+    <div class="day past"><span class="nr">1</span></div>
+    <div class="day past"><span class="nr">2</span></div>
+    <div class="day past"><span class="nr">3</span></div>
+    <div class="day past"><span class="nr">4</span></div>
+    <div class="day past">
+      <span class="nr">5</span>
+      <a class="chip done" href="#"><span class="t">✓</span><b>Norderstedt</b></a>
+      <span class="more" style="color:var(--green)">12 Räder gezählt</span>
+    </div>
+    <div class="day past"><span class="nr">6</span></div>
+    <div class="day past"><span class="nr">7</span></div>
+
+    <div class="day past"><span class="nr">8</span></div>
+    <div class="day past"><span class="nr">9</span></div>
+    <div class="day past"><span class="nr">10</span></div>
+    <div class="day past"><span class="nr">11</span></div>
+    <div class="day today">
+      <span class="nr">12 <span class="tag">Heute</span></span>
+      <a class="chip" href="#"><span class="t">17:00</span><b>Falkensee</b></a>
+      <a class="chip" href="#"><span class="t">19:00</span><b>Düsseldorf</b></a>
+      <a class="chip" href="#"><span class="t">19:00</span><b>Frankfurt</b></a>
+      <a class="more" href="#">+6 weitere</a>
+    </div>
+    <div class="day">
+      <span class="nr">13</span>
+      <a class="chip" href="#"><span class="t">20:45</span><b>Pinneberg</b></a>
+    </div>
+    <div class="day"><span class="nr">14</span></div>
+
+    <div class="day">
+      <span class="nr">15</span>
+      <a class="chip" href="#"><span class="t">18:00</span><b>Coburg</b></a>
+      <a class="chip" href="#"><span class="t">19:00</span><b>Gelsenkirchen</b></a>
+    </div>
+    <div class="day">
+      <span class="nr">16</span>
+      <a class="chip" href="#"><span class="t">21:00</span><b>Lisboa</b></a>
+    </div>
+    <div class="day"><span class="nr">17</span></div>
+    <div class="day"><span class="nr">18</span></div>
+    <div class="day">
+      <span class="nr">19</span>
+      <a class="chip" href="#"><span class="t">17:00</span><b>Wien</b></a>
+      <a class="chip" href="#"><span class="t">18:30</span><b>Los Angeles</b></a>
+      <a class="chip" href="#"><span class="t">20:00</span><b>Hannover</b></a>
+      <a class="more" href="#">+3 weitere</a>
+    </div>
+    <div class="day">
+      <span class="nr">20</span>
+      <a class="chip" href="#"><span class="t">10:00</span><b>Stirling</b></a>
+      <a class="chip" href="#"><span class="t">11:00</span><b>Herrenberg</b></a>
+      <a class="chip" href="#"><span class="t">11:00</span><b>Kaiserslautern</b></a>
+    </div>
+    <div class="day">
+      <span class="nr">21</span>
+      <a class="chip" href="#"><span class="t">09:00</span><b>Stuttgart</b></a>
+      <a class="chip" href="#"><span class="t">13:00</span><b>Köln</b></a>
+    </div>
+
+    <div class="day"><span class="nr">22</span></div>
+    <div class="day"><span class="nr">23</span></div>
+    <div class="day">
+      <span class="nr">24</span>
+      <a class="chip" href="#"><span class="t">17:30</span><b>Bruchsal</b></a>
+    </div>
+    <div class="day">
+      <span class="nr">25</span>
+      <a class="chip" href="#"><span class="t">18:00</span><b>Dessau</b></a>
+      <a class="chip" href="#"><span class="t">19:00</span><b>Boise</b></a>
+    </div>
+    <div class="day big">
+      <span class="nr">26 <span class="tag">Großer Freitag</span></span>
+      <a class="chip hh" href="06a-tour.html"><span class="t">19:00</span><b>Hamburg</b></a>
+      <a class="chip" href="#"><span class="t">18:00</span><b>Lüneburg</b></a>
+      <a class="chip" href="#"><span class="t">20:00</span><b>Berlin</b></a>
+      <a class="more" href="#">+40 weltweit</a>
+    </div>
+    <div class="day"><span class="nr">27</span></div>
+    <div class="day"><span class="nr">28</span></div>
+
+    <div class="day"><span class="nr">29</span></div>
+    <div class="day"><span class="nr">30</span></div>
+    <div class="day empty"></div><div class="day empty"></div><div class="day empty"></div><div class="day empty"></div><div class="day empty"></div>
+  </div>
+
+  <!-- Mobil: Agenda -->
+  <div class="cal-list">
+    <div class="dayblock today">
+      <div class="dh"><span class="wd">FR</span>12. Juni<span class="tag">Heute</span></div>
+      <a class="row" href="#"><span class="t">17:00</span><b>Falkensee</b><span class="p">Bahnhofsvorplatz</span></a>
+      <a class="row" href="#"><span class="t">18:00</span><b>Düren</b><span class="p">Karte</span></a>
+      <a class="row" href="#"><span class="t">18:00</span><b>Pittsburgh</b><span class="p">Dippy</span></a>
+      <a class="row" href="#"><span class="t">19:00</span><b>Düsseldorf</b><span class="p">Fürstenplatz</span></a>
+      <a class="row" href="#"><span class="t">19:00</span><b>Frankfurt</b><span class="p">Opernplatz</span></a>
+      <a class="row" href="#"><span class="t">19:00</span><b>Treptow-Köpenick</b><span class="p">Karte</span></a>
+    </div>
+    <div class="dayblock">
+      <div class="dh"><span class="wd">SA</span>13. Juni</div>
+      <a class="row" href="#"><span class="t">20:45</span><b>Pinneberg</b><span class="p">Karte</span></a>
+    </div>
+    <div class="dayblock">
+      <div class="dh"><span class="wd">MO</span>15. Juni</div>
+      <a class="row" href="#"><span class="t">18:00</span><b>Coburg</b><span class="p">Karte</span></a>
+      <a class="row" href="#"><span class="t">19:00</span><b>Gelsenkirchen</b><span class="p">Karte</span></a>
+    </div>
+    <div class="dayblock">
+      <div class="dh"><span class="wd">DI</span>16. Juni</div>
+      <a class="row" href="#"><span class="t">21:00</span><b>Lisboa</b><span class="p">Marquês de Pombal</span></a>
+    </div>
+    <div class="dayblock">
+      <div class="dh"><span class="wd">FR</span>19. Juni</div>
+      <a class="row" href="#"><span class="t">17:00</span><b>Wien</b><span class="p">Schwarzenbergplatz</span></a>
+      <a class="row" href="#"><span class="t">18:00</span><b>Fürth</b><span class="p">Karte</span></a>
+      <a class="row" href="#"><span class="t">18:30</span><b>Los Angeles</b><span class="p">Karte</span></a>
+      <a class="row" href="#"><span class="t">18:30</span><b>Wiesbaden</b><span class="p">Karte</span></a>
+      <a class="row" href="#"><span class="t">18:45</span><b>Mannheim</b><span class="p">Karte</span></a>
+      <a class="row" href="#"><span class="t">20:00</span><b>Hannover</b><span class="p">Karte</span></a>
+    </div>
+    <div class="dayblock">
+      <div class="dh"><span class="wd">SA</span>20. Juni</div>
+      <a class="row" href="#"><span class="t">10:00</span><b>Stirling</b><span class="p">The Thistles</span></a>
+      <a class="row" href="#"><span class="t">11:00</span><b>Herrenberg</b><span class="p">Karte</span></a>
+      <a class="row" href="#"><span class="t">11:00</span><b>Kaiserslautern</b><span class="p">Karte</span></a>
+    </div>
+    <div class="dayblock">
+      <div class="dh"><span class="wd">SO</span>21. Juni</div>
+      <a class="row" href="#"><span class="t">09:00</span><b>Stuttgart</b><span class="p">Karte</span></a>
+      <a class="row" href="#"><span class="t">13:00</span><b>Köln</b><span class="p">Karte</span></a>
+    </div>
+    <div class="dayblock">
+      <div class="dh"><span class="wd">MI</span>24. Juni</div>
+      <a class="row" href="#"><span class="t">17:30</span><b>Bruchsal</b><span class="p">Karte</span></a>
+    </div>
+    <div class="dayblock">
+      <div class="dh"><span class="wd">DO</span>25. Juni</div>
+      <a class="row" href="#"><span class="t">18:00</span><b>Dessau</b><span class="p">Karte</span></a>
+      <a class="row" href="#"><span class="t">19:00</span><b>Boise</b><span class="p">Karte</span></a>
+    </div>
+    <div class="dayblock big">
+      <div class="dh"><span class="wd">FR</span>26. Juni<span class="tag dark">Großer Freitag · 43 Touren</span></div>
+      <a class="row" href="06a-tour.html"><span class="t">19:00</span><b>Hamburg</b><span class="p">Alstervorland</span></a>
+      <a class="row" href="#"><span class="t">18:00</span><b>Lüneburg</b><span class="p">Am Sande</span></a>
+      <a class="row" href="#"><span class="t">18:00</span><b>Bonn</b><span class="p">Karte</span></a>
+      <a class="row" href="#"><span class="t">18:50</span><b>Dresden</b><span class="p">Karte</span></a>
+      <a class="row" href="#"><span class="t">19:00</span><b>München</b><span class="p">Karte</span></a>
+      <a class="row" href="#"><span class="t">20:00</span><b>Berlin</b><span class="p">Mariannenplatz</span></a>
+      <a class="row" href="#"><span class="t">+37</span><b>weitere weltweit</b><span class="p">→</span></a>
+    </div>
+  </div>
+
+</div>
+
+<p class="fine">Alle Zeiten Ortszeit · Touren ohne Uhrzeit stehen erst kurz vorher fest ·
+<a href="06n-tour-anlegen.html">Tour eintragen</a> — drei Felder genügen.</p>
+
+<!-- Mobile Tabbar -->
+<nav class="tabbar">
+  <a href="06-feed-aktiv.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M3 11.2 12 4l9 7.2M5.5 9.8V20h13V9.8"/></svg>
+    Timeline
+  </a>
+  <a href="06e-karte.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M12 21s7-6 7-11a7 7 0 0 0-14 0c0 5 7 11 7 11z"/><circle cx="12" cy="9.8" r="2.4"/></svg>
+    Karte
+  </a>
+  <a href="06h-hochladen.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M12 16V5m0 0-4 4m4-4 4 4M5 19h14"/></svg>
+    Hochladen
+  </a>
+  <a class="on" href="#">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><rect x="3.5" y="5" width="17" height="15.5" rx="2.5"/><path d="M3.5 9.5h17M8 3v4M16 3v4"/></svg>
+    Kalender
+  </a>
+  <a href="06d-profil.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><circle cx="12" cy="8.4" r="3.4"/><path d="M5 20c.8-3.4 3.6-5.2 7-5.2s6.2 1.8 7 5.2"/></svg>
+    Profil
+  </a>
+</nav>
+
+<a class="proto-back" href="index.html">← Übersicht</a>
+
+</body>
+</html>

--- a/design-prototypes/06d-profil.html
+++ b/design-prototypes/06d-profil.html
@@ -1,0 +1,446 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>malte · Profil — Prototyp 6 · criticalmass.in</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@500;600&display=swap" rel="stylesheet">
+<style>
+:root {
+  --bg: #f2f3f5;
+  --card: #ffffff;
+  --line: #e3e5e8;
+  --ink: #16181c;
+  --dim: #707684;
+  --accent: #f4581c;
+  --accent-deep: #d8450e;
+  --green: #1e7d4f;
+  --sans: "Archivo", "Helvetica Neue", Arial, sans-serif;
+  --mono: "IBM Plex Mono", Menlo, monospace;
+}
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html, body { overflow-x: clip; }
+body {
+  font-family: var(--sans);
+  background: var(--bg);
+  color: var(--ink);
+  line-height: 1.5;
+  font-size: 15px;
+  padding-bottom: 70px;
+}
+a { color: inherit; text-decoration: none; }
+button { font-family: inherit; cursor: pointer; }
+
+/* ---------- Topbar ---------- */
+.top { position: sticky; top: 0; z-index: 50; background: var(--card); border-bottom: 1px solid var(--line); }
+.top-inner { max-width: 1080px; margin: 0 auto; display: flex; align-items: center; gap: 22px; padding: 0 16px; height: 56px; }
+.brand { display: flex; align-items: center; gap: 9px; font-weight: 800; font-size: 1.05rem; letter-spacing: -.01em; }
+.brand .mark { width: 28px; height: 28px; border-radius: 8px; background: var(--accent); display: grid; place-items: center; }
+.top nav { display: flex; gap: 4px; }
+.top nav a { font-weight: 600; font-size: .92rem; color: var(--dim); padding: 6px 12px; border-radius: 8px; }
+.top nav a:hover { background: #f2f3f5; color: var(--ink); }
+.top .grow { flex: 1; }
+.search { display: flex; align-items: center; gap: 8px; background: #f2f3f5; border-radius: 9px; padding: 7px 12px; color: var(--dim); font-size: .88rem; min-width: 180px; }
+.upload-btn { display: inline-flex; align-items: center; gap: 8px; background: var(--accent); color: #fff; border: 0; border-radius: 9px; font-weight: 700; font-size: .9rem; padding: 8px 14px; }
+.upload-btn:hover { background: var(--accent-deep); }
+.ava { width: 34px; height: 34px; border-radius: 99px; flex: none; display: grid; place-items: center; font-weight: 800; font-size: .78rem; color: #fff; }
+.ava.xl { width: 76px; height: 76px; font-size: 1.5rem; border-radius: 24px; }
+.ava.l { width: 44px; height: 44px; font-size: .95rem; }
+.ava.xs { width: 24px; height: 24px; font-size: .6rem; border: 2px solid #fff; }
+.ava.mh { background: #3d4350; }
+.ava.kk { background: #0e7c82; }
+.ava.bb { background: #5a4fa0; }
+.ava.hh { background: #f4581c; }
+
+/* ---------- Layout ---------- */
+.shell { max-width: 1080px; margin: 0 auto; display: grid; grid-template-columns: minmax(0, 1fr) 340px; gap: 24px; padding: 22px 16px 40px; align-items: start; }
+.maincol { display: flex; flex-direction: column; gap: 18px; min-width: 0; }
+
+/* ---------- Profil-Hero ---------- */
+.hero { background: var(--card); border: 1px solid var(--line); border-radius: 14px; overflow: hidden; }
+.hero .head { display: flex; gap: 16px; padding: 18px 18px 14px; align-items: center; flex-wrap: wrap; }
+.hero h1 { font-size: 1.45rem; font-weight: 800; letter-spacing: -.02em; line-height: 1.15; }
+.hero .sub { color: var(--dim); font-size: .9rem; margin-top: 2px; }
+.hero .sub a { font-weight: 600; color: var(--ink); }
+.hero .sub a:hover { color: var(--accent); }
+.hero .acts { margin-left: auto; display: flex; gap: 8px; flex-wrap: wrap; }
+.kbtn { display: inline-flex; align-items: center; gap: 7px; border: 1px solid var(--line); background: var(--card); border-radius: 9px; padding: 8px 15px; font-weight: 700; font-size: .88rem; color: var(--ink); }
+.kbtn:hover { border-color: #c9cdd3; }
+.kbtn.sm { padding: 7px 13px; font-size: .85rem; }
+.kbtn svg { stroke: currentColor; }
+.spokecards { display: flex; gap: 8px; padding: 0 18px 16px; flex-wrap: wrap; }
+.spoke {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  border: 1px dashed #c9cdd3;
+  border-radius: 99px;
+  padding: 5px 13px 5px 8px;
+  font-size: .8rem;
+  font-weight: 700;
+  color: #3c4048;
+}
+.spoke i {
+  width: 20px; height: 20px;
+  border-radius: 99px;
+  display: grid;
+  place-items: center;
+  font-style: normal;
+  font-size: .62rem;
+  font-weight: 800;
+  color: #fff;
+  background: var(--green);
+}
+.spoke.gold i { background: #c98024; }
+.spoke.blue i { background: #2b6cb0; }
+.statband { display: flex; border-top: 1px solid var(--line); background: #fafbfc; }
+.statband > div { flex: 1; padding: 12px 18px; }
+.statband > div + div { border-left: 1px solid var(--line); }
+.statband .v { font-family: var(--mono); font-weight: 600; font-size: 1.15rem; }
+.statband .v small { font-size: .68em; color: var(--dim); margin-left: 2px; }
+.statband .k { font-size: .7rem; color: var(--dim); text-transform: uppercase; letter-spacing: .08em; margin-top: 1px; }
+
+/* ---------- Tabs ---------- */
+.tabs { display: flex; gap: 2px; background: var(--card); border: 1px solid var(--line); border-radius: 12px; padding: 4px; overflow-x: auto; }
+.tabs a { flex: 1; text-align: center; font-weight: 700; font-size: .88rem; color: var(--dim); border-radius: 9px; padding: 8px 12px; white-space: nowrap; }
+.tabs a.on { background: #f2f3f5; color: var(--ink); }
+.tabs a:hover:not(.on) { color: var(--ink); }
+.tabs a .n { font-family: var(--mono); font-size: .72rem; color: var(--dim); margin-left: 4px; }
+
+/* ---------- Aktivitätskarten ---------- */
+.activity { background: var(--card); border: 1px solid var(--line); border-radius: 14px; overflow: hidden; }
+.act-head { display: flex; gap: 12px; padding: 14px 18px 10px; align-items: center; }
+.act-head .who { line-height: 1.3; min-width: 0; }
+.act-head .who b { font-weight: 700; }
+.act-head .who .sub { color: var(--dim); font-size: .82rem; }
+.act-head .badge { margin-left: auto; font-family: var(--mono); font-size: .68rem; text-transform: uppercase; letter-spacing: .1em; color: var(--dim); border: 1px solid var(--line); border-radius: 6px; padding: 3px 8px; white-space: nowrap; }
+.act-title { padding: 0 18px 12px; }
+.act-title h3 { font-size: 1.1rem; font-weight: 800; letter-spacing: -.015em; }
+.act-title .where { color: var(--dim); font-size: .86rem; margin-top: 2px; }
+.actmap { display: block; width: 100%; height: auto; }
+.statrow { display: flex; border-top: 1px solid var(--line); background: #fafbfc; }
+.statrow > div { flex: 1; padding: 11px 18px; }
+.statrow > div + div { border-left: 1px solid var(--line); }
+.statrow .v { font-family: var(--mono); font-weight: 600; font-size: 1.1rem; }
+.statrow .v small { font-size: .68em; color: var(--dim); margin-left: 2px; }
+.statrow .k { font-size: .7rem; color: var(--dim); text-transform: uppercase; letter-spacing: .08em; }
+.kudosbar { display: flex; align-items: center; gap: 10px; padding: 11px 18px; flex-wrap: wrap; }
+.kudosbar .note { color: var(--dim); font-size: .84rem; }
+.kudosbar .note b { color: var(--ink); }
+.kudosbar .spacer { flex: 1; }
+.facepile { display: flex; }
+.facepile .ava.xs + .ava.xs { margin-left: -8px; }
+
+.joincard { display: flex; gap: 14px; align-items: center; border: 1px solid var(--line); border-radius: 12px; margin: 0 18px 16px; padding: 13px 16px; flex-wrap: wrap; }
+.datebadge { flex: none; width: 52px; border: 2px solid var(--ink); border-radius: 11px; text-align: center; overflow: hidden; }
+.datebadge .m { background: var(--ink); color: #fff; font-size: .6rem; font-weight: 800; letter-spacing: .12em; padding: 2.5px 0; text-transform: uppercase; }
+.datebadge .d { font-size: 1.25rem; font-weight: 800; padding: 3px 0 4px; }
+.joincard h4 { font-size: 1rem; font-weight: 800; }
+.joincard .sub { color: var(--dim); font-size: .84rem; }
+.joincard .right { margin-left: auto; }
+
+.photoband2 { display: grid; grid-template-columns: 1fr 1fr; gap: 4px; }
+.photoband2 .ph { position: relative; min-height: 140px; }
+.photoband2 .ph::after { content: ""; position: absolute; inset: 0; background-image: radial-gradient(rgba(22,24,28,.35) 1px, transparent 1.4px); background-size: 4px 4px; opacity: .45; }
+.ph.g1 { background: linear-gradient(140deg, #c5b8d6, #6a5a86); }
+.ph.g2 { background: linear-gradient(150deg, #d8b8a8, #97614c); }
+
+/* ---------- Rechte Spalte ---------- */
+.rail { display: flex; flex-direction: column; gap: 18px; position: sticky; top: 76px; }
+.box { background: var(--card); border: 1px solid var(--line); border-radius: 14px; padding: 16px 18px; }
+.box h4 { font-size: .95rem; font-weight: 800; display: flex; align-items: baseline; margin-bottom: 12px; }
+.box h4 small { margin-left: auto; font-weight: 600; color: var(--dim); font-size: .76rem; }
+.chart { width: 100%; height: auto; display: block; }
+.chart-note { font-size: .74rem; color: var(--dim); margin-top: 8px; }
+.cityrow { display: flex; gap: 10px; align-items: center; padding: 7px 8px; border-radius: 8px; font-size: .9rem; }
+.cityrow:hover { background: #f6f7f8; }
+.cityrow .cm { width: 28px; height: 28px; border-radius: 9px; display: grid; place-items: center; color: #fff; font-weight: 800; font-size: .68rem; flex: none; }
+.cityrow b { font-weight: 700; }
+.cityrow .x { margin-left: auto; color: var(--dim); font-size: .78rem; text-align: right; }
+.settings { display: flex; flex-direction: column; }
+.settings a { display: flex; gap: 11px; align-items: center; padding: 8px; border-radius: 8px; font-size: .9rem; font-weight: 600; }
+.settings a:hover { background: #f6f7f8; }
+.settings svg { flex: none; stroke: var(--dim); }
+.settings .out { color: #b3404a; }
+.settings .out svg { stroke: #b3404a; }
+.fine { font-size: .75rem; color: var(--dim); line-height: 1.6; padding: 0 6px; }
+
+/* ---------- Mobil ---------- */
+.tabbar { display: none; }
+.proto-back { position: fixed; bottom: 14px; right: 14px; z-index: 60; font-size: .75rem; font-weight: 700; background: var(--card); border: 1px solid var(--line); border-radius: 99px; padding: 6px 12px; color: var(--dim); }
+@media (max-width: 1000px) {
+  .shell { grid-template-columns: minmax(0, 1fr); }
+  .rail { position: static; }
+  .top nav, .search { display: none; }
+  .statband { flex-wrap: wrap; }
+  .statband > div { flex: 1 1 40%; border-top: 1px solid var(--line); margin-top: -1px; }
+  .hero .acts { margin-left: 0; }
+  .tabbar {
+    display: flex; position: fixed; bottom: 0; left: 0; right: 0; z-index: 55;
+    background: rgba(255,255,255,.96); backdrop-filter: blur(10px);
+    border-top: 1px solid var(--line);
+    padding: 6px 8px calc(6px + env(safe-area-inset-bottom));
+  }
+  .tabbar a { flex: 1; display: flex; flex-direction: column; align-items: center; gap: 2px; font-size: .62rem; font-weight: 700; color: var(--dim); padding: 4px 0; }
+  .tabbar a svg { stroke: currentColor; }
+  .tabbar a.on { color: var(--accent); }
+  .proto-back { bottom: 76px; }
+}
+</style>
+</head>
+<body>
+
+<header class="top">
+  <div class="top-inner">
+    <a class="brand" href="06-feed-aktiv.html">
+      <span class="mark">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.4"><circle cx="6" cy="17" r="3.2"/><circle cx="18" cy="17" r="3.2"/><path d="M6 17 9.5 9H8m1.5 0h5L18 17M12 17l-1.5-6"/></svg>
+      </span>
+      criticalmass.in
+    </a>
+    <nav>
+      <a href="06-feed-aktiv.html">Timeline</a>
+      <a href="06e-karte.html">Karte</a>
+      <a href="06c-kalender.html">Kalender</a>
+      <a href="06l-verzeichnis.html">Städte</a>
+      <a href="06f-forum.html">Forum</a>
+    </nav>
+    <span class="grow"></span>
+    <a class="search" href="06j-suche.html">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="m20 20-4-4"/></svg>
+      Stadt oder Tour suchen
+    </a>
+    <a class="upload-btn" href="06h-hochladen.html">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.2"><path d="M12 16V5m0 0 -4 4m4-4 4 4M5 19h14"/></svg>
+      Hochladen
+    </a>
+    <span class="ava mh">MH</span>
+  </div>
+</header>
+
+<div class="shell">
+
+  <!-- Hauptspalte -->
+  <main class="maincol">
+
+    <section class="hero">
+      <div class="head">
+        <span class="ava xl mh">MH</span>
+        <div>
+          <h1>malte</h1>
+          <p class="sub">Fährt mit seit 2014 · meistens bei <a href="06b-stadt.html">Critical Mass Hamburg</a></p>
+        </div>
+        <span class="acts">
+          <button class="kbtn">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M4 16.5 14.5 6a2.6 2.6 0 0 1 3.7 3.7L7.7 20.2 3.5 21z"/></svg>
+            Profil bearbeiten
+          </button>
+        </span>
+      </div>
+      <div class="spokecards" aria-label="Spoke Cards">
+        <span class="spoke"><i>12</i>12 Monate in Folge</span>
+        <span class="spoke gold"><i>❄</i>Allwetter — auch im Januar</span>
+        <span class="spoke blue"><i>4</i>4 Städte besucht</span>
+      </div>
+      <div class="statband">
+        <div><div class="v">34</div><div class="k">Massen gesamt</div></div>
+        <div><div class="v">7</div><div class="k">Dieses Jahr</div></div>
+        <div><div class="v">612<small>km</small></div><div class="k">In der Masse 2026</div></div>
+        <div><div class="v">18</div><div class="k">Tracks</div></div>
+      </div>
+    </section>
+
+    <nav class="tabs">
+      <a class="on" href="#">Aktivität</a>
+      <a href="#">Tracks<span class="n">18</span></a>
+      <a href="#">Fotos<span class="n">41</span></a>
+      <a href="#">Teilnahmen<span class="n">34</span></a>
+    </nav>
+
+    <!-- Angekündigte Teilnahme -->
+    <article class="activity">
+      <div class="act-head">
+        <span class="ava l mh">MH</span>
+        <div class="who">
+          <b>malte</b>
+          <div class="sub">vor 2 Tagen · Teilnahme angekündigt</div>
+        </div>
+        <span class="badge">Dabei</span>
+      </div>
+      <div class="joincard">
+        <span class="datebadge"><span class="m">Juni</span><span class="d">26</span></span>
+        <span>
+          <h4>Critical Mass Hamburg</h4>
+          <p class="sub">Freitag · 19:00 · Alstervorland — mit 131 anderen</p>
+        </span>
+        <a class="kbtn sm right" href="06a-tour.html">Zur Tour</a>
+      </div>
+    </article>
+
+    <!-- Eigener Track -->
+    <article class="activity">
+      <div class="act-head">
+        <span class="ava l mh">MH</span>
+        <div class="who">
+          <b>malte</b>
+          <div class="sub">29. Mai · GPX-Upload · Maimasse Hamburg</div>
+        </div>
+        <span class="badge">Track</span>
+      </div>
+      <div class="act-title">
+        <h3>Maimasse — vorne mitgerollt</h3>
+        <div class="where">Tour vom 29.05.2026 · Start Alstervorland</div>
+      </div>
+      <svg class="actmap" viewBox="0 0 760 220" aria-hidden="true">
+        <rect width="760" height="220" fill="#e9ecef"/>
+        <g stroke="#d9dde2" stroke-width="1.5">
+          <line x1="100" y1="0" x2="100" y2="220"/><line x1="220" y1="0" x2="220" y2="220"/>
+          <line x1="350" y1="0" x2="350" y2="220"/><line x1="500" y1="0" x2="500" y2="220"/>
+          <line x1="640" y1="0" x2="640" y2="220"/>
+          <line x1="0" y1="55" x2="760" y2="55"/><line x1="0" y1="120" x2="760" y2="120"/>
+          <line x1="0" y1="180" x2="760" y2="180"/>
+        </g>
+        <path d="M470,28 C528,22 570,48 580,92 C589,130 569,170 522,182 C480,191 448,172 438,140 C428,108 434,56 470,28 Z" fill="#d4e0ea" stroke="#bccddd" stroke-width="1.5"/>
+        <path d="M450,90 L490,55 L548,70 L568,115 L540,160 L488,170 L450,140 L395,155 L325,132 L250,150 L185,128 L155,85 L215,65 L295,90 L365,70 L420,105 L450,90"
+          fill="none" stroke="#f4581c" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+        <circle cx="450" cy="90" r="7" fill="#16181c"/>
+      </svg>
+      <div class="statrow">
+        <div><div class="v">21,7<small>km</small></div><div class="k">Strecke</div></div>
+        <div><div class="v">1:58<small>h</small></div><div class="k">Fahrzeit</div></div>
+        <div><div class="v">11,0<small>km/h</small></div><div class="k">Masse-Tempo</div></div>
+      </div>
+      <div class="kudosbar">
+        <span class="facepile">
+          <span class="ava xs kk">K</span><span class="ava xs bb">b</span>
+        </span>
+        <span class="note"><b>11× geklingelt</b></span>
+        <span class="spacer"></span>
+        <button class="kbtn sm">
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke-width="2.2"><path d="M12 4a5.5 5.5 0 0 0-5.5 5.5c0 4-1.6 5.4-2.5 6h16c-.9-.6-2.5-2-2.5-6A5.5 5.5 0 0 0 12 4z"/><path d="M10 19a2 2 0 0 0 4 0"/></svg>
+          Klingeln
+        </button>
+      </div>
+    </article>
+
+    <!-- Eigene Fotos -->
+    <article class="activity">
+      <div class="act-head">
+        <span class="ava l mh">MH</span>
+        <div class="who">
+          <b>malte</b>
+          <div class="sub">29. Mai · 2 Fotos · Maimasse Hamburg</div>
+        </div>
+        <span class="badge">Galerie</span>
+      </div>
+      <div class="act-title">
+        <h3>Kurz vorm Start am Alstervorland</h3>
+      </div>
+      <div class="photoband2">
+        <a class="ph g1" href="#"></a>
+        <a class="ph g2" href="#"></a>
+      </div>
+      <div class="kudosbar">
+        <span class="note"><b>6× geklingelt</b> · 1 Kommentar</span>
+      </div>
+    </article>
+
+  </main>
+
+  <!-- Rechte Spalte -->
+  <aside class="rail">
+
+    <div class="box">
+      <h4>Deine Masse-Kilometer <small>2021–2026</small></h4>
+      <svg class="chart" viewBox="0 0 304 140" aria-label="Kilometer pro Jahr">
+        <g font-family="IBM Plex Mono, monospace" font-size="9" fill="#707684" text-anchor="middle">
+          <rect x="8"   y="71" width="34" height="49" rx="4" fill="#e3e5e8"/><text x="25" y="136">21</text>
+          <rect x="58"  y="42" width="34" height="78" rx="4" fill="#e3e5e8"/><text x="75" y="136">22</text>
+          <rect x="108" y="48" width="34" height="72" rx="4" fill="#e3e5e8"/><text x="125" y="136">23</text>
+          <rect x="158" y="26" width="34" height="94" rx="4" fill="#e3e5e8"/><text x="175" y="136">24</text>
+          <rect x="208" y="1"  width="34" height="119" rx="4" fill="#e3e5e8"/><text x="225" y="136">25</text>
+          <rect x="258" y="66" width="34" height="54" rx="4" fill="#f4581c"/><text x="275" y="136">26</text>
+        </g>
+        <text x="225" y="14" font-family="IBM Plex Mono, monospace" font-size="9.5" fill="#707684" text-anchor="middle">312</text>
+        <text x="275" y="60" font-family="IBM Plex Mono, monospace" font-size="9.5" font-weight="600" fill="#f4581c" text-anchor="middle">142</text>
+      </svg>
+      <p class="chart-note">Kilometer aus deinen hochgeladenen Tracks · 2026 läuft noch</p>
+    </div>
+
+    <div class="box">
+      <h4>Deine Städte</h4>
+      <a class="cityrow" href="06b-stadt.html">
+        <span class="cm" style="background:#f4581c">HH</span>
+        <b>Hamburg</b><span class="x">28 Massen</span>
+      </a>
+      <a class="cityrow" href="#">
+        <span class="cm" style="background:#1e7d4f">LG</span>
+        <b>Lüneburg</b><span class="x">4 Massen</span>
+      </a>
+      <a class="cityrow" href="#">
+        <span class="cm" style="background:#5a4fa0">B</span>
+        <b>Berlin</b><span class="x">2 Massen</span>
+      </a>
+    </div>
+
+    <div class="box">
+      <h4>Konto</h4>
+      <div class="settings">
+        <a href="#">
+          <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke-width="2"><circle cx="12" cy="8.4" r="3.4"/><path d="M5 20c.8-3.4 3.6-5.2 7-5.2s6.2 1.8 7 5.2"/></svg>
+          Profil &amp; Foto
+        </a>
+        <a href="06m-mitteilungen.html">
+          <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M12 4a5.5 5.5 0 0 0-5.5 5.5c0 4-1.6 5.4-2.5 6h16c-.9-.6-2.5-2-2.5-6A5.5 5.5 0 0 0 12 4z"/><path d="M10 19a2 2 0 0 0 4 0"/></svg>
+          Mitteilungen
+        </a>
+        <a href="#">
+          <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M12 16V5m0 0-4 4m4-4 4 4M5 19h14"/></svg>
+          Tracks verwalten
+        </a>
+        <a href="#">
+          <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M4 17V7a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v10M2 17h20v2H2z"/></svg>
+          Datenexport (GPX, Fotos)
+        </a>
+        <a class="out" href="#">
+          <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M15 12H4m0 0 3.5-3.5M4 12l3.5 3.5M10 4h8a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2h-8"/></svg>
+          Abmelden
+        </a>
+      </div>
+    </div>
+
+    <p class="fine">Deine Tracks und Fotos gehören dir — Export jederzeit, Löschung ohne Rückfrage.</p>
+  </aside>
+
+</div>
+
+<!-- Mobile Tabbar -->
+<nav class="tabbar">
+  <a href="06-feed-aktiv.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M3 11.2 12 4l9 7.2M5.5 9.8V20h13V9.8"/></svg>
+    Timeline
+  </a>
+  <a href="06e-karte.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M12 21s7-6 7-11a7 7 0 0 0-14 0c0 5 7 11 7 11z"/><circle cx="12" cy="9.8" r="2.4"/></svg>
+    Karte
+  </a>
+  <a href="06h-hochladen.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M12 16V5m0 0-4 4m4-4 4 4M5 19h14"/></svg>
+    Hochladen
+  </a>
+  <a href="06c-kalender.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><rect x="3.5" y="5" width="17" height="15.5" rx="2.5"/><path d="M3.5 9.5h17M8 3v4M16 3v4"/></svg>
+    Kalender
+  </a>
+  <a class="on" href="#">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><circle cx="12" cy="8.4" r="3.4"/><path d="M5 20c.8-3.4 3.6-5.2 7-5.2s6.2 1.8 7 5.2"/></svg>
+    Profil
+  </a>
+</nav>
+
+<a class="proto-back" href="index.html">← Übersicht</a>
+
+</body>
+</html>

--- a/design-prototypes/06e-karte.html
+++ b/design-prototypes/06e-karte.html
@@ -1,0 +1,410 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Karte · Entdecken — Prototyp 6 · criticalmass.in</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@500;600&display=swap" rel="stylesheet">
+<style>
+:root {
+  --bg: #f2f3f5;
+  --card: #ffffff;
+  --line: #e3e5e8;
+  --ink: #16181c;
+  --dim: #707684;
+  --accent: #f4581c;
+  --accent-deep: #d8450e;
+  --green: #1e7d4f;
+  --sans: "Archivo", "Helvetica Neue", Arial, sans-serif;
+  --mono: "IBM Plex Mono", Menlo, monospace;
+}
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html, body { overflow-x: clip; }
+body {
+  font-family: var(--sans);
+  background: var(--bg);
+  color: var(--ink);
+  line-height: 1.5;
+  font-size: 15px;
+}
+a { color: inherit; text-decoration: none; }
+button { font-family: inherit; cursor: pointer; }
+
+/* ---------- Topbar ---------- */
+.top { position: sticky; top: 0; z-index: 50; background: var(--card); border-bottom: 1px solid var(--line); }
+.top-inner { max-width: 1480px; margin: 0 auto; display: flex; align-items: center; gap: 22px; padding: 0 16px; height: 56px; }
+.brand { display: flex; align-items: center; gap: 9px; font-weight: 800; font-size: 1.05rem; letter-spacing: -.01em; }
+.brand .mark { width: 28px; height: 28px; border-radius: 8px; background: var(--accent); display: grid; place-items: center; }
+.top nav { display: flex; gap: 4px; }
+.top nav a { font-weight: 600; font-size: .92rem; color: var(--dim); padding: 6px 12px; border-radius: 8px; }
+.top nav a:hover { background: #f2f3f5; color: var(--ink); }
+.top nav a.on { color: var(--ink); background: #f2f3f5; font-weight: 700; }
+.top .grow { flex: 1; }
+.upload-btn { display: inline-flex; align-items: center; gap: 8px; background: var(--accent); color: #fff; border: 0; border-radius: 9px; font-weight: 700; font-size: .9rem; padding: 8px 14px; }
+.upload-btn:hover { background: var(--accent-deep); }
+.ava { width: 34px; height: 34px; border-radius: 99px; flex: none; display: grid; place-items: center; font-weight: 800; font-size: .78rem; color: #fff; }
+.ava.mh { background: #3d4350; }
+
+/* ---------- Karte + Panel ---------- */
+.stage {
+  display: flex;
+  height: calc(100dvh - 56px);
+  max-width: 1480px;
+  margin: 0 auto;
+}
+.panel {
+  width: 372px;
+  flex: none;
+  background: var(--card);
+  border-right: 1px solid var(--line);
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+.panel .phead { padding: 16px 16px 12px; border-bottom: 1px solid var(--line); }
+.panel h1 { font-size: 1.15rem; font-weight: 800; letter-spacing: -.01em; }
+.panel .sub { color: var(--dim); font-size: .82rem; margin-top: 1px; }
+.filters { display: flex; gap: 6px; margin-top: 12px; flex-wrap: wrap; }
+.fchip {
+  border: 1px solid var(--line);
+  background: var(--card);
+  border-radius: 99px;
+  padding: 5px 13px;
+  font-size: .82rem;
+  font-weight: 700;
+  color: var(--dim);
+}
+.fchip.on { background: var(--ink); border-color: var(--ink); color: #fff; }
+.fchip:hover:not(.on) { border-color: #c9cdd3; color: var(--ink); }
+.plist { overflow-y: auto; flex: 1; padding: 8px; }
+.crow {
+  display: flex;
+  gap: 12px;
+  padding: 11px 10px;
+  border-radius: 12px;
+  align-items: center;
+}
+.crow:hover { background: #f6f7f8; }
+.crow .dot {
+  width: 34px; height: 34px;
+  flex: none;
+  border-radius: 99px;
+  display: grid;
+  place-items: center;
+  color: #fff;
+  font-weight: 800;
+  font-size: .68rem;
+}
+.crow .t { min-width: 0; }
+.crow b { font-weight: 700; display: block; line-height: 1.25; }
+.crow .when { font-size: .8rem; color: var(--dim); }
+.crow .when .hl { color: var(--accent); font-weight: 700; }
+.crow .dist { margin-left: auto; text-align: right; font-family: var(--mono); font-size: .74rem; color: var(--dim); white-space: nowrap; }
+.crow .dist b { display: block; font-family: var(--sans); font-size: .78rem; font-weight: 700; color: var(--ink); }
+.crow.me { background: #fff4ee; }
+.crow.me:hover { background: #ffeadf; }
+.pfoot { padding: 10px 16px; border-top: 1px solid var(--line); font-size: .76rem; color: var(--dim); }
+
+/* Kartenfläche */
+.maparea { position: relative; flex: 1; min-width: 0; background: #e9ecef; }
+.maparea svg.map { position: absolute; inset: 0; width: 100%; height: 100%; }
+.float-search {
+  position: absolute;
+  top: 14px; left: 14px;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 99px;
+  padding: 9px 16px;
+  font-size: .88rem;
+  color: var(--dim);
+  box-shadow: 0 4px 14px rgba(22,24,28,.08);
+  min-width: 230px;
+}
+.zoomers {
+  position: absolute;
+  top: 14px; right: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.zbtn {
+  width: 38px; height: 38px;
+  border: 1px solid var(--line);
+  background: var(--card);
+  border-radius: 10px;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--ink);
+  box-shadow: 0 4px 14px rgba(22,24,28,.08);
+  display: grid;
+  place-items: center;
+}
+.zbtn:hover { border-color: #c9cdd3; }
+.legend {
+  position: absolute;
+  bottom: 14px; left: 14px;
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 8px 13px;
+  font-size: .78rem;
+  color: var(--dim);
+  box-shadow: 0 4px 14px rgba(22,24,28,.08);
+}
+.legend b { color: var(--ink); }
+.legend .hl { color: var(--accent); font-weight: 700; }
+
+/* Map-Pins als HTML über SVG */
+.pin {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  display: grid;
+  place-items: center;
+  border-radius: 99px;
+  color: #fff;
+  font-weight: 800;
+  font-family: var(--mono);
+  border: 2.5px solid #fff;
+  box-shadow: 0 3px 10px rgba(22,24,28,.25);
+  background: #3d4350;
+}
+.pin.cluster { background: var(--accent); }
+.pin.s { width: 30px; height: 30px; font-size: .68rem; }
+.pin.m { width: 38px; height: 38px; font-size: .76rem; }
+.pin.l { width: 48px; height: 48px; font-size: .85rem; }
+.pin.city { background: #16181c; }
+.pin.hot { background: var(--accent); }
+.pin.hot::after {
+  content: "";
+  position: absolute;
+  inset: -7px;
+  border-radius: 99px;
+  border: 2px solid rgba(244,88,28,.45);
+  animation: ring 2.4s ease infinite;
+}
+@keyframes ring { 70% { transform: scale(1.25); opacity: 0; } 100% { transform: scale(1.25); opacity: 0; } }
+@media (prefers-reduced-motion: reduce) { .pin.hot::after { animation: none; } }
+.pinlabel {
+  position: absolute;
+  transform: translate(-50%, 8px);
+  background: #16181c;
+  color: #fff;
+  font-size: .7rem;
+  font-weight: 700;
+  border-radius: 7px;
+  padding: 3px 9px;
+  white-space: nowrap;
+}
+
+/* ---------- Mobil ---------- */
+.tabbar { display: none; }
+.proto-back { position: fixed; bottom: 14px; right: 14px; z-index: 60; font-size: .75rem; font-weight: 700; background: var(--card); border: 1px solid var(--line); border-radius: 99px; padding: 6px 12px; color: var(--dim); }
+@media (max-width: 900px) {
+  body { padding-bottom: 0; }
+  .top nav { display: none; }
+  .stage { flex-direction: column; height: calc(100dvh - 56px); }
+  .maparea { order: 1; flex: none; height: 44%; }
+  .panel {
+    order: 2;
+    width: auto;
+    flex: 1;
+    border-right: 0;
+    border-radius: 18px 18px 0 0;
+    margin-top: -16px;
+    z-index: 5;
+    box-shadow: 0 -8px 24px rgba(22,24,28,.1);
+  }
+  .panel::before {
+    content: "";
+    display: block;
+    width: 42px; height: 5px;
+    border-radius: 99px;
+    background: #d6d9de;
+    margin: 9px auto 2px;
+  }
+  .plist { padding-bottom: 76px; }
+  .float-search { display: none; }
+  .tabbar {
+    display: flex; position: fixed; bottom: 0; left: 0; right: 0; z-index: 55;
+    background: rgba(255,255,255,.96); backdrop-filter: blur(10px);
+    border-top: 1px solid var(--line);
+    padding: 6px 8px calc(6px + env(safe-area-inset-bottom));
+  }
+  .tabbar a { flex: 1; display: flex; flex-direction: column; align-items: center; gap: 2px; font-size: .62rem; font-weight: 700; color: var(--dim); padding: 4px 0; }
+  .tabbar a svg { stroke: currentColor; }
+  .tabbar a.on { color: var(--accent); }
+  .proto-back { bottom: 76px; }
+}
+</style>
+</head>
+<body>
+
+<header class="top">
+  <div class="top-inner">
+    <a class="brand" href="06-feed-aktiv.html">
+      <span class="mark">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.4"><circle cx="6" cy="17" r="3.2"/><circle cx="18" cy="17" r="3.2"/><path d="M6 17 9.5 9H8m1.5 0h5L18 17M12 17l-1.5-6"/></svg>
+      </span>
+      criticalmass.in
+    </a>
+    <nav>
+      <a href="06-feed-aktiv.html">Timeline</a>
+      <a class="on" href="#">Karte</a>
+      <a href="06c-kalender.html">Kalender</a>
+      <a href="06l-verzeichnis.html">Städte</a>
+      <a href="06f-forum.html">Forum</a>
+    </nav>
+    <span class="grow"></span>
+    <a class="upload-btn" href="06h-hochladen.html">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.2"><path d="M12 16V5m0 0 -4 4m4-4 4 4M5 19h14"/></svg>
+      Hochladen
+    </a>
+    <a class="ava mh" href="06d-profil.html">MH</a>
+  </div>
+</header>
+
+<div class="stage">
+
+  <!-- Linkes Panel -->
+  <aside class="panel">
+    <div class="phead">
+      <h1>Entdecken</h1>
+      <p class="sub">612 Städte weltweit · sortiert nach Entfernung</p>
+      <div class="filters">
+        <button class="fchip on">Alle</button>
+        <button class="fchip">Heute</button>
+        <button class="fchip">Großer Freitag</button>
+        <button class="fchip">Neu</button>
+      </div>
+    </div>
+    <div class="plist">
+      <a class="crow me" href="06b-stadt.html">
+        <span class="dot" style="background:var(--accent)">HH</span>
+        <span class="t"><b>Hamburg</b><span class="when"><span class="hl">Fr 26.06. · 19:00</span> · Alstervorland</span></span>
+        <span class="dist"><b>deine Stadt</b>~ 2.400 Räder</span>
+      </a>
+      <a class="crow" href="#">
+        <span class="dot" style="background:#0e7c82">NO</span>
+        <span class="t"><b>Norderstedt</b><span class="when">Fr 03.07. · 19:00 · Rathaus</span></span>
+        <span class="dist"><b>14 km</b>12 Räder</span>
+      </a>
+      <a class="crow" href="#">
+        <span class="dot" style="background:#5a4fa0">PI</span>
+        <span class="t"><b>Pinneberg</b><span class="when"><span class="hl">Sa 13.06. · 20:45</span></span></span>
+        <span class="dist"><b>23 km</b>~ 60 Räder</span>
+      </a>
+      <a class="crow" href="#">
+        <span class="dot" style="background:#1e7d4f">LG</span>
+        <span class="t"><b>Lüneburg</b><span class="when">Fr 26.06. · 18:00 · Am Sande</span></span>
+        <span class="dist"><b>43 km</b>~ 180 Räder</span>
+      </a>
+      <a class="crow" href="#">
+        <span class="dot" style="background:#2b6cb0">HB</span>
+        <span class="t"><b>Bremen</b><span class="when">Fr 26.06. · 19:00</span></span>
+        <span class="dist"><b>95 km</b>~ 800 Räder</span>
+      </a>
+      <a class="crow" href="#">
+        <span class="dot" style="background:#c98024">H</span>
+        <span class="t"><b>Hannover</b><span class="when">Fr 19.06. · 20:00</span></span>
+        <span class="dist"><b>132 km</b>~ 900 Räder</span>
+      </a>
+      <a class="crow" href="#">
+        <span class="dot" style="background:#b76fc4">B</span>
+        <span class="t"><b>Berlin</b><span class="when">Fr 26.06. · 20:00 · Mariannenplatz</span></span>
+        <span class="dist"><b>255 km</b>~ 1.900 Räder</span>
+      </a>
+      <a class="crow" href="#">
+        <span class="dot" style="background:#8c5e2a">ST</span>
+        <span class="t"><b>Stirling</b><span class="when"><span class="hl">Neu</span> · Sa 20.06. · 10:00</span></span>
+        <span class="dist"><b>1.012 km</b>erste Masse</span>
+      </a>
+    </div>
+    <p class="pfoot">Stadt fehlt? <a href="06n-tour-anlegen.html" style="text-decoration:underline">Trag deine Masse ein</a> — drei Felder genügen.</p>
+  </aside>
+
+  <!-- Karte -->
+  <main class="maparea">
+    <svg class="map" viewBox="0 0 1000 760" preserveAspectRatio="xMidYMid slice" aria-hidden="true">
+      <rect width="1000" height="760" fill="#e9ecef"/>
+      <g stroke="#dde1e6" stroke-width="1.5">
+        <line x1="125" y1="0" x2="125" y2="760"/><line x1="250" y1="0" x2="250" y2="760"/>
+        <line x1="375" y1="0" x2="375" y2="760"/><line x1="500" y1="0" x2="500" y2="760"/>
+        <line x1="625" y1="0" x2="625" y2="760"/><line x1="750" y1="0" x2="750" y2="760"/>
+        <line x1="875" y1="0" x2="875" y2="760"/>
+        <line x1="0" y1="95" x2="1000" y2="95"/><line x1="0" y1="190" x2="1000" y2="190"/>
+        <line x1="0" y1="285" x2="1000" y2="285"/><line x1="0" y1="380" x2="1000" y2="380"/>
+        <line x1="0" y1="475" x2="1000" y2="475"/><line x1="0" y1="570" x2="1000" y2="570"/>
+        <line x1="0" y1="665" x2="1000" y2="665"/>
+      </g>
+      <!-- Nordsee / Ostsee -->
+      <path d="M0,0 L1000,0 L1000,52 C900,70 840,40 760,76 C690,108 640,70 560,96 C470,124 420,80 330,108 C240,134 160,96 80,124 C50,134 20,128 0,140 Z" fill="#d4e0ea"/>
+      <!-- Elbe -->
+      <path d="M330,108 C360,200 320,300 370,380 C410,444 380,540 420,640" fill="none" stroke="#c3d2e0" stroke-width="7" stroke-linecap="round"/>
+      <!-- Weser/Rhein angedeutet -->
+      <path d="M240,130 C250,240 210,340 240,460" fill="none" stroke="#cdd9e4" stroke-width="5" stroke-linecap="round"/>
+      <path d="M95,300 C120,420 90,540 130,660" fill="none" stroke="#cdd9e4" stroke-width="6" stroke-linecap="round"/>
+    </svg>
+
+    <!-- Pins -->
+    <span class="pin l hot" style="top:24%; left:36%">HH</span>
+    <span class="pinlabel" style="top:30.5%; left:36%">Hamburg · Fr 19:00</span>
+    <span class="pin s city" style="top:19%; left:39%">NO</span>
+    <span class="pin s city" style="top:21%; left:31%">PI</span>
+    <span class="pin s city" style="top:33%; left:42%">LG</span>
+    <span class="pin m city" style="top:30%; left:24%">HB</span>
+    <span class="pin m city" style="top:47%; left:31%">H</span>
+    <span class="pin l city" style="top:34%; left:70%">B</span>
+    <span class="pin m cluster" style="top:58%; left:12%">23</span>
+    <span class="pin l cluster" style="top:66%; left:38%">47</span>
+    <span class="pin m cluster" style="top:80%; left:60%">19</span>
+    <span class="pin s cluster" style="top:12%; left:76%">7</span>
+
+    <span class="float-search">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="m20 20-4-4"/></svg>
+      Stadt oder Region suchen
+    </span>
+    <span class="zoomers">
+      <button class="zbtn">+</button>
+      <button class="zbtn">−</button>
+      <button class="zbtn" aria-label="Mein Standort">
+        <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="#16181c" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M12 2v3.5M12 18.5V22M2 12h3.5M18.5 12H22"/></svg>
+      </button>
+    </span>
+    <span class="legend"><b>612 Städte</b> · <span class="hl">43 Touren</span> in den nächsten 14 Tagen · Karte © OpenStreetMap</span>
+  </main>
+
+</div>
+
+<!-- Mobile Tabbar -->
+<nav class="tabbar">
+  <a href="06-feed-aktiv.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M3 11.2 12 4l9 7.2M5.5 9.8V20h13V9.8"/></svg>
+    Timeline
+  </a>
+  <a class="on" href="#">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M12 21s7-6 7-11a7 7 0 0 0-14 0c0 5 7 11 7 11z"/><circle cx="12" cy="9.8" r="2.4"/></svg>
+    Karte
+  </a>
+  <a href="06h-hochladen.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M12 16V5m0 0-4 4m4-4 4 4M5 19h14"/></svg>
+    Hochladen
+  </a>
+  <a href="06c-kalender.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><rect x="3.5" y="5" width="17" height="15.5" rx="2.5"/><path d="M3.5 9.5h17M8 3v4M16 3v4"/></svg>
+    Kalender
+  </a>
+  <a href="06d-profil.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><circle cx="12" cy="8.4" r="3.4"/><path d="M5 20c.8-3.4 3.6-5.2 7-5.2s6.2 1.8 7 5.2"/></svg>
+    Profil
+  </a>
+</nav>
+
+<a class="proto-back" href="index.html">← Übersicht</a>
+
+</body>
+</html>

--- a/design-prototypes/06f-forum.html
+++ b/design-prototypes/06f-forum.html
@@ -1,0 +1,376 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Forum — Prototyp 6 · criticalmass.in</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@500;600&display=swap" rel="stylesheet">
+<style>
+:root {
+  --bg: #f2f3f5;
+  --card: #ffffff;
+  --line: #e3e5e8;
+  --ink: #16181c;
+  --dim: #707684;
+  --accent: #f4581c;
+  --accent-deep: #d8450e;
+  --green: #1e7d4f;
+  --sans: "Archivo", "Helvetica Neue", Arial, sans-serif;
+  --mono: "IBM Plex Mono", Menlo, monospace;
+}
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html, body { overflow-x: clip; }
+body {
+  font-family: var(--sans);
+  background: var(--bg);
+  color: var(--ink);
+  line-height: 1.5;
+  font-size: 15px;
+  padding-bottom: 70px;
+}
+a { color: inherit; text-decoration: none; }
+button { font-family: inherit; cursor: pointer; }
+
+/* ---------- Topbar ---------- */
+.top { position: sticky; top: 0; z-index: 50; background: var(--card); border-bottom: 1px solid var(--line); }
+.top-inner { max-width: 1080px; margin: 0 auto; display: flex; align-items: center; gap: 22px; padding: 0 16px; height: 56px; }
+.brand { display: flex; align-items: center; gap: 9px; font-weight: 800; font-size: 1.05rem; letter-spacing: -.01em; }
+.brand .mark { width: 28px; height: 28px; border-radius: 8px; background: var(--accent); display: grid; place-items: center; }
+.top nav { display: flex; gap: 4px; }
+.top nav a { font-weight: 600; font-size: .92rem; color: var(--dim); padding: 6px 12px; border-radius: 8px; }
+.top nav a:hover { background: #f2f3f5; color: var(--ink); }
+.top nav a.on { color: var(--ink); background: #f2f3f5; font-weight: 700; }
+.top .grow { flex: 1; }
+.search { display: flex; align-items: center; gap: 8px; background: #f2f3f5; border-radius: 9px; padding: 7px 12px; color: var(--dim); font-size: .88rem; min-width: 180px; }
+.upload-btn { display: inline-flex; align-items: center; gap: 8px; background: var(--accent); color: #fff; border: 0; border-radius: 9px; font-weight: 700; font-size: .9rem; padding: 8px 14px; }
+.upload-btn:hover { background: var(--accent-deep); }
+.ava { width: 34px; height: 34px; border-radius: 99px; flex: none; display: grid; place-items: center; font-weight: 800; font-size: .78rem; color: #fff; }
+.ava.s { width: 28px; height: 28px; font-size: .64rem; }
+.ava.xs { width: 22px; height: 22px; font-size: .56rem; border: 2px solid #fff; }
+.ava.mh { background: #3d4350; }
+.ava.lk { background: #c98024; }
+.ava.kk { background: #0e7c82; }
+.ava.bb { background: #5a4fa0; }
+.ava.an { background: #1e7d4f; }
+.ava.vh { background: #2b6cb0; }
+
+/* ---------- Layout ---------- */
+.shell { max-width: 1080px; margin: 0 auto; display: grid; grid-template-columns: minmax(0, 1fr) 340px; gap: 24px; padding: 22px 16px 40px; align-items: start; }
+.maincol { display: flex; flex-direction: column; gap: 18px; min-width: 0; }
+.pagehead { display: flex; align-items: baseline; gap: 14px; flex-wrap: wrap; }
+.pagehead h1 { font-size: 1.45rem; font-weight: 800; letter-spacing: -.02em; }
+.pagehead .sub { color: var(--dim); font-size: .88rem; }
+
+/* ---------- Threads ---------- */
+.box { background: var(--card); border: 1px solid var(--line); border-radius: 14px; overflow: hidden; }
+.box .bhead { display: flex; align-items: baseline; padding: 14px 18px 12px; border-bottom: 1px solid var(--line); }
+.box .bhead h2 { font-size: 1rem; font-weight: 800; }
+.box .bhead a { margin-left: auto; font-size: .8rem; color: var(--dim); }
+.box .bhead a:hover { color: var(--accent); }
+.thread { display: flex; gap: 13px; padding: 13px 18px; border-bottom: 1px solid var(--line); align-items: center; }
+.thread:last-child { border-bottom: 0; }
+.thread:hover { background: #fafbfc; }
+.thread .t { min-width: 0; flex: 1; }
+.thread h3 { font-size: .98rem; font-weight: 700; line-height: 1.3; }
+.thread .meta { font-size: .8rem; color: var(--dim); margin-top: 2px; display: flex; gap: 8px; flex-wrap: wrap; align-items: baseline; }
+.bchip {
+  font-size: .68rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: .06em;
+  border-radius: 6px;
+  padding: 1.5px 7px;
+  background: #f2f3f5;
+  color: #4c5260;
+}
+.bchip.city { background: #fff4ee; color: var(--accent-deep); }
+.thread .stats { flex: none; text-align: right; }
+.thread .stats .n { font-family: var(--mono); font-weight: 600; font-size: 1.05rem; }
+.thread .stats .k { font-size: .7rem; color: var(--dim); text-transform: uppercase; letter-spacing: .06em; }
+.thread.hot h3::before {
+  content: "●";
+  color: var(--accent);
+  margin-right: 7px;
+  font-size: .7em;
+  vertical-align: 2px;
+}
+
+/* ---------- Boards ---------- */
+.boardgrid { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+.board {
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 16px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.board:hover { border-color: #c9cdd3; }
+.board .bh { display: flex; gap: 12px; align-items: center; }
+.board .bicon {
+  width: 38px; height: 38px;
+  border-radius: 11px;
+  display: grid;
+  place-items: center;
+  color: #fff;
+  font-weight: 800;
+  font-size: .8rem;
+  flex: none;
+}
+.board h3 { font-size: 1.02rem; font-weight: 800; }
+.board p { font-size: .86rem; color: var(--dim); }
+.board .bstats {
+  display: flex;
+  gap: 16px;
+  font-family: var(--mono);
+  font-size: .76rem;
+  color: var(--dim);
+  border-top: 1px solid var(--line);
+  padding-top: 10px;
+  margin-top: 2px;
+  align-items: center;
+}
+.board .bstats b { color: var(--ink); font-weight: 600; }
+.board .last { margin-left: auto; display: flex; align-items: center; gap: 6px; font-family: var(--sans); }
+
+/* ---------- Rail ---------- */
+.rail { display: flex; flex-direction: column; gap: 18px; position: sticky; top: 76px; }
+.rbox { background: var(--card); border: 1px solid var(--line); border-radius: 14px; padding: 16px 18px; }
+.rbox h4 { font-size: .95rem; font-weight: 800; margin-bottom: 10px; }
+.newbtn {
+  width: 100%;
+  background: var(--accent);
+  border: 0;
+  color: #fff;
+  font-weight: 700;
+  font-size: .95rem;
+  border-radius: 10px;
+  padding: 12px;
+}
+.newbtn:hover { background: var(--accent-deep); }
+.rbox .hint { font-size: .8rem; color: var(--dim); margin-top: 10px; }
+.rule { display: flex; gap: 10px; align-items: baseline; padding: 5px 0; font-size: .88rem; color: #3c4048; }
+.rule .nr { font-family: var(--mono); font-size: .72rem; font-weight: 600; color: var(--accent); flex: none; }
+.toprow { display: flex; gap: 10px; align-items: center; padding: 7px 8px; border-radius: 8px; font-size: .9rem; }
+.toprow:hover { background: #f6f7f8; }
+.toprow .bicon { width: 28px; height: 28px; border-radius: 9px; display: grid; place-items: center; color: #fff; font-weight: 800; font-size: .64rem; flex: none; }
+.toprow b { font-weight: 700; }
+.toprow .x { margin-left: auto; font-family: var(--mono); font-size: .76rem; color: var(--dim); }
+.fine { font-size: .75rem; color: var(--dim); line-height: 1.6; padding: 0 6px; }
+
+/* ---------- Mobil ---------- */
+.tabbar { display: none; }
+.proto-back { position: fixed; bottom: 14px; right: 14px; z-index: 60; font-size: .75rem; font-weight: 700; background: var(--card); border: 1px solid var(--line); border-radius: 99px; padding: 6px 12px; color: var(--dim); }
+@media (max-width: 1000px) {
+  .shell { grid-template-columns: minmax(0, 1fr); }
+  .rail { position: static; }
+  .top nav, .search { display: none; }
+  .boardgrid { grid-template-columns: 1fr; }
+  .thread .stats { display: none; }
+  .tabbar {
+    display: flex; position: fixed; bottom: 0; left: 0; right: 0; z-index: 55;
+    background: rgba(255,255,255,.96); backdrop-filter: blur(10px);
+    border-top: 1px solid var(--line);
+    padding: 6px 8px calc(6px + env(safe-area-inset-bottom));
+  }
+  .tabbar a { flex: 1; display: flex; flex-direction: column; align-items: center; gap: 2px; font-size: .62rem; font-weight: 700; color: var(--dim); padding: 4px 0; }
+  .tabbar a svg { stroke: currentColor; }
+  .proto-back { bottom: 76px; }
+}
+</style>
+</head>
+<body>
+
+<header class="top">
+  <div class="top-inner">
+    <a class="brand" href="06-feed-aktiv.html">
+      <span class="mark">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.4"><circle cx="6" cy="17" r="3.2"/><circle cx="18" cy="17" r="3.2"/><path d="M6 17 9.5 9H8m1.5 0h5L18 17M12 17l-1.5-6"/></svg>
+      </span>
+      criticalmass.in
+    </a>
+    <nav>
+      <a href="06-feed-aktiv.html">Timeline</a>
+      <a href="06e-karte.html">Karte</a>
+      <a href="06c-kalender.html">Kalender</a>
+      <a href="06l-verzeichnis.html">Städte</a>
+      <a class="on" href="#">Forum</a>
+    </nav>
+    <span class="grow"></span>
+    <a class="search" href="06j-suche.html">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="m20 20-4-4"/></svg>
+      Forum durchsuchen
+    </a>
+    <a class="upload-btn" href="06h-hochladen.html">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.2"><path d="M12 16V5m0 0 -4 4m4-4 4 4M5 19h14"/></svg>
+      Hochladen
+    </a>
+    <a class="ava mh" href="06d-profil.html">MH</a>
+  </div>
+</header>
+
+<div class="shell">
+
+  <main class="maincol">
+
+    <div class="pagehead">
+      <h1>Forum</h1>
+      <span class="sub">Diskussionen rund um die Masse — 2.140 Themen · 18.732 Beiträge</span>
+    </div>
+
+    <!-- Gerade diskutiert -->
+    <section class="box">
+      <div class="bhead">
+        <h2>Gerade diskutiert</h2>
+        <a href="#">Alle aktiven Themen →</a>
+      </div>
+      <a class="thread hot" href="#">
+        <span class="ava s lk">LK</span>
+        <span class="t">
+          <h3>Route im Juni mal Richtung Hafen?</h3>
+          <span class="meta"><span class="bchip city">Hamburg</span> Lotte · letzte Antwort vor 40 min</span>
+        </span>
+        <span class="stats"><span class="n">14</span><span class="k">Antworten</span></span>
+      </a>
+      <a class="thread hot" href="#">
+        <span class="ava s bb">b</span>
+        <span class="t">
+          <h3>Welche Musikanlage fürs Lastenrad — Erfahrungen?</h3>
+          <span class="meta"><span class="bchip">Allgemein</span> birnenblau · letzte Antwort vor 2 Std</span>
+        </span>
+        <span class="stats"><span class="n">31</span><span class="k">Antworten</span></span>
+      </a>
+      <a class="thread" href="#">
+        <span class="ava s an">A</span>
+        <span class="t">
+          <h3>Kidical Mass im Juli — wer plant mit?</h3>
+          <span class="meta"><span class="bchip city">Köln</span> Anna · letzte Antwort gestern</span>
+        </span>
+        <span class="stats"><span class="n">22</span><span class="k">Antworten</span></span>
+      </a>
+      <a class="thread" href="#">
+        <span class="ava s vh">VH</span>
+        <span class="t">
+          <h3>Corken — wie macht ihr das an großen Kreuzungen?</h3>
+          <span class="meta"><span class="bchip">Allgemein</span> velohanseat · letzte Antwort vor 2 Tagen</span>
+        </span>
+        <span class="stats"><span class="n">48</span><span class="k">Antworten</span></span>
+      </a>
+      <a class="thread" href="#">
+        <span class="ava s kk">KK</span>
+        <span class="t">
+          <h3>Erste Masse in Stirling — Tipps für den Start?</h3>
+          <span class="meta"><span class="bchip city">Stirling</span> Katrin · letzte Antwort vor 2 Tagen</span>
+        </span>
+        <span class="stats"><span class="n">9</span><span class="k">Antworten</span></span>
+      </a>
+    </section>
+
+    <!-- Boards -->
+    <div class="pagehead" style="margin-top:6px">
+      <h1 style="font-size:1.1rem">Boards</h1>
+      <span class="sub">Allgemein und je Stadt</span>
+    </div>
+    <div class="boardgrid">
+      <a class="board" href="#">
+        <span class="bh">
+          <span class="bicon" style="background:#16181c">
+            <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2"><path d="M20 12a8 8 0 1 0-3.1 6.3L20 19.5l-.8-3A8 8 0 0 0 20 12z"/></svg>
+          </span>
+          <h3>Critical Mass weltweit</h3>
+        </span>
+        <p>Grundsatzfragen, Recht (§ 27 StVO), Aktionen, Presse — alles, was mehr als eine Stadt betrifft.</p>
+        <span class="bstats"><span><b>412</b> Themen</span><span><b>5.870</b> Beiträge</span>
+          <span class="last"><span class="ava xs bb">b</span>vor 2 Std</span></span>
+      </a>
+      <a class="board" href="#">
+        <span class="bh">
+          <span class="bicon" style="background:#1e7d4f">
+            <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2"><path d="M4 17c3-1 4-7 7-7s3 5 6 5 3-3 3-3"/><circle cx="4" cy="17" r="1.6"/><circle cx="20" cy="12" r="1.6"/></svg>
+          </span>
+          <h3>Technik &amp; Ausrüstung</h3>
+        </span>
+        <p>Lastenräder, Anlagen, Licht, Anhänger — und was sonst noch rollt und blinkt.</p>
+        <span class="bstats"><span><b>238</b> Themen</span><span><b>3.104</b> Beiträge</span>
+          <span class="last"><span class="ava xs vh">V</span>gestern</span></span>
+      </a>
+      <a class="board" href="#">
+        <span class="bh">
+          <span class="bicon" style="background:var(--accent)">HH</span>
+          <h3>Board Hamburg</h3>
+        </span>
+        <p>Routen, Treffpunkte und Drumherum der Critical Mass Hamburg.</p>
+        <span class="bstats"><span><b>186</b> Themen</span><span><b>2.412</b> Beiträge</span>
+          <span class="last"><span class="ava xs lk">L</span>vor 40 min</span></span>
+      </a>
+      <a class="board" href="#">
+        <span class="bh">
+          <span class="bicon" style="background:#5a4fa0">B</span>
+          <h3>Board Berlin</h3>
+        </span>
+        <p>Mariannenplatz, Routenwünsche, Mini-Masses in den Kiezen.</p>
+        <span class="bstats"><span><b>164</b> Themen</span><span><b>1.987</b> Beiträge</span>
+          <span class="last"><span class="ava xs an">A</span>vor 5 Std</span></span>
+      </a>
+    </div>
+
+  </main>
+
+  <!-- Rail -->
+  <aside class="rail">
+    <div class="rbox">
+      <button class="newbtn">Neues Thema starten</button>
+      <p class="hint">Du brauchst nur ein criticalmass.in-Konto — keine Klarnamenpflicht.</p>
+    </div>
+
+    <div class="rbox">
+      <h4>Hausordnung <span style="font-weight:600;color:var(--dim);font-size:.76rem">· kurz</span></h4>
+      <div class="rule"><span class="nr">01</span>Freundlich bleiben — wie auf der Straße.</div>
+      <div class="rule"><span class="nr">02</span>Keine Klarnamen anderer ohne Einverständnis.</div>
+      <div class="rule"><span class="nr">03</span>Stadt-Themen ins Stadt-Board, der Rest nach „Weltweit".</div>
+    </div>
+
+    <div class="rbox">
+      <h4>Aktivste Boards <span style="font-weight:600;color:var(--dim);font-size:.76rem">· 30 Tage</span></h4>
+      <a class="toprow" href="#"><span class="bicon" style="background:var(--accent)">HH</span><b>Hamburg</b><span class="x">86 Beiträge</span></a>
+      <a class="toprow" href="#"><span class="bicon" style="background:#16181c">CM</span><b>Weltweit</b><span class="x">74 Beiträge</span></a>
+      <a class="toprow" href="#"><span class="bicon" style="background:#5a4fa0">B</span><b>Berlin</b><span class="x">52 Beiträge</span></a>
+      <a class="toprow" href="#"><span class="bicon" style="background:#0e7c82">K</span><b>Köln</b><span class="x">31 Beiträge</span></a>
+    </div>
+
+    <p class="fine">Jede Stadt bekommt automatisch ein eigenes Board, sobald sie eingetragen ist.</p>
+  </aside>
+
+</div>
+
+<!-- Mobile Tabbar -->
+<nav class="tabbar">
+  <a href="06-feed-aktiv.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M3 11.2 12 4l9 7.2M5.5 9.8V20h13V9.8"/></svg>
+    Timeline
+  </a>
+  <a href="06e-karte.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M12 21s7-6 7-11a7 7 0 0 0-14 0c0 5 7 11 7 11z"/><circle cx="12" cy="9.8" r="2.4"/></svg>
+    Karte
+  </a>
+  <a href="06h-hochladen.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M12 16V5m0 0-4 4m4-4 4 4M5 19h14"/></svg>
+    Hochladen
+  </a>
+  <a href="06c-kalender.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><rect x="3.5" y="5" width="17" height="15.5" rx="2.5"/><path d="M3.5 9.5h17M8 3v4M16 3v4"/></svg>
+    Kalender
+  </a>
+  <a href="06d-profil.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><circle cx="12" cy="8.4" r="3.4"/><path d="M5 20c.8-3.4 3.6-5.2 7-5.2s6.2 1.8 7 5.2"/></svg>
+    Profil
+  </a>
+</nav>
+
+<a class="proto-back" href="index.html">← Übersicht</a>
+
+</body>
+</html>

--- a/design-prototypes/06g-galerie.html
+++ b/design-prototypes/06g-galerie.html
@@ -1,0 +1,305 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Galerie · Maimasse Hamburg — Prototyp 6 · criticalmass.in</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@500;600&display=swap" rel="stylesheet">
+<style>
+:root {
+  --bg: #f2f3f5;
+  --card: #ffffff;
+  --line: #e3e5e8;
+  --ink: #16181c;
+  --dim: #707684;
+  --accent: #f4581c;
+  --accent-deep: #d8450e;
+  --green: #1e7d4f;
+  --sans: "Archivo", "Helvetica Neue", Arial, sans-serif;
+  --mono: "IBM Plex Mono", Menlo, monospace;
+}
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html, body { overflow-x: clip; }
+body {
+  font-family: var(--sans);
+  background: var(--bg);
+  color: var(--ink);
+  line-height: 1.5;
+  font-size: 15px;
+  padding-bottom: 70px;
+}
+a { color: inherit; text-decoration: none; }
+button { font-family: inherit; cursor: pointer; }
+
+/* ---------- Topbar ---------- */
+.top { position: sticky; top: 0; z-index: 50; background: var(--card); border-bottom: 1px solid var(--line); }
+.top-inner { max-width: 1080px; margin: 0 auto; display: flex; align-items: center; gap: 22px; padding: 0 16px; height: 56px; }
+.brand { display: flex; align-items: center; gap: 9px; font-weight: 800; font-size: 1.05rem; letter-spacing: -.01em; }
+.brand .mark { width: 28px; height: 28px; border-radius: 8px; background: var(--accent); display: grid; place-items: center; }
+.top nav { display: flex; gap: 4px; }
+.top nav a { font-weight: 600; font-size: .92rem; color: var(--dim); padding: 6px 12px; border-radius: 8px; }
+.top nav a:hover { background: #f2f3f5; color: var(--ink); }
+.top .grow { flex: 1; }
+.search { display: flex; align-items: center; gap: 8px; background: #f2f3f5; border-radius: 9px; padding: 7px 12px; color: var(--dim); font-size: .88rem; min-width: 180px; }
+.upload-btn { display: inline-flex; align-items: center; gap: 8px; background: var(--accent); color: #fff; border: 0; border-radius: 9px; font-weight: 700; font-size: .9rem; padding: 8px 14px; }
+.upload-btn:hover { background: var(--accent-deep); }
+.ava { width: 34px; height: 34px; border-radius: 99px; flex: none; display: grid; place-items: center; font-weight: 800; font-size: .78rem; color: #fff; }
+.ava.xs { width: 22px; height: 22px; font-size: .56rem; border: 2px solid #fff; }
+.ava.mh { background: #3d4350; }
+.ava.sj { background: #8c5e2a; }
+.ava.kk { background: #0e7c82; }
+.ava.vh { background: #2b6cb0; }
+
+/* ---------- Layout ---------- */
+.shell { max-width: 1080px; margin: 0 auto; display: grid; grid-template-columns: minmax(0, 1fr) 320px; gap: 24px; padding: 22px 16px 40px; align-items: start; }
+.maincol { display: flex; flex-direction: column; gap: 18px; min-width: 0; }
+.crumbs { grid-column: 1 / -1; font-size: .84rem; color: var(--dim); display: flex; gap: 7px; flex-wrap: wrap; }
+.crumbs a:hover { color: var(--ink); text-decoration: underline; }
+.crumbs b { color: var(--ink); font-weight: 600; }
+
+/* ---------- Kopf ---------- */
+.galhead { background: var(--card); border: 1px solid var(--line); border-radius: 14px; overflow: hidden; }
+.galhead .inner { padding: 16px 18px 14px; display: flex; gap: 14px; align-items: flex-start; flex-wrap: wrap; }
+.galhead .when { font-family: var(--mono); font-size: .72rem; text-transform: uppercase; letter-spacing: .14em; color: var(--accent); font-weight: 600; }
+.galhead h1 { font-size: 1.45rem; font-weight: 800; letter-spacing: -.02em; }
+.galhead .sub { color: var(--dim); font-size: .9rem; margin-top: 2px; }
+.galhead .sub a { font-weight: 600; color: var(--ink); }
+.galhead .sub a:hover { color: var(--accent); }
+.galhead .acts { margin-left: auto; display: flex; gap: 8px; flex-wrap: wrap; }
+.kbtn { display: inline-flex; align-items: center; gap: 7px; border: 1px solid var(--line); background: var(--card); border-radius: 9px; padding: 8px 15px; font-weight: 700; font-size: .88rem; color: var(--ink); }
+.kbtn:hover { border-color: #c9cdd3; }
+.kbtn.solid { background: var(--accent); border-color: var(--accent); color: #fff; }
+.kbtn.solid:hover { background: var(--accent-deep); }
+.statband { display: flex; border-top: 1px solid var(--line); background: #fafbfc; }
+.statband > div { flex: 1; padding: 12px 18px; }
+.statband > div + div { border-left: 1px solid var(--line); }
+.statband .v { font-family: var(--mono); font-weight: 600; font-size: 1.15rem; }
+.statband .k { font-size: .7rem; color: var(--dim); text-transform: uppercase; letter-spacing: .08em; margin-top: 1px; }
+
+/* ---------- Raster ---------- */
+.grid { columns: 3; column-gap: 10px; }
+.shot {
+  position: relative;
+  display: block;
+  border-radius: 12px;
+  overflow: hidden;
+  margin-bottom: 10px;
+  break-inside: avoid;
+  border: 1px solid var(--line);
+}
+.shot::after { content: ""; position: absolute; inset: 0; background-image: radial-gradient(rgba(22,24,28,.32) 1px, transparent 1.4px); background-size: 4px 4px; opacity: .45; }
+.shot .ph { display: block; width: 100%; }
+.shot .credit {
+  position: absolute;
+  left: 8px; bottom: 8px;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: rgba(22,24,28,.78);
+  color: #fff;
+  font-size: .7rem;
+  font-weight: 700;
+  border-radius: 99px;
+  padding: 3px 10px 3px 4px;
+}
+.shot:hover { border-color: var(--accent); }
+.shot .ph { aspect-ratio: 4/3; }
+.shot.tall .ph { aspect-ratio: 3/4; }
+.shot.wide .ph { aspect-ratio: 16/9; }
+.g1 { background: linear-gradient(140deg, #b9cdd8, #54707f); }
+.g2 { background: linear-gradient(150deg, #d8cba8, #97804c); }
+.g3 { background: linear-gradient(160deg, #c5b8d6, #6a5a86); }
+.g4 { background: linear-gradient(130deg, #c2d3ba, #5d8262); }
+.g5 { background: linear-gradient(150deg, #d8b8a8, #97614c); }
+.g6 { background: linear-gradient(140deg, #b6c4d8, #58789c); }
+.g7 { background: linear-gradient(155deg, #d6c4b8, #8c6e56); }
+.g8 { background: linear-gradient(135deg, #bfd0c8, #5e7d70); }
+.g9 { background: linear-gradient(145deg, #ccc0d8, #7a6294); }
+.loadmore { text-align: center; }
+.loadmore .kbtn { padding: 10px 22px; }
+
+/* ---------- Rail ---------- */
+.rail { display: flex; flex-direction: column; gap: 18px; position: sticky; top: 76px; }
+.rbox { background: var(--card); border: 1px solid var(--line); border-radius: 14px; padding: 16px 18px; }
+.rbox h4 { font-size: .95rem; font-weight: 800; margin-bottom: 10px; }
+.galrow { display: flex; gap: 11px; align-items: center; padding: 7px 6px; border-radius: 10px; }
+.galrow:hover { background: #f6f7f8; }
+.galrow .thumb { width: 52px; height: 40px; border-radius: 8px; flex: none; position: relative; overflow: hidden; }
+.galrow .thumb::after { content: ""; position: absolute; inset: 0; background-image: radial-gradient(rgba(22,24,28,.3) 1px, transparent 1.4px); background-size: 4px 4px; opacity: .4; }
+.galrow b { font-weight: 700; font-size: .9rem; display: block; line-height: 1.25; }
+.galrow .x { font-size: .76rem; color: var(--dim); }
+.privacy { display: flex; gap: 10px; align-items: baseline; padding: 5px 0; font-size: .86rem; color: #3c4048; }
+.privacy .nr { font-family: var(--mono); font-size: .72rem; font-weight: 600; color: var(--accent); flex: none; }
+.fine { font-size: .75rem; color: var(--dim); line-height: 1.6; padding: 0 6px; }
+
+/* ---------- Mobil ---------- */
+.tabbar { display: none; }
+.proto-back { position: fixed; bottom: 14px; right: 14px; z-index: 60; font-size: .75rem; font-weight: 700; background: var(--card); border: 1px solid var(--line); border-radius: 99px; padding: 6px 12px; color: var(--dim); }
+@media (max-width: 1000px) {
+  .shell { grid-template-columns: minmax(0, 1fr); }
+  .rail { position: static; }
+  .top nav, .search { display: none; }
+  .galhead .acts { margin-left: 0; }
+  .grid { columns: 2; }
+  .statband { flex-wrap: wrap; }
+  .statband > div { flex: 1 1 40%; border-top: 1px solid var(--line); margin-top: -1px; }
+  .tabbar {
+    display: flex; position: fixed; bottom: 0; left: 0; right: 0; z-index: 55;
+    background: rgba(255,255,255,.96); backdrop-filter: blur(10px);
+    border-top: 1px solid var(--line);
+    padding: 6px 8px calc(6px + env(safe-area-inset-bottom));
+  }
+  .tabbar a { flex: 1; display: flex; flex-direction: column; align-items: center; gap: 2px; font-size: .62rem; font-weight: 700; color: var(--dim); padding: 4px 0; }
+  .tabbar a svg { stroke: currentColor; }
+  .proto-back { bottom: 76px; }
+}
+</style>
+</head>
+<body>
+
+<header class="top">
+  <div class="top-inner">
+    <a class="brand" href="06-feed-aktiv.html">
+      <span class="mark">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.4"><circle cx="6" cy="17" r="3.2"/><circle cx="18" cy="17" r="3.2"/><path d="M6 17 9.5 9H8m1.5 0h5L18 17M12 17l-1.5-6"/></svg>
+      </span>
+      criticalmass.in
+    </a>
+    <nav>
+      <a href="06-feed-aktiv.html">Timeline</a>
+      <a href="06e-karte.html">Karte</a>
+      <a href="06c-kalender.html">Kalender</a>
+      <a href="06l-verzeichnis.html">Städte</a>
+      <a href="06f-forum.html">Forum</a>
+    </nav>
+    <span class="grow"></span>
+    <a class="search" href="06j-suche.html">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="m20 20-4-4"/></svg>
+      Stadt oder Tour suchen
+    </a>
+    <a class="upload-btn" href="06h-hochladen.html">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.2"><path d="M12 16V5m0 0 -4 4m4-4 4 4M5 19h14"/></svg>
+      Hochladen
+    </a>
+    <a class="ava mh" href="06d-profil.html">MH</a>
+  </div>
+</header>
+
+<div class="shell">
+
+  <p class="crumbs">
+    <a href="06-feed-aktiv.html">Timeline</a> ›
+    <a href="06b-stadt.html">Hamburg</a> ›
+    <a href="#">Maimasse · 29. Mai 2026</a> ›
+    <b>Galerie</b>
+  </p>
+
+  <main class="maincol">
+
+    <section class="galhead">
+      <div class="inner">
+        <div>
+          <span class="when">Galerie · Tour vom 29. Mai 2026</span>
+          <h1>Maimasse Hamburg</h1>
+          <p class="sub">Abendlicht, volle Kreuzungen, ~ 2.400 Räder · <a href="06b-stadt.html">Stadtseite →</a></p>
+        </div>
+        <span class="acts">
+          <a class="kbtn solid" href="06h-hochladen.html">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.2"><path d="M12 16V5m0 0-4 4m4-4 4 4M5 19h14"/></svg>
+            Eigene Fotos dazu
+          </a>
+          <button class="kbtn">Diashow</button>
+        </span>
+      </div>
+      <div class="statband">
+        <div><div class="v">23</div><div class="k">Fotos</div></div>
+        <div><div class="v">6</div><div class="k">Fotograf:innen</div></div>
+        <div><div class="v">57</div><div class="k">× geklingelt</div></div>
+        <div><div class="v">CC BY-NC</div><div class="k">Standard-Lizenz</div></div>
+      </div>
+    </section>
+
+    <div class="grid">
+      <a class="shot wide" href="#"><span class="ph g1"></span><span class="credit"><span class="ava xs sj">SR</span>stadtrand</span></a>
+      <a class="shot tall" href="#"><span class="ph g2"></span><span class="credit"><span class="ava xs kk">K</span>Katrin</span></a>
+      <a class="shot" href="#"><span class="ph g3"></span><span class="credit"><span class="ava xs mh">M</span>malte</span></a>
+      <a class="shot" href="#"><span class="ph g4"></span><span class="credit"><span class="ava xs sj">SR</span>stadtrand</span></a>
+      <a class="shot tall" href="#"><span class="ph g5"></span><span class="credit"><span class="ava xs vh">V</span>velohanseat</span></a>
+      <a class="shot wide" href="#"><span class="ph g6"></span><span class="credit"><span class="ava xs sj">SR</span>stadtrand</span></a>
+      <a class="shot" href="#"><span class="ph g7"></span><span class="credit"><span class="ava xs kk">K</span>Katrin</span></a>
+      <a class="shot" href="#"><span class="ph g8"></span><span class="credit"><span class="ava xs mh">M</span>malte</span></a>
+      <a class="shot tall" href="#"><span class="ph g9"></span><span class="credit"><span class="ava xs vh">V</span>velohanseat</span></a>
+    </div>
+
+    <div class="loadmore">
+      <button class="kbtn">14 weitere Fotos laden</button>
+    </div>
+
+  </main>
+
+  <!-- Rail -->
+  <aside class="rail">
+    <div class="rbox">
+      <h4>Hausordnung für Fotos</h4>
+      <div class="privacy"><span class="nr">01</span>Gesichter Unbeteiligter? Verpixeln geht direkt beim Upload.</div>
+      <div class="privacy"><span class="nr">02</span>Kennzeichen werden automatisch erkannt und unkenntlich gemacht.</div>
+      <div class="privacy"><span class="nr">03</span>Du bestimmst die Lizenz — Standard ist CC BY-NC.</div>
+    </div>
+
+    <div class="rbox">
+      <h4>Weitere Galerien</h4>
+      <a class="galrow" href="#">
+        <span class="thumb g4"></span>
+        <span><b>Aprilmasse Hamburg</b><span class="x">24.04.2026 · 11 Fotos</span></span>
+      </a>
+      <a class="galrow" href="#">
+        <span class="thumb g6"></span>
+        <span><b>CM Bonn am Rheinufer</b><span class="x">29.05.2026 · 4 Fotos</span></span>
+      </a>
+      <a class="galrow" href="#">
+        <span class="thumb g2"></span>
+        <span><b>Wintermasse Berlin</b><span class="x">28.11.2025 · 9 Fotos</span></span>
+      </a>
+      <a class="galrow" href="#">
+        <span class="thumb g9"></span>
+        <span><b>Norderstedt im Juni</b><span class="x">05.06.2026 · 1 Foto</span></span>
+      </a>
+    </div>
+
+    <p class="fine">Alle Fotos bleiben bei criticalmass.in gespeichert — kein externer Dienst,
+    Original-Dateien jederzeit als Export verfügbar.</p>
+  </aside>
+
+</div>
+
+<!-- Mobile Tabbar -->
+<nav class="tabbar">
+  <a href="06-feed-aktiv.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M3 11.2 12 4l9 7.2M5.5 9.8V20h13V9.8"/></svg>
+    Timeline
+  </a>
+  <a href="06e-karte.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M12 21s7-6 7-11a7 7 0 0 0-14 0c0 5 7 11 7 11z"/><circle cx="12" cy="9.8" r="2.4"/></svg>
+    Karte
+  </a>
+  <a href="06h-hochladen.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M12 16V5m0 0-4 4m4-4 4 4M5 19h14"/></svg>
+    Hochladen
+  </a>
+  <a href="06c-kalender.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><rect x="3.5" y="5" width="17" height="15.5" rx="2.5"/><path d="M3.5 9.5h17M8 3v4M16 3v4"/></svg>
+    Kalender
+  </a>
+  <a href="06d-profil.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><circle cx="12" cy="8.4" r="3.4"/><path d="M5 20c.8-3.4 3.6-5.2 7-5.2s6.2 1.8 7 5.2"/></svg>
+    Profil
+  </a>
+</nav>
+
+<a class="proto-back" href="index.html">← Übersicht</a>
+
+</body>
+</html>

--- a/design-prototypes/06h-hochladen.html
+++ b/design-prototypes/06h-hochladen.html
@@ -1,0 +1,366 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Hochladen — Prototyp 6 · criticalmass.in</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@500;600&display=swap" rel="stylesheet">
+<style>
+:root {
+  --bg: #f2f3f5;
+  --card: #ffffff;
+  --line: #e3e5e8;
+  --ink: #16181c;
+  --dim: #707684;
+  --accent: #f4581c;
+  --accent-deep: #d8450e;
+  --green: #1e7d4f;
+  --amber: #b07814;
+  --sans: "Archivo", "Helvetica Neue", Arial, sans-serif;
+  --mono: "IBM Plex Mono", Menlo, monospace;
+}
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html, body { overflow-x: clip; }
+body {
+  font-family: var(--sans);
+  background: var(--bg);
+  color: var(--ink);
+  line-height: 1.5;
+  font-size: 15px;
+  padding-bottom: 70px;
+}
+a { color: inherit; text-decoration: none; }
+button { font-family: inherit; cursor: pointer; }
+
+/* ---------- Topbar ---------- */
+.top { position: sticky; top: 0; z-index: 50; background: var(--card); border-bottom: 1px solid var(--line); }
+.top-inner { max-width: 1080px; margin: 0 auto; display: flex; align-items: center; gap: 22px; padding: 0 16px; height: 56px; }
+.brand { display: flex; align-items: center; gap: 9px; font-weight: 800; font-size: 1.05rem; letter-spacing: -.01em; }
+.brand .mark { width: 28px; height: 28px; border-radius: 8px; background: var(--accent); display: grid; place-items: center; }
+.top nav { display: flex; gap: 4px; }
+.top nav a { font-weight: 600; font-size: .92rem; color: var(--dim); padding: 6px 12px; border-radius: 8px; }
+.top nav a:hover { background: #f2f3f5; color: var(--ink); }
+.top .grow { flex: 1; }
+.ava { width: 34px; height: 34px; border-radius: 99px; flex: none; display: grid; place-items: center; font-weight: 800; font-size: .78rem; color: #fff; }
+.ava.mh { background: #3d4350; }
+
+/* ---------- Layout ---------- */
+.shell { max-width: 1080px; margin: 0 auto; display: grid; grid-template-columns: minmax(0, 1fr) 340px; gap: 24px; padding: 22px 16px 40px; align-items: start; }
+.maincol { display: flex; flex-direction: column; gap: 18px; min-width: 0; }
+.pagehead h1 { font-size: 1.45rem; font-weight: 800; letter-spacing: -.02em; }
+.pagehead .sub { color: var(--dim); font-size: .88rem; margin-top: 2px; }
+
+/* ---------- Typ-Tabs ---------- */
+.tabs { display: flex; gap: 2px; background: var(--card); border: 1px solid var(--line); border-radius: 12px; padding: 4px; }
+.tabs a { flex: 1; display: flex; align-items: center; justify-content: center; gap: 8px; font-weight: 700; font-size: .9rem; color: var(--dim); border-radius: 9px; padding: 9px 12px; }
+.tabs a.on { background: #f2f3f5; color: var(--ink); }
+.tabs a:hover:not(.on) { color: var(--ink); }
+.tabs svg { stroke: currentColor; }
+
+/* ---------- Dropzone ---------- */
+.drop {
+  background: var(--card);
+  border: 2px dashed #c9cdd3;
+  border-radius: 16px;
+  padding: 44px 24px;
+  text-align: center;
+  transition: border-color .15s ease;
+}
+.drop:hover { border-color: var(--accent); }
+.drop .ic {
+  width: 58px; height: 58px;
+  margin: 0 auto 14px;
+  border-radius: 18px;
+  background: #fff4ee;
+  display: grid;
+  place-items: center;
+}
+.drop h2 { font-size: 1.1rem; font-weight: 800; }
+.drop p { color: var(--dim); font-size: .88rem; margin-top: 4px; }
+.drop .kbtn { margin-top: 16px; }
+.kbtn { display: inline-flex; align-items: center; gap: 7px; border: 1px solid var(--line); background: var(--card); border-radius: 9px; padding: 8px 15px; font-weight: 700; font-size: .88rem; color: var(--ink); }
+.kbtn:hover { border-color: #c9cdd3; }
+.kbtn.solid { background: var(--accent); border-color: var(--accent); color: #fff; }
+.kbtn.solid:hover { background: var(--accent-deep); }
+.kbtn.sm { padding: 6px 12px; font-size: .82rem; }
+
+/* ---------- Upload-Liste ---------- */
+.box { background: var(--card); border: 1px solid var(--line); border-radius: 14px; overflow: hidden; }
+.box .bhead { display: flex; align-items: baseline; padding: 14px 18px 12px; border-bottom: 1px solid var(--line); }
+.box .bhead h2 { font-size: 1rem; font-weight: 800; }
+.box .bhead span { margin-left: auto; font-family: var(--mono); font-size: .74rem; color: var(--dim); }
+.file { padding: 14px 18px; border-bottom: 1px solid var(--line); }
+.file:last-child { border-bottom: 0; }
+.file .frow { display: flex; gap: 12px; align-items: center; }
+.ficon {
+  width: 40px; height: 40px;
+  border-radius: 11px;
+  display: grid;
+  place-items: center;
+  flex: none;
+  font-family: var(--mono);
+  font-size: .6rem;
+  font-weight: 600;
+  color: #fff;
+  background: #3d4350;
+}
+.ficon.fit { background: #5a4fa0; }
+.file .fname { min-width: 0; }
+.file .fname b { font-weight: 700; font-size: .94rem; display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.file .fname .fmeta { font-size: .78rem; color: var(--dim); font-family: var(--mono); }
+.scta { margin-left: auto; flex: none; display: flex; gap: 8px; align-items: center; }
+.status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: .76rem;
+  font-weight: 800;
+  border-radius: 99px;
+  padding: 4px 11px;
+  white-space: nowrap;
+}
+.status.ok { background: #e8f3ed; color: var(--green); }
+.status.check { background: #fdf3e0; color: var(--amber); }
+.status.parked { background: #f2f3f5; color: var(--dim); }
+.assign {
+  margin: 12px 0 0 52px;
+  border: 1px solid var(--line);
+  border-radius: 11px;
+  padding: 11px 14px;
+  font-size: .88rem;
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+  background: #fafbfc;
+}
+.assign .q { color: var(--dim); }
+.assign b { font-weight: 700; }
+.assign .opts { display: flex; gap: 8px; flex-wrap: wrap; }
+.assign .opt {
+  border: 1px solid var(--line);
+  background: var(--card);
+  border-radius: 99px;
+  padding: 5px 13px;
+  font-size: .82rem;
+  font-weight: 700;
+}
+.assign .opt:hover { border-color: var(--accent); color: var(--accent); }
+.note-fit {
+  margin: 8px 0 0 52px;
+  font-size: .78rem;
+  color: var(--dim);
+  display: flex;
+  gap: 7px;
+  align-items: baseline;
+}
+.note-fit .tick { color: var(--green); font-weight: 800; }
+
+/* ---------- Rail ---------- */
+.rail { display: flex; flex-direction: column; gap: 18px; position: sticky; top: 76px; }
+.rbox { background: var(--card); border: 1px solid var(--line); border-radius: 14px; padding: 16px 18px; }
+.rbox h4 { font-size: .95rem; font-weight: 800; margin-bottom: 10px; }
+.step { display: flex; gap: 10px; align-items: baseline; padding: 5px 0; font-size: .88rem; color: #3c4048; }
+.step .nr { font-family: var(--mono); font-size: .72rem; font-weight: 600; color: var(--accent); flex: none; }
+.step b { font-weight: 700; }
+.lastrow { display: flex; gap: 10px; align-items: baseline; padding: 7px 6px; border-radius: 8px; font-size: .88rem; }
+.lastrow:hover { background: #f6f7f8; }
+.lastrow .d { font-family: var(--mono); font-size: .76rem; color: var(--dim); flex: none; width: 70px; }
+.lastrow b { font-weight: 700; }
+.lastrow .x { margin-left: auto; color: var(--dim); font-size: .76rem; }
+.fine { font-size: .75rem; color: var(--dim); line-height: 1.6; padding: 0 6px; }
+
+/* ---------- Mobil ---------- */
+.tabbar { display: none; }
+.proto-back { position: fixed; bottom: 14px; right: 14px; z-index: 60; font-size: .75rem; font-weight: 700; background: var(--card); border: 1px solid var(--line); border-radius: 99px; padding: 6px 12px; color: var(--dim); }
+@media (max-width: 1000px) {
+  .shell { grid-template-columns: minmax(0, 1fr); }
+  .rail { position: static; }
+  .top nav { display: none; }
+  .scta { margin-left: 0; }
+  .file .frow { flex-wrap: wrap; }
+  .assign, .note-fit { margin-left: 0; }
+  .tabbar {
+    display: flex; position: fixed; bottom: 0; left: 0; right: 0; z-index: 55;
+    background: rgba(255,255,255,.96); backdrop-filter: blur(10px);
+    border-top: 1px solid var(--line);
+    padding: 6px 8px calc(6px + env(safe-area-inset-bottom));
+  }
+  .tabbar a { flex: 1; display: flex; flex-direction: column; align-items: center; gap: 2px; font-size: .62rem; font-weight: 700; color: var(--dim); padding: 4px 0; }
+  .tabbar a svg { stroke: currentColor; }
+  .tabbar a.on { color: var(--accent); }
+  .proto-back { bottom: 76px; }
+}
+</style>
+</head>
+<body>
+
+<header class="top">
+  <div class="top-inner">
+    <a class="brand" href="06-feed-aktiv.html">
+      <span class="mark">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.4"><circle cx="6" cy="17" r="3.2"/><circle cx="18" cy="17" r="3.2"/><path d="M6 17 9.5 9H8m1.5 0h5L18 17M12 17l-1.5-6"/></svg>
+      </span>
+      criticalmass.in
+    </a>
+    <nav>
+      <a href="06-feed-aktiv.html">Timeline</a>
+      <a href="06e-karte.html">Karte</a>
+      <a href="06c-kalender.html">Kalender</a>
+      <a href="06l-verzeichnis.html">Städte</a>
+      <a href="06f-forum.html">Forum</a>
+    </nav>
+    <span class="grow"></span>
+    <a class="ava mh" href="06d-profil.html">MH</a>
+  </div>
+</header>
+
+<div class="shell">
+
+  <main class="maincol">
+
+    <div class="pagehead">
+      <h1>Hochladen</h1>
+      <p class="sub">Tracks, Fotos oder Schätzungen — alles landet bei der passenden Tour.</p>
+    </div>
+
+    <nav class="tabs">
+      <a class="on" href="#">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M4 17c3-1 4-7 7-7s3 5 6 5 3-3 3-3"/><circle cx="4" cy="17" r="1.6"/><circle cx="20" cy="12" r="1.6"/></svg>
+        Tracks (GPX/FIT)
+      </a>
+      <a href="06g-galerie.html">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke-width="2"><rect x="3.5" y="5.5" width="17" height="13.5" rx="2.5"/><circle cx="9" cy="10.5" r="1.6"/><path d="m4.5 17 4.5-4 3.5 3 3-2.5 4 3.5"/></svg>
+        Fotos
+      </a>
+      <a href="#">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M5 20V9M12 20V4M19 20v-7"/></svg>
+        Schätzung
+      </a>
+    </nav>
+
+    <!-- Dropzone -->
+    <div class="drop">
+      <span class="ic">
+        <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="#f4581c" stroke-width="2"><path d="M12 16V5m0 0-4 4m4-4 4 4"/><path d="M4 16.5V18a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-1.5"/></svg>
+      </span>
+      <h2>GPX- oder FIT-Dateien hierher ziehen</h2>
+      <p>Auch mehrere auf einmal — jede Datei wird einzeln hochgeladen und zugeordnet.</p>
+      <button class="kbtn solid">Dateien auswählen</button>
+    </div>
+
+    <!-- Uploads -->
+    <section class="box">
+      <div class="bhead">
+        <h2>Deine Uploads</h2>
+        <span>3 Dateien · 2,4 MB</span>
+      </div>
+
+      <div class="file">
+        <div class="frow">
+          <span class="ficon fit">FIT</span>
+          <span class="fname">
+            <b>2026-05-29-feierabend.fit</b>
+            <span class="fmeta">812 KB · hochgeladen 21:48</span>
+          </span>
+          <span class="scta">
+            <span class="status ok">✓ Zugeordnet</span>
+            <a class="kbtn sm" href="06b-stadt.html">Ansehen</a>
+          </span>
+        </div>
+        <p class="note-fit"><span class="tick">✓</span>FIT automatisch in GPX umgewandelt ·
+        erkannt: <b style="color:var(--ink)">Maimasse Hamburg, 29.05.2026</b> (Datum, Start und Route passen)</p>
+      </div>
+
+      <div class="file">
+        <div class="frow">
+          <span class="ficon">GPX</span>
+          <span class="fname">
+            <b>berlin-november.gpx</b>
+            <span class="fmeta">1,1 MB · hochgeladen 21:49</span>
+          </span>
+          <span class="scta">
+            <span class="status check">? Bitte prüfen</span>
+          </span>
+        </div>
+        <div class="assign">
+          <span class="q">Zwei Touren kommen infrage — welche war's?</span>
+          <span class="opts">
+            <button class="opt">CM Berlin · 28.11.2025</button>
+            <button class="opt">CM Treptow-Köpenick · 28.11.2025</button>
+            <button class="opt" style="color:var(--dim)">Keine davon</button>
+          </span>
+        </div>
+      </div>
+
+      <div class="file">
+        <div class="frow">
+          <span class="ficon">GPX</span>
+          <span class="fname">
+            <b>tour-irgendwann.gpx</b>
+            <span class="fmeta">486 KB · hochgeladen 21:49</span>
+          </span>
+          <span class="scta">
+            <span class="status parked">geparkt</span>
+            <button class="kbtn sm">Tour wählen</button>
+          </span>
+        </div>
+        <p class="note-fit">Keine passende Tour gefunden — der Track wartet in deinem Profil,
+        bis du ihn zuordnest oder löschst.</p>
+      </div>
+    </section>
+
+  </main>
+
+  <!-- Rail -->
+  <aside class="rail">
+    <div class="rbox">
+      <h4>So funktioniert die Zuordnung</h4>
+      <div class="step"><span class="nr">01</span><span><b>Hochladen.</b> FIT-Dateien werden automatisch zu GPX normalisiert.</span></div>
+      <div class="step"><span class="nr">02</span><span><b>Abgleich.</b> Datum, Startpunkt und Strecke werden mit allen Touren verglichen.</span></div>
+      <div class="step"><span class="nr">03</span><span><b>Zuordnung.</b> Passt alles eindeutig, landet der Track direkt an der Tour — sonst fragen wir nach.</span></div>
+    </div>
+
+    <div class="rbox">
+      <h4>Deine letzten Uploads</h4>
+      <a class="lastrow" href="#"><span class="d">29.05.</span><b>Maimasse Hamburg</b><span class="x">21,7 km</span></a>
+      <a class="lastrow" href="#"><span class="d">24.04.</span><b>Aprilmasse Hamburg</b><span class="x">18,9 km</span></a>
+      <a class="lastrow" href="#"><span class="d">27.03.</span><b>CM Lüneburg</b><span class="x">14,2 km</span></a>
+    </div>
+
+    <p class="fine">Dein Track gehört dir: jederzeit als GPX exportieren oder löschen —
+    ohne Rückfrage, ohne Frist. Es gibt keinen Umweg über Drittanbieter.</p>
+  </aside>
+
+</div>
+
+<!-- Mobile Tabbar -->
+<nav class="tabbar">
+  <a href="06-feed-aktiv.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M3 11.2 12 4l9 7.2M5.5 9.8V20h13V9.8"/></svg>
+    Timeline
+  </a>
+  <a href="06e-karte.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M12 21s7-6 7-11a7 7 0 0 0-14 0c0 5 7 11 7 11z"/><circle cx="12" cy="9.8" r="2.4"/></svg>
+    Karte
+  </a>
+  <a class="on" href="#">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M12 16V5m0 0-4 4m4-4 4 4M5 19h14"/></svg>
+    Hochladen
+  </a>
+  <a href="06c-kalender.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><rect x="3.5" y="5" width="17" height="15.5" rx="2.5"/><path d="M3.5 9.5h17M8 3v4M16 3v4"/></svg>
+    Kalender
+  </a>
+  <a href="06d-profil.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><circle cx="12" cy="8.4" r="3.4"/><path d="M5 20c.8-3.4 3.6-5.2 7-5.2s6.2 1.8 7 5.2"/></svg>
+    Profil
+  </a>
+</nav>
+
+<a class="proto-back" href="index.html">← Übersicht</a>
+
+</body>
+</html>

--- a/design-prototypes/06i-statistik.html
+++ b/design-prototypes/06i-statistik.html
@@ -1,0 +1,254 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Statistik — Prototyp 6 · criticalmass.in</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@500;600&display=swap" rel="stylesheet">
+<style>
+:root {
+  --bg: #f2f3f5;
+  --card: #ffffff;
+  --line: #e3e5e8;
+  --ink: #16181c;
+  --dim: #707684;
+  --accent: #f4581c;
+  --accent-deep: #d8450e;
+  --green: #1e7d4f;
+  --sans: "Archivo", "Helvetica Neue", Arial, sans-serif;
+  --mono: "IBM Plex Mono", Menlo, monospace;
+}
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html, body { overflow-x: clip; }
+body { font-family: var(--sans); background: var(--bg); color: var(--ink); line-height: 1.5; font-size: 15px; padding-bottom: 70px; }
+a { color: inherit; text-decoration: none; }
+button { font-family: inherit; cursor: pointer; }
+
+.top { position: sticky; top: 0; z-index: 50; background: var(--card); border-bottom: 1px solid var(--line); }
+.top-inner { max-width: 1080px; margin: 0 auto; display: flex; align-items: center; gap: 22px; padding: 0 16px; height: 56px; }
+.brand { display: flex; align-items: center; gap: 9px; font-weight: 800; font-size: 1.05rem; letter-spacing: -.01em; }
+.brand .mark { width: 28px; height: 28px; border-radius: 8px; background: var(--accent); display: grid; place-items: center; }
+.top nav { display: flex; gap: 4px; }
+.top nav a { font-weight: 600; font-size: .92rem; color: var(--dim); padding: 6px 12px; border-radius: 8px; }
+.top nav a:hover { background: #f2f3f5; color: var(--ink); }
+.top .grow { flex: 1; }
+.search { display: flex; align-items: center; gap: 8px; background: #f2f3f5; border-radius: 9px; padding: 7px 12px; color: var(--dim); font-size: .88rem; min-width: 180px; }
+.upload-btn { display: inline-flex; align-items: center; gap: 8px; background: var(--accent); color: #fff; border: 0; border-radius: 9px; font-weight: 700; font-size: .9rem; padding: 8px 14px; }
+.ava { width: 34px; height: 34px; border-radius: 99px; flex: none; display: grid; place-items: center; font-weight: 800; font-size: .78rem; color: #fff; }
+.ava.mh { background: #3d4350; }
+
+.shell { max-width: 1080px; margin: 0 auto; display: grid; grid-template-columns: minmax(0, 1fr) 340px; gap: 24px; padding: 22px 16px 40px; align-items: start; }
+.maincol { display: flex; flex-direction: column; gap: 18px; min-width: 0; }
+.pagehead h1 { font-size: 1.45rem; font-weight: 800; letter-spacing: -.02em; }
+.pagehead .sub { color: var(--dim); font-size: .88rem; margin-top: 2px; }
+
+.tabs { display: flex; gap: 2px; background: var(--card); border: 1px solid var(--line); border-radius: 12px; padding: 4px; overflow-x: auto; }
+.tabs a { flex: 1; text-align: center; font-weight: 700; font-size: .88rem; color: var(--dim); border-radius: 9px; padding: 8px 12px; white-space: nowrap; }
+.tabs a.on { background: #f2f3f5; color: var(--ink); }
+.tabs a:hover:not(.on) { color: var(--ink); }
+
+.box { background: var(--card); border: 1px solid var(--line); border-radius: 14px; overflow: hidden; }
+.box .bhead { display: flex; align-items: baseline; padding: 14px 18px 12px; }
+.box .bhead h2 { font-size: 1rem; font-weight: 800; }
+.box .bhead span { margin-left: auto; font-family: var(--mono); font-size: .72rem; color: var(--dim); }
+.statband { display: flex; border-top: 1px solid var(--line); background: #fafbfc; flex-wrap: wrap; }
+.statband > div { flex: 1 1 25%; padding: 14px 18px; }
+.statband > div + div { border-left: 1px solid var(--line); }
+.statband .v { font-family: var(--mono); font-weight: 600; font-size: 1.35rem; }
+.statband .k { font-size: .7rem; color: var(--dim); text-transform: uppercase; letter-spacing: .08em; margin-top: 1px; }
+
+.chartwrap { padding: 8px 12px 14px; }
+svg.line { width: 100%; height: auto; display: block; }
+
+.rank { padding: 4px 10px 12px; }
+.rankrow { display: grid; grid-template-columns: 26px 1fr auto; gap: 10px; align-items: center; padding: 7px 8px; border-radius: 8px; font-size: .94rem; }
+.rankrow:hover { background: #f6f7f8; }
+.rankrow .nr { font-family: var(--mono); font-size: .8rem; color: var(--dim); }
+.rankrow .city { font-weight: 700; }
+.rankrow .bar { height: 5px; border-radius: 4px; background: #ffe0d1; position: relative; margin-top: 5px; }
+.rankrow .bar i { position: absolute; inset: 0 auto 0 0; border-radius: 4px; background: var(--accent); }
+.rankrow .n { font-family: var(--mono); font-size: .88rem; font-weight: 600; }
+.rank .note { font-size: .76rem; color: var(--dim); padding: 8px; }
+
+.rail { display: flex; flex-direction: column; gap: 18px; position: sticky; top: 76px; }
+.rbox { background: var(--card); border: 1px solid var(--line); border-radius: 14px; padding: 16px 18px; }
+.rbox h4 { font-size: .95rem; font-weight: 800; margin-bottom: 10px; }
+.rec { display: flex; gap: 12px; padding: 8px 0; border-bottom: 1px solid var(--line); align-items: baseline; }
+.rec:last-child { border-bottom: 0; }
+.rec .v { font-family: var(--mono); font-weight: 600; font-size: 1.05rem; color: var(--accent); flex: none; min-width: 74px; }
+.rec .t b { font-weight: 700; display: block; font-size: .9rem; }
+.rec .t span { font-size: .78rem; color: var(--dim); }
+.fine { font-size: .75rem; color: var(--dim); line-height: 1.6; padding: 0 6px; }
+
+.tabbar { display: none; }
+.proto-back { position: fixed; bottom: 14px; right: 14px; z-index: 60; font-size: .75rem; font-weight: 700; background: var(--card); border: 1px solid var(--line); border-radius: 99px; padding: 6px 12px; color: var(--dim); }
+@media (max-width: 1000px) {
+  .shell { grid-template-columns: minmax(0, 1fr); }
+  .rail { position: static; }
+  .top nav, .search { display: none; }
+  .statband > div { flex: 1 1 40%; border-top: 1px solid var(--line); margin-top: -1px; }
+  .tabbar { display: flex; position: fixed; bottom: 0; left: 0; right: 0; z-index: 55; background: rgba(255,255,255,.96); backdrop-filter: blur(10px); border-top: 1px solid var(--line); padding: 6px 8px calc(6px + env(safe-area-inset-bottom)); }
+  .tabbar a { flex: 1; display: flex; flex-direction: column; align-items: center; gap: 2px; font-size: .62rem; font-weight: 700; color: var(--dim); padding: 4px 0; }
+  .tabbar a svg { stroke: currentColor; }
+  .proto-back { bottom: 76px; }
+}
+</style>
+</head>
+<body>
+
+<header class="top">
+  <div class="top-inner">
+    <a class="brand" href="06-feed-aktiv.html">
+      <span class="mark">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.4"><circle cx="6" cy="17" r="3.2"/><circle cx="18" cy="17" r="3.2"/><path d="M6 17 9.5 9H8m1.5 0h5L18 17M12 17l-1.5-6"/></svg>
+      </span>
+      criticalmass.in
+    </a>
+    <nav>
+      <a href="06-feed-aktiv.html">Timeline</a>
+      <a href="06e-karte.html">Karte</a>
+      <a href="06c-kalender.html">Kalender</a>
+      <a href="06l-verzeichnis.html">Städte</a>
+      <a href="06f-forum.html">Forum</a>
+    </nav>
+    <span class="grow"></span>
+    <a class="search" href="06j-suche.html">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="m20 20-4-4"/></svg>
+      Stadt oder Tour suchen
+    </a>
+    <a class="upload-btn" href="06h-hochladen.html">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.2"><path d="M12 16V5m0 0 -4 4m4-4 4 4M5 19h14"/></svg>
+      Hochladen
+    </a>
+    <a class="ava mh" href="06d-profil.html">MH</a>
+  </div>
+</header>
+
+<div class="shell">
+
+  <main class="maincol">
+
+    <div class="pagehead">
+      <h1>Statistik</h1>
+      <p class="sub">Was die Masse weltweit zusammenträgt — alle Zahlen aus Schätzungen, Tracks und Fotos der Community.</p>
+    </div>
+
+    <nav class="tabs">
+      <a class="on" href="#">Überblick</a>
+      <a href="#">Top 10</a>
+      <a href="#">Monate</a>
+      <a href="#">Städte</a>
+    </nav>
+
+    <section class="box">
+      <div class="bhead"><h2>Seit 2011 gesammelt</h2><span>Stand: 12.06.2026</span></div>
+      <div class="statband">
+        <div><div class="v">612</div><div class="k">Städte</div></div>
+        <div><div class="v">31.480</div><div class="k">Touren</div></div>
+        <div><div class="v">18.240</div><div class="k">Tracks</div></div>
+        <div><div class="v">92.118</div><div class="k">Fotos</div></div>
+      </div>
+    </section>
+
+    <section class="box">
+      <div class="bhead"><h2>Radfahrende pro Monat, alle Städte</h2><span>Jul 24 – Mai 26</span></div>
+      <div class="chartwrap">
+        <svg class="line" viewBox="0 0 720 260" aria-label="Teilnehmende pro Monat">
+          <g stroke="#edeef1" stroke-width="1.5">
+            <line x1="30" y1="40" x2="690" y2="40"/>
+            <line x1="30" y1="103" x2="690" y2="103"/>
+            <line x1="30" y1="167" x2="690" y2="167"/>
+            <line x1="30" y1="230" x2="690" y2="230"/>
+          </g>
+          <g font-family="IBM Plex Mono, monospace" font-size="10" fill="#a0a6b1">
+            <text x="2" y="44">30k</text>
+            <text x="2" y="107">20k</text>
+            <text x="2" y="171">10k</text>
+            <text x="30" y="250">Jul 24</text>
+            <text x="195" y="250">Jan 25</text>
+            <text x="378" y="250">Jul 25</text>
+            <text x="555" y="250">Jan 26</text>
+            <text x="660" y="250">Mai 26</text>
+          </g>
+          <path d="M30,230 L30,78 L60,65 L90,110 L120,148 L150,186 L180,205 L210,205 L240,198 L270,173 L300,141 L330,116 L360,91 L390,72 L420,59 L450,103 L480,141 L510,179 L540,198 L570,198 L600,192 L630,167 L660,135 L690,110 L690,230 Z"
+            fill="rgba(244,88,28,.10)"/>
+          <polyline points="30,78 60,65 90,110 120,148 150,186 180,205 210,205 240,198 270,173 300,141 330,116 360,91 390,72 420,59 450,103 480,141 510,179 540,198 570,198 600,192 630,167 660,135 690,110"
+            fill="none" stroke="#f4581c" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+          <circle cx="420" cy="59" r="5" fill="#f4581c"/>
+          <text x="420" y="44" font-family="IBM Plex Mono, monospace" font-size="10.5" font-weight="600" fill="#d8450e" text-anchor="middle">27.300 · Aug 25</text>
+          <circle cx="690" cy="110" r="5" fill="#fff" stroke="#f4581c" stroke-width="2.5"/>
+        </svg>
+      </div>
+    </section>
+
+    <section class="box">
+      <div class="bhead"><h2>Top 10 im Mai 2026</h2><span>geschätzte Räder</span></div>
+      <div class="rank">
+        <a class="rankrow" href="06b-stadt.html"><span class="nr">1</span><span><span class="city">Hamburg</span><span class="bar"><i style="width:100%"></i></span></span><span class="n">2.400</span></a>
+        <a class="rankrow" href="#"><span class="nr">2</span><span><span class="city">Berlin</span><span class="bar"><i style="width:79%"></i></span></span><span class="n">1.900</span></a>
+        <a class="rankrow" href="#"><span class="nr">3</span><span><span class="city">München</span><span class="bar"><i style="width:46%"></i></span></span><span class="n">1.100</span></a>
+        <a class="rankrow" href="#"><span class="nr">4</span><span><span class="city">Hannover</span><span class="bar"><i style="width:38%"></i></span></span><span class="n">900</span></a>
+        <a class="rankrow" href="#"><span class="nr">5</span><span><span class="city">Köln</span><span class="bar"><i style="width:35%"></i></span></span><span class="n">850</span></a>
+        <a class="rankrow" href="#"><span class="nr">6</span><span><span class="city">Bremen</span><span class="bar"><i style="width:33%"></i></span></span><span class="n">800</span></a>
+        <a class="rankrow" href="#"><span class="nr">7</span><span><span class="city">Wien</span><span class="bar"><i style="width:29%"></i></span></span><span class="n">700</span></a>
+        <a class="rankrow" href="#"><span class="nr">8</span><span><span class="city">Lisboa</span><span class="bar"><i style="width:27%"></i></span></span><span class="n">650</span></a>
+        <a class="rankrow" href="#"><span class="nr">9</span><span><span class="city">Dresden</span><span class="bar"><i style="width:22%"></i></span></span><span class="n">520</span></a>
+        <a class="rankrow" href="#"><span class="nr">10</span><span><span class="city">Stuttgart</span><span class="bar"><i style="width:20%"></i></span></span><span class="n">480</span></a>
+        <p class="note">Mittelwerte der Community-Schätzungen · <a href="#" style="text-decoration:underline">Methodik</a></p>
+      </div>
+    </section>
+
+  </main>
+
+  <aside class="rail">
+    <div class="rbox">
+      <h4>Rekorde</h4>
+      <div class="rec"><span class="v">5.200</span><span class="t"><b>Größte erfasste Masse</b><span>Hamburg · August 2025</span></span></div>
+      <div class="rec"><span class="v">38,82 km</span><span class="t"><b>Längster Track</b><span>Berlin · Juni 2024 · 3 h 43 min</span></span></div>
+      <div class="rec"><span class="v">178</span><span class="t"><b>Meiste Massen in Folge</b><span>Hamburg · seit August 2011</span></span></div>
+      <div class="rec"><span class="v">−7 °C</span><span class="t"><b>Kälteste Masse mit Track</b><span>Dresden · Januar 2024</span></span></div>
+    </div>
+
+    <div class="rbox">
+      <h4>Dieses Jahr bisher</h4>
+      <div class="rec"><span class="v">2.218</span><span class="t"><b>Touren gefahren</b><span>Januar – Mai 2026</span></span></div>
+      <div class="rec"><span class="v">14</span><span class="t"><b>Neue Städte</b><span>zuletzt: Stirling (Schottland)</span></span></div>
+      <div class="rec"><span class="v">1.604</span><span class="t"><b>Tracks hochgeladen</b><span>davon 38 % als FIT</span></span></div>
+    </div>
+
+    <p class="fine">Alle Auswertungen entstehen aus dem, was die Community einträgt —
+    es gibt kein Tracking und keine Zählung im Hintergrund.
+    <a href="#" style="text-decoration:underline">Rohdaten per API</a></p>
+  </aside>
+
+</div>
+
+<nav class="tabbar">
+  <a href="06-feed-aktiv.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M3 11.2 12 4l9 7.2M5.5 9.8V20h13V9.8"/></svg>
+    Timeline
+  </a>
+  <a href="06e-karte.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M12 21s7-6 7-11a7 7 0 0 0-14 0c0 5 7 11 7 11z"/><circle cx="12" cy="9.8" r="2.4"/></svg>
+    Karte
+  </a>
+  <a href="06h-hochladen.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M12 16V5m0 0-4 4m4-4 4 4M5 19h14"/></svg>
+    Hochladen
+  </a>
+  <a href="06c-kalender.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><rect x="3.5" y="5" width="17" height="15.5" rx="2.5"/><path d="M3.5 9.5h17M8 3v4M16 3v4"/></svg>
+    Kalender
+  </a>
+  <a href="06d-profil.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><circle cx="12" cy="8.4" r="3.4"/><path d="M5 20c.8-3.4 3.6-5.2 7-5.2s6.2 1.8 7 5.2"/></svg>
+    Profil
+  </a>
+</nav>
+
+<a class="proto-back" href="index.html">← Übersicht</a>
+
+</body>
+</html>

--- a/design-prototypes/06j-suche.html
+++ b/design-prototypes/06j-suche.html
@@ -1,0 +1,206 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Suche — Prototyp 6 · criticalmass.in</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@500;600&display=swap" rel="stylesheet">
+<style>
+:root {
+  --bg: #f2f3f5;
+  --card: #ffffff;
+  --line: #e3e5e8;
+  --ink: #16181c;
+  --dim: #707684;
+  --accent: #f4581c;
+  --accent-deep: #d8450e;
+  --green: #1e7d4f;
+  --sans: "Archivo", "Helvetica Neue", Arial, sans-serif;
+  --mono: "IBM Plex Mono", Menlo, monospace;
+}
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html, body { overflow-x: clip; }
+body { font-family: var(--sans); background: var(--bg); color: var(--ink); line-height: 1.5; font-size: 15px; padding-bottom: 70px; }
+a { color: inherit; text-decoration: none; }
+button { font-family: inherit; cursor: pointer; }
+
+.top { position: sticky; top: 0; z-index: 50; background: var(--card); border-bottom: 1px solid var(--line); }
+.top-inner { max-width: 1080px; margin: 0 auto; display: flex; align-items: center; gap: 22px; padding: 0 16px; height: 56px; }
+.brand { display: flex; align-items: center; gap: 9px; font-weight: 800; font-size: 1.05rem; letter-spacing: -.01em; }
+.brand .mark { width: 28px; height: 28px; border-radius: 8px; background: var(--accent); display: grid; place-items: center; }
+.top nav { display: flex; gap: 4px; }
+.top nav a { font-weight: 600; font-size: .92rem; color: var(--dim); padding: 6px 12px; border-radius: 8px; }
+.top nav a:hover { background: #f2f3f5; color: var(--ink); }
+.top .grow { flex: 1; }
+.ava { width: 34px; height: 34px; border-radius: 99px; flex: none; display: grid; place-items: center; font-weight: 800; font-size: .78rem; color: #fff; }
+.ava.mh { background: #3d4350; }
+.ava.lk { background: #c98024; }
+
+.shell { max-width: 720px; margin: 0 auto; padding: 30px 16px 40px; display: flex; flex-direction: column; gap: 18px; }
+
+.bigsearch {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: var(--card);
+  border: 2px solid var(--ink);
+  border-radius: 99px;
+  padding: 13px 22px;
+  box-shadow: 0 6px 18px rgba(22,24,28,.07);
+}
+.bigsearch svg { flex: none; stroke: var(--dim); }
+.bigsearch input { flex: 1; border: 0; font: inherit; font-size: 1.05rem; font-weight: 600; color: var(--ink); outline: none; min-width: 0; }
+.bigsearch .kbd { font-family: var(--mono); font-size: .68rem; color: var(--dim); border: 1px solid var(--line); border-radius: 6px; padding: 2px 7px; }
+
+.tabs { display: flex; gap: 2px; background: var(--card); border: 1px solid var(--line); border-radius: 12px; padding: 4px; }
+.tabs a { flex: 1; text-align: center; font-weight: 700; font-size: .88rem; color: var(--dim); border-radius: 9px; padding: 8px 12px; white-space: nowrap; }
+.tabs a.on { background: #f2f3f5; color: var(--ink); }
+.tabs a .n { font-family: var(--mono); font-size: .72rem; margin-left: 5px; }
+
+.group { background: var(--card); border: 1px solid var(--line); border-radius: 14px; overflow: hidden; }
+.group .ghead { padding: 12px 18px 10px; border-bottom: 1px solid var(--line); font-size: .76rem; font-weight: 800; text-transform: uppercase; letter-spacing: .1em; color: var(--dim); }
+.hit { display: flex; gap: 13px; align-items: center; padding: 12px 18px; border-bottom: 1px solid var(--line); }
+.hit:last-child { border-bottom: 0; }
+.hit:hover { background: #fafbfc; }
+.hit .ic { width: 38px; height: 38px; border-radius: 11px; flex: none; display: grid; place-items: center; color: #fff; font-weight: 800; font-size: .76rem; }
+.hit .t { min-width: 0; flex: 1; }
+.hit b { font-weight: 700; }
+.hit b mark { background: #ffe4d6; color: inherit; border-radius: 3px; padding: 0 1px; }
+.hit .sub { display: block; font-size: .8rem; color: var(--dim); }
+.hit .x { flex: none; font-family: var(--mono); font-size: .76rem; color: var(--dim); text-align: right; }
+.hit .x .hl { color: var(--accent); font-weight: 600; }
+.allhits { display: block; text-align: center; padding: 11px; font-size: .85rem; font-weight: 700; color: var(--accent); }
+.allhits:hover { background: #fff4ee; }
+.fine { font-size: .78rem; color: var(--dim); text-align: center; line-height: 1.7; }
+.fine code { font-family: var(--mono); font-size: .74rem; background: #e9ebee; border-radius: 5px; padding: 1px 6px; }
+
+.tabbar { display: none; }
+.proto-back { position: fixed; bottom: 14px; right: 14px; z-index: 60; font-size: .75rem; font-weight: 700; background: var(--card); border: 1px solid var(--line); border-radius: 99px; padding: 6px 12px; color: var(--dim); }
+@media (max-width: 900px) {
+  .top nav { display: none; }
+  .tabbar { display: flex; position: fixed; bottom: 0; left: 0; right: 0; z-index: 55; background: rgba(255,255,255,.96); backdrop-filter: blur(10px); border-top: 1px solid var(--line); padding: 6px 8px calc(6px + env(safe-area-inset-bottom)); }
+  .tabbar a { flex: 1; display: flex; flex-direction: column; align-items: center; gap: 2px; font-size: .62rem; font-weight: 700; color: var(--dim); padding: 4px 0; }
+  .tabbar a svg { stroke: currentColor; }
+  .proto-back { bottom: 76px; }
+}
+</style>
+</head>
+<body>
+
+<header class="top">
+  <div class="top-inner">
+    <a class="brand" href="06-feed-aktiv.html">
+      <span class="mark">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.4"><circle cx="6" cy="17" r="3.2"/><circle cx="18" cy="17" r="3.2"/><path d="M6 17 9.5 9H8m1.5 0h5L18 17M12 17l-1.5-6"/></svg>
+      </span>
+      criticalmass.in
+    </a>
+    <nav>
+      <a href="06-feed-aktiv.html">Timeline</a>
+      <a href="06e-karte.html">Karte</a>
+      <a href="06c-kalender.html">Kalender</a>
+      <a href="06l-verzeichnis.html">Städte</a>
+      <a href="06f-forum.html">Forum</a>
+    </nav>
+    <span class="grow"></span>
+    <a class="ava mh" href="06d-profil.html">MH</a>
+  </div>
+</header>
+
+<div class="shell">
+
+  <div class="bigsearch">
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke-width="2.2"><circle cx="11" cy="11" r="7"/><path d="m20 20-4-4"/></svg>
+    <input type="text" value="ham" autofocus>
+    <span class="kbd">ESC</span>
+  </div>
+
+  <nav class="tabs">
+    <a class="on" href="#">Alle<span class="n">7</span></a>
+    <a href="#">Städte<span class="n">2</span></a>
+    <a href="#">Touren<span class="n">4</span></a>
+    <a href="#">Forum<span class="n">1</span></a>
+  </nav>
+
+  <section class="group">
+    <div class="ghead">Städte</div>
+    <a class="hit" href="06b-stadt.html">
+      <span class="ic" style="background:var(--accent)">HH</span>
+      <span class="t"><b><mark>Ham</mark>burg</b><span class="sub">Deutschland · 178 Massen seit 2011 · zuletzt ~ 2.400 Räder</span></span>
+      <span class="x"><span class="hl">Fr 26.06.</span><br>19:00</span>
+    </a>
+    <a class="hit" href="#">
+      <span class="ic" style="background:#3d4350">HA</span>
+      <span class="t"><b><mark>Ham</mark>m (Westf.)</b><span class="sub">Deutschland · zuletzt 40 Räder</span></span>
+      <span class="x">Fr 19.06.<br>19:00</span>
+    </a>
+  </section>
+
+  <section class="group">
+    <div class="ghead">Touren</div>
+    <a class="hit" href="06a-tour.html">
+      <span class="ic" style="background:#16181c">
+        <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2"><rect x="3.5" y="5" width="17" height="15.5" rx="2.5"/><path d="M3.5 9.5h17M8 3v4M16 3v4"/></svg>
+      </span>
+      <span class="t"><b>Critical Mass <mark>Ham</mark>burg · 26.06.2026</b><span class="sub">Alstervorland, Höhe Milchstraße · 132 dabei</span></span>
+      <span class="x"><span class="hl">in 14 Tg</span></span>
+    </a>
+    <a class="hit" href="#">
+      <span class="ic" style="background:#1e7d4f">
+        <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2"><path d="m5 12 4.5 4.5L19 7"/></svg>
+      </span>
+      <span class="t"><b>Maimasse <mark>Ham</mark>burg · 29.05.2026</b><span class="sub">~ 2.400 Räder · 4 Tracks · 23 Fotos</span></span>
+      <span class="x">gefahren</span>
+    </a>
+    <a class="hit" href="#">
+      <span class="ic" style="background:#1e7d4f">
+        <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2"><path d="m5 12 4.5 4.5L19 7"/></svg>
+      </span>
+      <span class="t"><b>Aprilmasse <mark>Ham</mark>burg · 24.04.2026</b><span class="sub">~ 1.900 Räder · 3 Tracks · 11 Fotos</span></span>
+      <span class="x">gefahren</span>
+    </a>
+    <a class="allhits" href="#">Alle 4 Touren anzeigen</a>
+  </section>
+
+  <section class="group">
+    <div class="ghead">Forum</div>
+    <a class="hit" href="06f-forum.html">
+      <span class="ava lk" style="border-radius:11px">LK</span>
+      <span class="t"><b>Route im Juni mal Richtung <mark>Ha</mark>fen?</b><span class="sub">Board <mark>Ham</mark>burg · 14 Antworten · vor 40 min</span></span>
+    </a>
+  </section>
+
+  <p class="fine">Tipp: <code>26.06.</code> findet alle Touren an dem Tag ·
+  <code>@katrin</code> findet Menschen · <code>#track</code> sucht nur in Tracks</p>
+
+</div>
+
+<nav class="tabbar">
+  <a href="06-feed-aktiv.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M3 11.2 12 4l9 7.2M5.5 9.8V20h13V9.8"/></svg>
+    Timeline
+  </a>
+  <a href="06e-karte.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M12 21s7-6 7-11a7 7 0 0 0-14 0c0 5 7 11 7 11z"/><circle cx="12" cy="9.8" r="2.4"/></svg>
+    Karte
+  </a>
+  <a href="06h-hochladen.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M12 16V5m0 0-4 4m4-4 4 4M5 19h14"/></svg>
+    Hochladen
+  </a>
+  <a href="06c-kalender.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><rect x="3.5" y="5" width="17" height="15.5" rx="2.5"/><path d="M3.5 9.5h17M8 3v4M16 3v4"/></svg>
+    Kalender
+  </a>
+  <a href="06d-profil.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><circle cx="12" cy="8.4" r="3.4"/><path d="M5 20c.8-3.4 3.6-5.2 7-5.2s6.2 1.8 7 5.2"/></svg>
+    Profil
+  </a>
+</nav>
+
+<a class="proto-back" href="index.html">← Übersicht</a>
+
+</body>
+</html>

--- a/design-prototypes/06k-anmelden.html
+++ b/design-prototypes/06k-anmelden.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Anmelden — Prototyp 6 · criticalmass.in</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@500;600&display=swap" rel="stylesheet">
+<style>
+:root {
+  --bg: #f2f3f5;
+  --card: #ffffff;
+  --line: #e3e5e8;
+  --ink: #16181c;
+  --dim: #707684;
+  --accent: #f4581c;
+  --accent-deep: #d8450e;
+  --green: #1e7d4f;
+  --sans: "Archivo", "Helvetica Neue", Arial, sans-serif;
+  --mono: "IBM Plex Mono", Menlo, monospace;
+}
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html, body { overflow-x: clip; }
+body {
+  font-family: var(--sans);
+  background: var(--bg);
+  color: var(--ink);
+  line-height: 1.5;
+  font-size: 15px;
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+}
+a { color: inherit; text-decoration: none; }
+button { font-family: inherit; cursor: pointer; }
+
+.top { background: var(--card); border-bottom: 1px solid var(--line); }
+.top-inner { max-width: 1080px; margin: 0 auto; display: flex; align-items: center; gap: 22px; padding: 0 16px; height: 56px; }
+.brand { display: flex; align-items: center; gap: 9px; font-weight: 800; font-size: 1.05rem; letter-spacing: -.01em; }
+.brand .mark { width: 28px; height: 28px; border-radius: 8px; background: var(--accent); display: grid; place-items: center; }
+.top .back { margin-left: auto; font-size: .88rem; font-weight: 600; color: var(--dim); }
+.top .back:hover { color: var(--ink); }
+
+.stage { flex: 1; display: grid; place-items: center; padding: 36px 16px 48px; }
+.auth { width: 100%; max-width: 420px; }
+.authcard { background: var(--card); border: 1px solid var(--line); border-radius: 18px; padding: 26px 26px 24px; box-shadow: 0 10px 30px rgba(22,24,28,.06); }
+.authcard .mark {
+  width: 46px; height: 46px;
+  border-radius: 14px;
+  background: var(--accent);
+  display: grid;
+  place-items: center;
+  margin: 0 auto 14px;
+}
+.authcard h1 { text-align: center; font-size: 1.3rem; font-weight: 800; letter-spacing: -.01em; }
+.authcard .sub { text-align: center; color: var(--dim); font-size: .88rem; margin-top: 3px; }
+.switch { display: flex; gap: 2px; background: #f2f3f5; border-radius: 11px; padding: 4px; margin: 18px 0; }
+.switch a { flex: 1; text-align: center; font-weight: 700; font-size: .88rem; color: var(--dim); border-radius: 8px; padding: 8px; }
+.switch a.on { background: var(--card); color: var(--ink); box-shadow: 0 1px 3px rgba(22,24,28,.1); }
+.field { margin-bottom: 13px; }
+.field label { display: block; font-size: .72rem; font-weight: 800; text-transform: uppercase; letter-spacing: .1em; color: var(--dim); margin-bottom: 5px; }
+.field input {
+  width: 100%;
+  border: 1px solid var(--line);
+  background: #fafbfc;
+  border-radius: 10px;
+  padding: 11px 14px;
+  font: inherit;
+  color: var(--ink);
+}
+.field input:focus { outline: 2px solid rgba(244,88,28,.4); border-color: var(--accent); }
+.row-between { display: flex; justify-content: space-between; align-items: center; font-size: .82rem; margin: 4px 0 16px; }
+.row-between label { display: flex; gap: 7px; align-items: center; color: var(--dim); }
+.row-between a { color: var(--accent); font-weight: 600; }
+.go {
+  width: 100%;
+  background: var(--accent);
+  border: 0;
+  color: #fff;
+  font-weight: 800;
+  font-size: 1rem;
+  border-radius: 11px;
+  padding: 13px;
+}
+.go:hover { background: var(--accent-deep); }
+.captcha {
+  margin-top: 13px;
+  border: 1px dashed var(--line);
+  border-radius: 10px;
+  padding: 10px 14px;
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  font-size: .78rem;
+  color: var(--dim);
+}
+.captcha .tick { width: 18px; height: 18px; border-radius: 6px; background: #e8f3ed; color: var(--green); display: grid; place-items: center; font-weight: 800; font-size: .7rem; flex: none; }
+.below { text-align: center; font-size: .85rem; color: var(--dim); margin-top: 18px; }
+.below a { color: var(--accent); font-weight: 700; }
+.promise {
+  margin-top: 22px;
+  display: grid;
+  gap: 8px;
+}
+.promise .p { display: flex; gap: 10px; align-items: baseline; font-size: .84rem; color: #3c4048; }
+.promise .nr { font-family: var(--mono); font-size: .7rem; font-weight: 600; color: var(--accent); flex: none; }
+footer { text-align: center; font-size: .75rem; color: var(--dim); padding: 0 16px 26px; }
+footer a { text-decoration: underline; text-decoration-color: #d4d7db; }
+.proto-back { position: fixed; bottom: 14px; right: 14px; z-index: 60; font-size: .75rem; font-weight: 700; background: var(--card); border: 1px solid var(--line); border-radius: 99px; padding: 6px 12px; color: var(--dim); }
+</style>
+</head>
+<body>
+
+<header class="top">
+  <div class="top-inner">
+    <a class="brand" href="06-feed-aktiv.html">
+      <span class="mark">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.4"><circle cx="6" cy="17" r="3.2"/><circle cx="18" cy="17" r="3.2"/><path d="M6 17 9.5 9H8m1.5 0h5L18 17M12 17l-1.5-6"/></svg>
+      </span>
+      criticalmass.in
+    </a>
+    <a class="back" href="06-feed-aktiv.html">Ohne Konto weiterstöbern →</a>
+  </div>
+</header>
+
+<main class="stage">
+  <div class="auth">
+    <div class="authcard">
+      <span class="mark">
+        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.2"><circle cx="6" cy="17" r="3.2"/><circle cx="18" cy="17" r="3.2"/><path d="M6 17 9.5 9H8m1.5 0h5L18 17M12 17l-1.5-6"/></svg>
+      </span>
+      <h1>Schön, dass du rollst.</h1>
+      <p class="sub">Mit Konto kannst du teilnehmen, schätzen, klingeln und hochladen.</p>
+
+      <nav class="switch">
+        <a class="on" href="#">Anmelden</a>
+        <a href="06o-registrieren.html">Konto anlegen</a>
+      </nav>
+
+      <div class="field">
+        <label for="em">E-Mail oder Nutzername</label>
+        <input id="em" type="text" value="malte">
+      </div>
+      <div class="field">
+        <label for="pw">Passwort</label>
+        <input id="pw" type="password" value="••••••••••">
+      </div>
+      <div class="row-between">
+        <label><input type="checkbox" checked> Angemeldet bleiben</label>
+        <a href="#">Passwort vergessen?</a>
+      </div>
+      <button class="go">Anmelden</button>
+      <div class="captcha">
+        <span class="tick">✓</span>
+        Anti-Roboter-Prüfung bestanden (FriendlyCaptcha — läuft lokal, ohne Google)
+      </div>
+    </div>
+
+    <p class="below">Neu hier? <a href="06o-registrieren.html">Konto anlegen</a> — nur eine E-Mail-Adresse nötig.</p>
+
+    <div class="promise">
+      <p class="p"><span class="nr">01</span>Keine Klarnamenpflicht — nenn dich, wie dich die Masse kennt.</p>
+      <p class="p"><span class="nr">02</span>Keine Werbung, kein Tracking, keine Weitergabe. Punkt.</p>
+      <p class="p"><span class="nr">03</span>Konto löschen geht jederzeit selbst — mitsamt allen Daten.</p>
+    </div>
+  </div>
+</main>
+
+<footer>
+  <a href="#">Impressum</a> · <a href="#">Datenschutz</a> · <a href="#">FAQ</a>
+</footer>
+
+<a class="proto-back" href="index.html">← Übersicht</a>
+
+</body>
+</html>

--- a/design-prototypes/06l-verzeichnis.html
+++ b/design-prototypes/06l-verzeichnis.html
@@ -1,0 +1,287 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Städte — Prototyp 6 · criticalmass.in</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@500;600&display=swap" rel="stylesheet">
+<style>
+:root {
+  --bg: #f2f3f5;
+  --card: #ffffff;
+  --line: #e3e5e8;
+  --ink: #16181c;
+  --dim: #707684;
+  --accent: #f4581c;
+  --accent-deep: #d8450e;
+  --green: #1e7d4f;
+  --sans: "Archivo", "Helvetica Neue", Arial, sans-serif;
+  --mono: "IBM Plex Mono", Menlo, monospace;
+}
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html, body { overflow-x: clip; }
+body { font-family: var(--sans); background: var(--bg); color: var(--ink); line-height: 1.5; font-size: 15px; padding-bottom: 70px; }
+a { color: inherit; text-decoration: none; }
+button { font-family: inherit; cursor: pointer; }
+
+.top { position: sticky; top: 0; z-index: 50; background: var(--card); border-bottom: 1px solid var(--line); }
+.top-inner { max-width: 1080px; margin: 0 auto; display: flex; align-items: center; gap: 22px; padding: 0 16px; height: 56px; }
+.brand { display: flex; align-items: center; gap: 9px; font-weight: 800; font-size: 1.05rem; letter-spacing: -.01em; }
+.brand .mark { width: 28px; height: 28px; border-radius: 8px; background: var(--accent); display: grid; place-items: center; }
+.top nav { display: flex; gap: 4px; }
+.top nav a { font-weight: 600; font-size: .92rem; color: var(--dim); padding: 6px 12px; border-radius: 8px; }
+.top nav a:hover { background: #f2f3f5; color: var(--ink); }
+.top nav a.on { color: var(--ink); background: #f2f3f5; font-weight: 700; }
+.top .grow { flex: 1; }
+.search { display: flex; align-items: center; gap: 8px; background: #f2f3f5; border-radius: 9px; padding: 7px 12px; color: var(--dim); font-size: .88rem; min-width: 180px; }
+.upload-btn { display: inline-flex; align-items: center; gap: 8px; background: var(--accent); color: #fff; border: 0; border-radius: 9px; font-weight: 700; font-size: .9rem; padding: 8px 14px; }
+.ava { width: 34px; height: 34px; border-radius: 99px; flex: none; display: grid; place-items: center; font-weight: 800; font-size: .78rem; color: #fff; }
+.ava.mh { background: #3d4350; }
+
+.shell { max-width: 1080px; margin: 0 auto; display: grid; grid-template-columns: minmax(0, 1fr) 320px; gap: 24px; padding: 22px 16px 40px; align-items: start; }
+.maincol { display: flex; flex-direction: column; gap: 18px; min-width: 0; }
+.pagehead h1 { font-size: 1.45rem; font-weight: 800; letter-spacing: -.02em; }
+.pagehead .sub { color: var(--dim); font-size: .88rem; margin-top: 2px; }
+
+.tabs { display: flex; gap: 2px; background: var(--card); border: 1px solid var(--line); border-radius: 12px; padding: 4px; overflow-x: auto; }
+.tabs a { flex: 1; text-align: center; font-weight: 700; font-size: .88rem; color: var(--dim); border-radius: 9px; padding: 8px 14px; white-space: nowrap; }
+.tabs a.on { background: #f2f3f5; color: var(--ink); }
+.tabs a .n { font-family: var(--mono); font-size: .72rem; margin-left: 5px; }
+
+.landgrid { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+.land { background: var(--card); border: 1px solid var(--line); border-radius: 14px; padding: 15px 17px; display: flex; gap: 13px; align-items: center; }
+.land:hover { border-color: #c9cdd3; }
+.land .flag { width: 40px; height: 40px; border-radius: 12px; display: grid; place-items: center; color: #fff; font-weight: 800; font-size: .76rem; flex: none; font-family: var(--mono); }
+.land b { font-weight: 800; display: block; }
+.land .x { font-size: .8rem; color: var(--dim); }
+.land .go { margin-left: auto; font-family: var(--mono); font-size: .8rem; color: var(--dim); }
+
+.box { background: var(--card); border: 1px solid var(--line); border-radius: 14px; overflow: hidden; }
+.box .bhead { display: flex; align-items: baseline; padding: 14px 18px 12px; border-bottom: 1px solid var(--line); }
+.box .bhead h2 { font-size: 1rem; font-weight: 800; }
+.box .bhead span { margin-left: auto; font-family: var(--mono); font-size: .72rem; color: var(--dim); }
+.crow { display: flex; gap: 12px; padding: 11px 18px; border-bottom: 1px solid var(--line); align-items: center; }
+.crow:last-of-type { border-bottom: 0; }
+.crow:hover { background: #fafbfc; }
+.crow .dot { width: 34px; height: 34px; flex: none; border-radius: 99px; display: grid; place-items: center; color: #fff; font-weight: 800; font-size: .68rem; }
+.crow b { font-weight: 700; display: block; line-height: 1.25; }
+.crow .when { font-size: .8rem; color: var(--dim); }
+.crow .when .hl { color: var(--accent); font-weight: 700; }
+.crow .x { margin-left: auto; font-family: var(--mono); font-size: .78rem; color: var(--dim); text-align: right; white-space: nowrap; }
+.allhits { display: block; text-align: center; padding: 12px; font-size: .86rem; font-weight: 700; color: var(--accent); border-top: 1px solid var(--line); }
+.allhits:hover { background: #fff4ee; }
+
+.rail { display: flex; flex-direction: column; gap: 18px; position: sticky; top: 76px; }
+.rbox { background: var(--card); border: 1px solid var(--line); border-radius: 14px; padding: 16px 18px; }
+.rbox h4 { font-size: .95rem; font-weight: 800; margin-bottom: 10px; }
+.mapcta {
+  display: block;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  overflow: hidden;
+}
+.mapcta .mini { display: block; height: 110px; background: #e9ecef; position: relative; overflow: hidden; }
+.mapcta .mini i { position: absolute; border-radius: 99px; background: var(--accent); border: 2px solid #fff; }
+.mapcta .lbl { padding: 10px 14px; font-weight: 700; font-size: .9rem; display: flex; align-items: center; }
+.mapcta .lbl span { margin-left: auto; color: var(--accent); }
+.newrow { display: flex; gap: 10px; align-items: baseline; padding: 7px 6px; border-radius: 8px; font-size: .9rem; }
+.newrow:hover { background: #f6f7f8; }
+.newrow .d { font-family: var(--mono); font-size: .74rem; color: var(--dim); flex: none; width: 56px; }
+.newrow b { font-weight: 700; }
+.newrow .x { margin-left: auto; color: var(--dim); font-size: .76rem; }
+.kbtn { display: inline-flex; align-items: center; gap: 7px; border: 1px solid var(--line); background: var(--card); border-radius: 9px; padding: 8px 15px; font-weight: 700; font-size: .88rem; color: var(--ink); }
+.kbtn.solid { background: var(--accent); border-color: var(--accent); color: #fff; width: 100%; justify-content: center; }
+.kbtn.solid:hover { background: var(--accent-deep); }
+.rbox .hint { font-size: .8rem; color: var(--dim); margin-top: 10px; }
+.fine { font-size: .75rem; color: var(--dim); line-height: 1.6; padding: 0 6px; }
+
+.tabbar { display: none; }
+.proto-back { position: fixed; bottom: 14px; right: 14px; z-index: 60; font-size: .75rem; font-weight: 700; background: var(--card); border: 1px solid var(--line); border-radius: 99px; padding: 6px 12px; color: var(--dim); }
+@media (max-width: 1000px) {
+  .shell { grid-template-columns: minmax(0, 1fr); }
+  .rail { position: static; }
+  .top nav, .search { display: none; }
+  .landgrid { grid-template-columns: 1fr; }
+  .tabbar { display: flex; position: fixed; bottom: 0; left: 0; right: 0; z-index: 55; background: rgba(255,255,255,.96); backdrop-filter: blur(10px); border-top: 1px solid var(--line); padding: 6px 8px calc(6px + env(safe-area-inset-bottom)); }
+  .tabbar a { flex: 1; display: flex; flex-direction: column; align-items: center; gap: 2px; font-size: .62rem; font-weight: 700; color: var(--dim); padding: 4px 0; }
+  .tabbar a svg { stroke: currentColor; }
+  .proto-back { bottom: 76px; }
+}
+</style>
+</head>
+<body>
+
+<header class="top">
+  <div class="top-inner">
+    <a class="brand" href="06-feed-aktiv.html">
+      <span class="mark">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.4"><circle cx="6" cy="17" r="3.2"/><circle cx="18" cy="17" r="3.2"/><path d="M6 17 9.5 9H8m1.5 0h5L18 17M12 17l-1.5-6"/></svg>
+      </span>
+      criticalmass.in
+    </a>
+    <nav>
+      <a href="06-feed-aktiv.html">Timeline</a>
+      <a href="06e-karte.html">Karte</a>
+      <a href="06c-kalender.html">Kalender</a>
+      <a class="on" href="#">Städte</a>
+      <a href="06f-forum.html">Forum</a>
+    </nav>
+    <span class="grow"></span>
+    <a class="search" href="06j-suche.html">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="m20 20-4-4"/></svg>
+      Stadt oder Tour suchen
+    </a>
+    <a class="upload-btn" href="06h-hochladen.html">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.2"><path d="M12 16V5m0 0 -4 4m4-4 4 4M5 19h14"/></svg>
+      Hochladen
+    </a>
+    <a class="ava mh" href="06d-profil.html">MH</a>
+  </div>
+</header>
+
+<div class="shell">
+
+  <main class="maincol">
+
+    <div class="pagehead">
+      <h1>Städte</h1>
+      <p class="sub">612 Städte auf 5 Kontinenten — jede mit eigener Seite, eigenem Board und eigener Statistik.</p>
+    </div>
+
+    <nav class="tabs">
+      <a class="on" href="#">Europa<span class="n">486</span></a>
+      <a href="#">Nordamerika<span class="n">74</span></a>
+      <a href="#">Südamerika<span class="n">28</span></a>
+      <a href="#">Asien<span class="n">16</span></a>
+      <a href="#">Ozeanien<span class="n">8</span></a>
+    </nav>
+
+    <div class="landgrid">
+      <a class="land" href="#">
+        <span class="flag" style="background:#16181c">DE</span>
+        <span><b>Deutschland</b><span class="x">214 Städte · zuletzt neu: Eberswalde</span></span>
+        <span class="go">→</span>
+      </a>
+      <a class="land" href="#">
+        <span class="flag" style="background:#d8232a">AT</span>
+        <span><b>Österreich</b><span class="x">18 Städte · größte: Wien</span></span>
+        <span class="go">→</span>
+      </a>
+      <a class="land" href="#">
+        <span class="flag" style="background:#b3404a">CH</span>
+        <span><b>Schweiz</b><span class="x">14 Städte · größte: Zürich</span></span>
+        <span class="go">→</span>
+      </a>
+      <a class="land" href="#">
+        <span class="flag" style="background:#1e7d4f">PT</span>
+        <span><b>Portugal</b><span class="x">6 Städte · größte: Lisboa</span></span>
+        <span class="go">→</span>
+      </a>
+      <a class="land" href="#">
+        <span class="flag" style="background:#5b3a8c">UK</span>
+        <span><b>Großbritannien</b><span class="x">24 Städte · zuletzt neu: Stirling</span></span>
+        <span class="go">→</span>
+      </a>
+      <a class="land" href="#">
+        <span class="flag" style="background:#2b6cb0">…</span>
+        <span><b>Alle Länder</b><span class="x">31 Länder in Europa</span></span>
+        <span class="go">→</span>
+      </a>
+    </div>
+
+    <section class="box">
+      <div class="bhead"><h2>Deutschland — die Größten</h2><span>nach Rädern im Mai</span></div>
+      <a class="crow" href="06b-stadt.html">
+        <span class="dot" style="background:var(--accent)">HH</span>
+        <span><b>Hamburg</b><span class="when"><span class="hl">Fr 26.06. · 19:00</span> · Alstervorland</span></span>
+        <span class="x">~ 2.400</span>
+      </a>
+      <a class="crow" href="#">
+        <span class="dot" style="background:#5a4fa0">B</span>
+        <span><b>Berlin</b><span class="when">Fr 26.06. · 20:00 · Mariannenplatz</span></span>
+        <span class="x">~ 1.900</span>
+      </a>
+      <a class="crow" href="#">
+        <span class="dot" style="background:#0e7c82">M</span>
+        <span><b>München</b><span class="when">Fr 26.06. · 19:00</span></span>
+        <span class="x">~ 1.100</span>
+      </a>
+      <a class="crow" href="#">
+        <span class="dot" style="background:#c98024">H</span>
+        <span><b>Hannover</b><span class="when">Fr 19.06. · 20:00</span></span>
+        <span class="x">~ 900</span>
+      </a>
+      <a class="crow" href="#">
+        <span class="dot" style="background:#2b6cb0">HB</span>
+        <span><b>Bremen</b><span class="when">Fr 26.06. · 19:00</span></span>
+        <span class="x">~ 800</span>
+      </a>
+      <a class="allhits" href="#">Alle 214 Städte in Deutschland (A–Z)</a>
+    </section>
+
+  </main>
+
+  <aside class="rail">
+    <div class="rbox">
+      <h4>Lieber auf der Karte?</h4>
+      <a class="mapcta" href="06e-karte.html">
+        <span class="mini">
+          <i style="width:12px;height:12px;top:34px;left:48px"></i>
+          <i style="width:8px;height:8px;top:58px;left:88px"></i>
+          <i style="width:10px;height:10px;top:28px;left:150px"></i>
+          <i style="width:8px;height:8px;top:66px;left:190px"></i>
+          <i style="width:14px;height:14px;top:44px;left:236px"></i>
+        </span>
+        <span class="lbl">Karte öffnen <span>→</span></span>
+      </a>
+    </div>
+
+    <div class="rbox">
+      <h4>Neu dabei</h4>
+      <a class="newrow" href="#"><span class="d">10.06.</span><b>Stirling</b><span class="x">Schottland</span></a>
+      <a class="newrow" href="#"><span class="d">28.05.</span><b>Eberswalde</b><span class="x">Deutschland</span></a>
+      <a class="newrow" href="#"><span class="d">14.05.</span><b>Coimbra</b><span class="x">Portugal</span></a>
+      <a class="newrow" href="#"><span class="d">02.05.</span><b>Boise</b><span class="x">USA</span></a>
+    </div>
+
+    <div class="rbox">
+      <h4>Deine Stadt fehlt?</h4>
+      <a class="kbtn solid" href="06n-tour-anlegen.html">Stadt &amp; erste Tour eintragen</a>
+      <p class="hint">Drei Felder genügen — Name, Datum, Uhrzeit. Den Rest ergänzt die Community.</p>
+    </div>
+
+    <p class="fine">Jede Stadtseite gehört der Community — wie in einem Wiki kann jede:r
+    mit Konto Texte, Treffpunkte und Termine pflegen.</p>
+  </aside>
+
+</div>
+
+<nav class="tabbar">
+  <a href="06-feed-aktiv.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M3 11.2 12 4l9 7.2M5.5 9.8V20h13V9.8"/></svg>
+    Timeline
+  </a>
+  <a href="06e-karte.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M12 21s7-6 7-11a7 7 0 0 0-14 0c0 5 7 11 7 11z"/><circle cx="12" cy="9.8" r="2.4"/></svg>
+    Karte
+  </a>
+  <a href="06h-hochladen.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M12 16V5m0 0-4 4m4-4 4 4M5 19h14"/></svg>
+    Hochladen
+  </a>
+  <a href="06c-kalender.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><rect x="3.5" y="5" width="17" height="15.5" rx="2.5"/><path d="M3.5 9.5h17M8 3v4M16 3v4"/></svg>
+    Kalender
+  </a>
+  <a href="06d-profil.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><circle cx="12" cy="8.4" r="3.4"/><path d="M5 20c.8-3.4 3.6-5.2 7-5.2s6.2 1.8 7 5.2"/></svg>
+    Profil
+  </a>
+</nav>
+
+<a class="proto-back" href="index.html">← Übersicht</a>
+
+</body>
+</html>

--- a/design-prototypes/06m-mitteilungen.html
+++ b/design-prototypes/06m-mitteilungen.html
@@ -1,0 +1,276 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Mitteilungen — Prototyp 6 · criticalmass.in</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@500;600&display=swap" rel="stylesheet">
+<style>
+:root {
+  --bg: #f2f3f5;
+  --card: #ffffff;
+  --line: #e3e5e8;
+  --ink: #16181c;
+  --dim: #707684;
+  --accent: #f4581c;
+  --accent-deep: #d8450e;
+  --green: #1e7d4f;
+  --sans: "Archivo", "Helvetica Neue", Arial, sans-serif;
+  --mono: "IBM Plex Mono", Menlo, monospace;
+}
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html, body { overflow-x: clip; }
+body { font-family: var(--sans); background: var(--bg); color: var(--ink); line-height: 1.5; font-size: 15px; padding-bottom: 70px; }
+a { color: inherit; text-decoration: none; }
+button { font-family: inherit; cursor: pointer; }
+
+.top { position: sticky; top: 0; z-index: 50; background: var(--card); border-bottom: 1px solid var(--line); }
+.top-inner { max-width: 1080px; margin: 0 auto; display: flex; align-items: center; gap: 22px; padding: 0 16px; height: 56px; }
+.brand { display: flex; align-items: center; gap: 9px; font-weight: 800; font-size: 1.05rem; letter-spacing: -.01em; }
+.brand .mark { width: 28px; height: 28px; border-radius: 8px; background: var(--accent); display: grid; place-items: center; }
+.top nav { display: flex; gap: 4px; }
+.top nav a { font-weight: 600; font-size: .92rem; color: var(--dim); padding: 6px 12px; border-radius: 8px; }
+.top nav a:hover { background: #f2f3f5; color: var(--ink); }
+.top .grow { flex: 1; }
+.ava { width: 34px; height: 34px; border-radius: 99px; flex: none; display: grid; place-items: center; font-weight: 800; font-size: .78rem; color: #fff; }
+.ava.s { width: 38px; height: 38px; font-size: .8rem; }
+.ava.mh { background: #3d4350; }
+.ava.kk { background: #0e7c82; }
+.ava.cb { background: #b76fc4; }
+.ava.bb { background: #5a4fa0; }
+.ava.lg { background: #1e7d4f; }
+.ava.sys { background: var(--accent); }
+
+.shell { max-width: 680px; margin: 0 auto; padding: 26px 16px 40px; display: flex; flex-direction: column; gap: 18px; }
+.pagehead { display: flex; align-items: baseline; gap: 14px; }
+.pagehead h1 { font-size: 1.45rem; font-weight: 800; letter-spacing: -.02em; }
+.pagehead a { margin-left: auto; font-size: .84rem; font-weight: 700; color: var(--accent); }
+
+.box { background: var(--card); border: 1px solid var(--line); border-radius: 14px; overflow: hidden; }
+.dayhead { padding: 11px 18px 9px; font-size: .72rem; font-weight: 800; text-transform: uppercase; letter-spacing: .1em; color: var(--dim); border-bottom: 1px solid var(--line); background: #fafbfc; }
+.note { display: flex; gap: 13px; padding: 14px 18px; border-bottom: 1px solid var(--line); align-items: flex-start; position: relative; }
+.note:last-child { border-bottom: 0; }
+.note:hover { background: #fafbfc; }
+.note .t { min-width: 0; flex: 1; font-size: .94rem; }
+.note .t b { font-weight: 700; }
+.note .t .obj { color: var(--accent-deep); font-weight: 600; }
+.note .sub { font-size: .8rem; color: var(--dim); margin-top: 2px; }
+.note .when { flex: none; font-family: var(--mono); font-size: .74rem; color: var(--dim); white-space: nowrap; }
+.note.unread { background: #fffaf7; }
+.note.unread::before {
+  content: "";
+  position: absolute;
+  left: 7px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 7px; height: 7px;
+  border-radius: 99px;
+  background: var(--accent);
+}
+.note .ic {
+  position: absolute;
+  left: 40px;
+  top: 38px;
+  width: 20px; height: 20px;
+  border-radius: 99px;
+  border: 2.5px solid #fff;
+  display: grid;
+  place-items: center;
+}
+.ic.bell { background: var(--accent); }
+.ic.chat { background: #2b6cb0; }
+.ic.ride { background: #16181c; }
+.ic.track { background: var(--green); }
+
+.settings { background: var(--card); border: 1px solid var(--line); border-radius: 14px; padding: 16px 18px; }
+.settings h4 { font-size: .95rem; font-weight: 800; margin-bottom: 6px; }
+.settings .hint { font-size: .8rem; color: var(--dim); margin-bottom: 12px; }
+.swrow { display: flex; align-items: center; gap: 12px; padding: 9px 0; border-top: 1px solid var(--line); font-size: .92rem; }
+.swrow .d { font-size: .78rem; color: var(--dim); display: block; }
+.swrow .sw {
+  margin-left: auto;
+  width: 40px; height: 23px;
+  border-radius: 99px;
+  background: var(--green);
+  position: relative;
+  flex: none;
+}
+.swrow .sw::after {
+  content: "";
+  position: absolute;
+  top: 2.5px; right: 2.5px;
+  width: 18px; height: 18px;
+  border-radius: 99px;
+  background: #fff;
+}
+.swrow .sw.off { background: #cdd1d8; }
+.swrow .sw.off::after { right: auto; left: 2.5px; }
+.fine { font-size: .76rem; color: var(--dim); text-align: center; }
+
+.tabbar { display: none; }
+.proto-back { position: fixed; bottom: 14px; right: 14px; z-index: 60; font-size: .75rem; font-weight: 700; background: var(--card); border: 1px solid var(--line); border-radius: 99px; padding: 6px 12px; color: var(--dim); }
+@media (max-width: 900px) {
+  .top nav { display: none; }
+  .tabbar { display: flex; position: fixed; bottom: 0; left: 0; right: 0; z-index: 55; background: rgba(255,255,255,.96); backdrop-filter: blur(10px); border-top: 1px solid var(--line); padding: 6px 8px calc(6px + env(safe-area-inset-bottom)); }
+  .tabbar a { flex: 1; display: flex; flex-direction: column; align-items: center; gap: 2px; font-size: .62rem; font-weight: 700; color: var(--dim); padding: 4px 0; }
+  .tabbar a svg { stroke: currentColor; }
+  .proto-back { bottom: 76px; }
+}
+</style>
+</head>
+<body>
+
+<header class="top">
+  <div class="top-inner">
+    <a class="brand" href="06-feed-aktiv.html">
+      <span class="mark">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.4"><circle cx="6" cy="17" r="3.2"/><circle cx="18" cy="17" r="3.2"/><path d="M6 17 9.5 9H8m1.5 0h5L18 17M12 17l-1.5-6"/></svg>
+      </span>
+      criticalmass.in
+    </a>
+    <nav>
+      <a href="06-feed-aktiv.html">Timeline</a>
+      <a href="06e-karte.html">Karte</a>
+      <a href="06c-kalender.html">Kalender</a>
+      <a href="06l-verzeichnis.html">Städte</a>
+      <a href="06f-forum.html">Forum</a>
+    </nav>
+    <span class="grow"></span>
+    <a class="ava mh" href="06d-profil.html">MH</a>
+  </div>
+</header>
+
+<div class="shell">
+
+  <div class="pagehead">
+    <h1>Mitteilungen</h1>
+    <a href="#">Alle als gelesen markieren</a>
+  </div>
+
+  <section class="box">
+    <div class="dayhead">Heute</div>
+    <a class="note unread" href="06a-tour.html">
+      <span style="position:relative">
+        <span class="ava s kk">KK</span>
+        <span class="ic chat">
+          <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="3"><path d="M20 12a8 8 0 1 0-3.1 6.3L20 19.5l-.8-3A8 8 0 0 0 20 12z"/></svg>
+        </span>
+      </span>
+      <span class="t"><b>Katrin</b> hat auf deinen Kommentar geantwortet:
+        „Familien-Gruppe ist notiert — wir bringen Luftballons mit."
+        <span class="sub">Critical Mass Hamburg · 26.06.2026</span>
+      </span>
+      <span class="when">vor 2 Std</span>
+    </a>
+    <a class="note unread" href="#">
+      <span style="position:relative">
+        <span class="ava s cb">CB</span>
+        <span class="ic bell">
+          <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="3"><path d="M12 4a5.5 5.5 0 0 0-5.5 5.5c0 4-1.6 5.4-2.5 6h16c-.9-.6-2.5-2-2.5-6A5.5 5.5 0 0 0 12 4z"/></svg>
+        </span>
+      </span>
+      <span class="t"><b>CM Bonn</b> und <b>3 weitere</b> haben für deinen Track geklingelt.
+        <span class="sub">Maimasse Hamburg · 21,7 km</span>
+      </span>
+      <span class="when">vor 4 Std</span>
+    </a>
+    <a class="note unread" href="06a-tour.html">
+      <span style="position:relative">
+        <span class="ava s lg">LG</span>
+        <span class="ic ride">
+          <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="3"><rect x="4" y="5" width="16" height="15" rx="2"/><path d="M4 9.5h16"/></svg>
+        </span>
+      </span>
+      <span class="t">Neue Tour in <b>Lüneburg</b>, einer deiner Städte:
+        <span class="obj">Fr 26.06. · 18:00 · Am Sande</span>
+      </span>
+      <span class="when">vor 6 Std</span>
+    </a>
+  </section>
+
+  <section class="box">
+    <div class="dayhead">Diese Woche</div>
+    <a class="note" href="06b-stadt.html">
+      <span style="position:relative">
+        <span class="ava s sys">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.4"><path d="m5 12 4.5 4.5L19 7"/></svg>
+        </span>
+        <span class="ic track">
+          <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="3"><path d="M4 17c3-1 4-7 7-7s3 5 6 5 3-3 3-3"/></svg>
+        </span>
+      </span>
+      <span class="t">Dein Track wurde der <b>Maimasse Hamburg</b> zugeordnet —
+        Datum, Start und Route passten eindeutig.
+        <span class="sub">2026-05-29-feierabend.fit → GPX</span>
+      </span>
+      <span class="when">29.05.</span>
+    </a>
+    <a class="note" href="#">
+      <span style="position:relative">
+        <span class="ava s bb">b</span>
+        <span class="ic chat">
+          <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="3"><path d="M20 12a8 8 0 1 0-3.1 6.3L20 19.5l-.8-3A8 8 0 0 0 20 12z"/></svg>
+        </span>
+      </span>
+      <span class="t"><b>birnenblau</b> hat dich im Forum erwähnt:
+        „…wie @malte schon sagte, hinten links sammeln."
+        <span class="sub">Board Hamburg · Route im Juni mal Richtung Hafen?</span>
+      </span>
+      <span class="when">Mi</span>
+    </a>
+    <a class="note" href="06g-galerie.html">
+      <span style="position:relative">
+        <span class="ava s kk">KK</span>
+        <span class="ic bell">
+          <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="3"><path d="M12 4a5.5 5.5 0 0 0-5.5 5.5c0 4-1.6 5.4-2.5 6h16c-.9-.6-2.5-2-2.5-6A5.5 5.5 0 0 0 12 4z"/></svg>
+        </span>
+      </span>
+      <span class="t"><b>Katrin</b> hat für deine 2 Fotos geklingelt.
+        <span class="sub">Galerie Maimasse Hamburg</span>
+      </span>
+      <span class="when">Mo</span>
+    </a>
+  </section>
+
+  <section class="settings">
+    <h4>Was dich erreicht</h4>
+    <p class="hint">Mitteilungen kommen nur hier an — E-Mails gibt's höchstens wöchentlich gebündelt, wenn du willst.</p>
+    <div class="swrow"><span>Klingeln für deine Beiträge<span class="d">Tracks, Fotos, Schätzungen</span></span><span class="sw"></span></div>
+    <div class="swrow"><span>Antworten &amp; Erwähnungen<span class="d">Kommentare und Forum</span></span><span class="sw"></span></div>
+    <div class="swrow"><span>Neue Touren deiner Städte<span class="d">Hamburg, Lüneburg, Berlin</span></span><span class="sw"></span></div>
+    <div class="swrow"><span>Wöchentliche E-Mail-Zusammenfassung<span class="d">freitags, vor der Masse</span></span><span class="sw off"></span></div>
+  </section>
+
+  <p class="fine">Mitteilungen älter als 90 Tage werden automatisch gelöscht.</p>
+
+</div>
+
+<nav class="tabbar">
+  <a href="06-feed-aktiv.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M3 11.2 12 4l9 7.2M5.5 9.8V20h13V9.8"/></svg>
+    Timeline
+  </a>
+  <a href="06e-karte.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M12 21s7-6 7-11a7 7 0 0 0-14 0c0 5 7 11 7 11z"/><circle cx="12" cy="9.8" r="2.4"/></svg>
+    Karte
+  </a>
+  <a href="06h-hochladen.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M12 16V5m0 0-4 4m4-4 4 4M5 19h14"/></svg>
+    Hochladen
+  </a>
+  <a href="06c-kalender.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><rect x="3.5" y="5" width="17" height="15.5" rx="2.5"/><path d="M3.5 9.5h17M8 3v4M16 3v4"/></svg>
+    Kalender
+  </a>
+  <a href="06d-profil.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><circle cx="12" cy="8.4" r="3.4"/><path d="M5 20c.8-3.4 3.6-5.2 7-5.2s6.2 1.8 7 5.2"/></svg>
+    Profil
+  </a>
+</nav>
+
+<a class="proto-back" href="index.html">← Übersicht</a>
+
+</body>
+</html>

--- a/design-prototypes/06n-tour-anlegen.html
+++ b/design-prototypes/06n-tour-anlegen.html
@@ -1,0 +1,338 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Tour eintragen — Prototyp 6 · criticalmass.in</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@500;600&display=swap" rel="stylesheet">
+<style>
+:root {
+  --bg: #f2f3f5;
+  --card: #ffffff;
+  --line: #e3e5e8;
+  --ink: #16181c;
+  --dim: #707684;
+  --accent: #f4581c;
+  --accent-deep: #d8450e;
+  --green: #1e7d4f;
+  --sans: "Archivo", "Helvetica Neue", Arial, sans-serif;
+  --mono: "IBM Plex Mono", Menlo, monospace;
+}
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html, body { overflow-x: clip; }
+body { font-family: var(--sans); background: var(--bg); color: var(--ink); line-height: 1.5; font-size: 15px; padding-bottom: 70px; }
+a { color: inherit; text-decoration: none; }
+button { font-family: inherit; cursor: pointer; }
+
+.top { position: sticky; top: 0; z-index: 50; background: var(--card); border-bottom: 1px solid var(--line); }
+.top-inner { max-width: 1080px; margin: 0 auto; display: flex; align-items: center; gap: 22px; padding: 0 16px; height: 56px; }
+.brand { display: flex; align-items: center; gap: 9px; font-weight: 800; font-size: 1.05rem; letter-spacing: -.01em; }
+.brand .mark { width: 28px; height: 28px; border-radius: 8px; background: var(--accent); display: grid; place-items: center; }
+.top nav { display: flex; gap: 4px; }
+.top nav a { font-weight: 600; font-size: .92rem; color: var(--dim); padding: 6px 12px; border-radius: 8px; }
+.top nav a:hover { background: #f2f3f5; color: var(--ink); }
+.top .grow { flex: 1; }
+.ava { width: 34px; height: 34px; border-radius: 99px; flex: none; display: grid; place-items: center; font-weight: 800; font-size: .78rem; color: #fff; }
+.ava.mh { background: #3d4350; }
+
+.shell { max-width: 1080px; margin: 0 auto; display: grid; grid-template-columns: minmax(0, 1fr) 340px; gap: 24px; padding: 22px 16px 40px; align-items: start; }
+.maincol { display: flex; flex-direction: column; gap: 18px; min-width: 0; }
+.pagehead h1 { font-size: 1.45rem; font-weight: 800; letter-spacing: -.02em; }
+.pagehead .sub { color: var(--dim); font-size: .88rem; margin-top: 2px; }
+.pagehead .sub b { color: var(--accent-deep); }
+
+.formbox { background: var(--card); border: 1px solid var(--line); border-radius: 14px; padding: 20px; }
+.formbox h2 {
+  font-size: .76rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: .1em;
+  color: var(--dim);
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  margin-bottom: 14px;
+}
+.formbox h2 .req { background: var(--accent); color: #fff; font-size: .64rem; border-radius: 99px; padding: 2px 9px; letter-spacing: .06em; }
+.frow { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 14px; }
+.field { min-width: 0; }
+.field label { display: block; font-size: .72rem; font-weight: 800; text-transform: uppercase; letter-spacing: .1em; color: var(--dim); margin-bottom: 5px; }
+.field .inp {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  width: 100%;
+  border: 1px solid var(--line);
+  background: #fafbfc;
+  border-radius: 10px;
+  padding: 11px 13px;
+  font-weight: 600;
+}
+.field .inp svg { flex: none; stroke: var(--dim); }
+.field .inp input { border: 0; background: transparent; font: inherit; width: 100%; outline: none; min-width: 0; }
+.field .hint { font-size: .76rem; color: var(--dim); margin-top: 5px; }
+.field .hint b { color: var(--green); }
+
+details.more { border: 1px solid var(--line); border-radius: 14px; background: var(--card); overflow: clip; }
+details.more summary {
+  list-style: none;
+  cursor: pointer;
+  padding: 15px 20px;
+  font-weight: 700;
+  font-size: .95rem;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: #3c4048;
+}
+details.more summary::after { content: "+"; margin-left: auto; font-family: var(--mono); font-size: 1.1rem; color: var(--dim); }
+details.more[open] summary::after { content: "−"; }
+details.more .inner { padding: 4px 20px 20px; display: flex; flex-direction: column; gap: 14px; }
+.field textarea {
+  width: 100%;
+  border: 1px solid var(--line);
+  background: #fafbfc;
+  border-radius: 10px;
+  padding: 11px 13px;
+  font: inherit;
+  min-height: 90px;
+  resize: vertical;
+}
+.mappick { border: 1px solid var(--line); border-radius: 12px; overflow: hidden; }
+.mappick .mini { height: 130px; background: #e9ecef; position: relative; }
+.mappick .mini::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(#dde1e6 1.5px, transparent 1.5px),
+    linear-gradient(90deg, #dde1e6 1.5px, transparent 1.5px);
+  background-size: 56px 44px;
+}
+.mappick .pin {
+  position: absolute;
+  left: 50%; top: 46%;
+  transform: translate(-50%, -100%);
+  z-index: 2;
+}
+.mappick .lbl { display: flex; align-items: center; gap: 9px; padding: 10px 14px; font-size: .86rem; font-weight: 600; color: var(--dim); }
+.mappick .lbl b { color: var(--ink); }
+.mappick .lbl .kbtn { margin-left: auto; }
+
+.submitrow { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; }
+.kbtn { display: inline-flex; align-items: center; gap: 7px; border: 1px solid var(--line); background: var(--card); border-radius: 9px; padding: 8px 15px; font-weight: 700; font-size: .88rem; color: var(--ink); }
+.kbtn:hover { border-color: #c9cdd3; }
+.kbtn.solid { background: var(--accent); border-color: var(--accent); color: #fff; padding: 12px 22px; font-size: .98rem; }
+.kbtn.solid:hover { background: var(--accent-deep); }
+.kbtn.sm { padding: 6px 12px; font-size: .8rem; }
+.submitrow .note { font-size: .8rem; color: var(--dim); }
+
+.rail { display: flex; flex-direction: column; gap: 18px; position: sticky; top: 76px; }
+.rbox { background: var(--card); border: 1px solid var(--line); border-radius: 14px; padding: 16px 18px; }
+.rbox h4 { font-size: .95rem; font-weight: 800; margin-bottom: 10px; }
+.step { display: flex; gap: 10px; align-items: baseline; padding: 5px 0; font-size: .88rem; color: #3c4048; }
+.step .nr { font-family: var(--mono); font-size: .72rem; font-weight: 600; color: var(--accent); flex: none; }
+.step b { font-weight: 700; }
+.preview {
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 13px 15px;
+  display: flex;
+  gap: 13px;
+  align-items: center;
+}
+.datebadge { flex: none; width: 50px; border: 2px solid var(--ink); border-radius: 11px; text-align: center; overflow: hidden; }
+.datebadge .m { background: var(--ink); color: #fff; font-size: .58rem; font-weight: 800; letter-spacing: .12em; padding: 2.5px 0; text-transform: uppercase; }
+.datebadge .d { font-size: 1.2rem; font-weight: 800; padding: 3px 0 4px; }
+.preview b { font-weight: 800; display: block; }
+.preview .x { font-size: .8rem; color: var(--dim); }
+.rbox .hint { font-size: .8rem; color: var(--dim); margin-top: 10px; }
+.rbox .hint a { color: var(--accent); font-weight: 600; }
+.fine { font-size: .75rem; color: var(--dim); line-height: 1.6; padding: 0 6px; }
+
+.tabbar { display: none; }
+.proto-back { position: fixed; bottom: 14px; right: 14px; z-index: 60; font-size: .75rem; font-weight: 700; background: var(--card); border: 1px solid var(--line); border-radius: 99px; padding: 6px 12px; color: var(--dim); }
+@media (max-width: 1000px) {
+  .shell { grid-template-columns: minmax(0, 1fr); }
+  .rail { position: static; }
+  .top nav { display: none; }
+  .frow { grid-template-columns: 1fr; }
+  .tabbar { display: flex; position: fixed; bottom: 0; left: 0; right: 0; z-index: 55; background: rgba(255,255,255,.96); backdrop-filter: blur(10px); border-top: 1px solid var(--line); padding: 6px 8px calc(6px + env(safe-area-inset-bottom)); }
+  .tabbar a { flex: 1; display: flex; flex-direction: column; align-items: center; gap: 2px; font-size: .62rem; font-weight: 700; color: var(--dim); padding: 4px 0; }
+  .tabbar a svg { stroke: currentColor; }
+  .proto-back { bottom: 76px; }
+}
+</style>
+</head>
+<body>
+
+<header class="top">
+  <div class="top-inner">
+    <a class="brand" href="06-feed-aktiv.html">
+      <span class="mark">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.4"><circle cx="6" cy="17" r="3.2"/><circle cx="18" cy="17" r="3.2"/><path d="M6 17 9.5 9H8m1.5 0h5L18 17M12 17l-1.5-6"/></svg>
+      </span>
+      criticalmass.in
+    </a>
+    <nav>
+      <a href="06-feed-aktiv.html">Timeline</a>
+      <a href="06e-karte.html">Karte</a>
+      <a href="06c-kalender.html">Kalender</a>
+      <a href="06l-verzeichnis.html">Städte</a>
+      <a href="06f-forum.html">Forum</a>
+    </nav>
+    <span class="grow"></span>
+    <a class="ava mh" href="06d-profil.html">MH</a>
+  </div>
+</header>
+
+<div class="shell">
+
+  <main class="maincol">
+
+    <div class="pagehead">
+      <h1>Tour eintragen</h1>
+      <p class="sub"><b>Drei Felder genügen.</b> Alles andere kann die Community später ergänzen — wie in einem Wiki.</p>
+    </div>
+
+    <section class="formbox">
+      <h2>Das Nötigste <span class="req">Pflicht</span></h2>
+      <div class="frow">
+        <div class="field">
+          <label for="stadt">Stadt</label>
+          <span class="inp">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M12 21s7-6 7-11a7 7 0 0 0-14 0c0 5 7 11 7 11z"/><circle cx="12" cy="9.8" r="2.4"/></svg>
+            <input id="stadt" type="text" value="Hamburg">
+          </span>
+          <p class="hint"><b>✓ gefunden</b> — Critical Mass Hamburg, 178 Massen</p>
+        </div>
+        <div class="field">
+          <label for="datum">Datum</label>
+          <span class="inp">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke-width="2"><rect x="3.5" y="5" width="17" height="15.5" rx="2.5"/><path d="M3.5 9.5h17M8 3v4M16 3v4"/></svg>
+            <input id="datum" type="text" value="31.07.2026">
+          </span>
+          <p class="hint">Freitag — der letzte im Juli</p>
+        </div>
+        <div class="field">
+          <label for="zeit">Uhrzeit</label>
+          <span class="inp">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke-width="2"><circle cx="12" cy="12" r="8.5"/><path d="M12 7v5l3.5 2"/></svg>
+            <input id="zeit" type="text" value="19:00">
+          </span>
+          <p class="hint">Ortszeit</p>
+        </div>
+      </div>
+    </section>
+
+    <details class="more">
+      <summary>
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#707684" stroke-width="2"><path d="M12 21s7-6 7-11a7 7 0 0 0-14 0c0 5 7 11 7 11z"/><circle cx="12" cy="9.8" r="2.4"/></svg>
+        Treffpunkt (optional, aber hilfreich)
+      </summary>
+      <div class="inner">
+        <div class="field">
+          <label for="treff">Ort</label>
+          <span class="inp">
+            <input id="treff" type="text" value="Alstervorland, Höhe Milchstraße">
+          </span>
+        </div>
+        <div class="mappick">
+          <div class="mini">
+            <span class="pin">
+              <svg width="30" height="30" viewBox="0 0 24 24" fill="#f4581c"><path d="M12 22s7.5-7 7.5-12.5a7.5 7.5 0 1 0-15 0C4.5 15 12 22 12 22z"/><circle cx="12" cy="9.3" r="2.6" fill="#fff"/></svg>
+            </span>
+          </div>
+          <div class="lbl">Pin sitzt: <b>53.5712, 9.9904</b>
+            <button class="kbtn sm">Auf Karte verschieben</button>
+          </div>
+        </div>
+      </div>
+    </details>
+
+    <details class="more">
+      <summary>
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#707684" stroke-width="2"><path d="M4 16.5 14.5 6a2.6 2.6 0 0 1 3.7 3.7L7.7 20.2 3.5 21z"/></svg>
+        Titel &amp; Beschreibung (optional)
+      </summary>
+      <div class="inner">
+        <div class="field">
+          <label for="titel">Titel</label>
+          <span class="inp"><input id="titel" type="text" placeholder="Standard: Critical Mass Hamburg 31.07.2026"></span>
+        </div>
+        <div class="field">
+          <label for="beschr">Beschreibung</label>
+          <textarea id="beschr" placeholder="Besonderheiten? Sommerroute, Bademasse, Treffpunkt-Änderung …"></textarea>
+        </div>
+      </div>
+    </details>
+
+    <div class="submitrow">
+      <button class="kbtn solid">Tour eintragen</button>
+      <a class="kbtn" href="06b-stadt.html">Abbrechen</a>
+      <span class="note">Keine Freigabe nötig — Fehler korrigiert die Community einfach mit.</span>
+    </div>
+
+  </main>
+
+  <aside class="rail">
+    <div class="rbox">
+      <h4>Vorschau</h4>
+      <div class="preview">
+        <span class="datebadge"><span class="m">Juli</span><span class="d">31</span></span>
+        <span>
+          <b>Critical Mass Hamburg</b>
+          <span class="x">Freitag · 19:00 · Alstervorland, Höhe Milchstraße</span>
+        </span>
+      </div>
+      <p class="hint">So erscheint die Tour in Timeline, Kalender und auf der Stadtseite.</p>
+    </div>
+
+    <div class="rbox">
+      <h4>Gut zu wissen</h4>
+      <div class="step"><span class="nr">01</span><span><b>Wiederkehrend?</b> Städte mit festem Rhythmus („letzter Freitag, 19:00") bekommen ihre Touren automatisch angelegt.</span></div>
+      <div class="step"><span class="nr">02</span><span><b>Falsch eingetragen?</b> Touren lassen sich bis zum Start bearbeiten — danach nur noch ergänzen.</span></div>
+      <div class="step"><span class="nr">03</span><span><b>Keine Route nötig.</b> Die entsteht unterwegs — Tracks kommen hinterher.</span></div>
+    </div>
+
+    <div class="rbox">
+      <h4>Stadt gibt's noch nicht?</h4>
+      <p class="hint" style="margin-top:0">Dann lege sie hier zuerst an — Name und Land reichen.
+      <a href="#">Stadt anlegen →</a></p>
+    </div>
+
+    <p class="fine">Mit dem Eintragen bestätigst du nichts weiter, als dass du's ernst meinst.
+    Critical Mass hat keinen Veranstalter — auch nicht durch dieses Formular.</p>
+  </aside>
+
+</div>
+
+<nav class="tabbar">
+  <a href="06-feed-aktiv.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M3 11.2 12 4l9 7.2M5.5 9.8V20h13V9.8"/></svg>
+    Timeline
+  </a>
+  <a href="06e-karte.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M12 21s7-6 7-11a7 7 0 0 0-14 0c0 5 7 11 7 11z"/><circle cx="12" cy="9.8" r="2.4"/></svg>
+    Karte
+  </a>
+  <a href="06h-hochladen.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M12 16V5m0 0-4 4m4-4 4 4M5 19h14"/></svg>
+    Hochladen
+  </a>
+  <a href="06c-kalender.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><rect x="3.5" y="5" width="17" height="15.5" rx="2.5"/><path d="M3.5 9.5h17M8 3v4M16 3v4"/></svg>
+    Kalender
+  </a>
+  <a href="06d-profil.html">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><circle cx="12" cy="8.4" r="3.4"/><path d="M5 20c.8-3.4 3.6-5.2 7-5.2s6.2 1.8 7 5.2"/></svg>
+    Profil
+  </a>
+</nav>
+
+<a class="proto-back" href="index.html">← Übersicht</a>
+
+</body>
+</html>

--- a/design-prototypes/06o-registrieren.html
+++ b/design-prototypes/06o-registrieren.html
@@ -1,0 +1,196 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Konto anlegen — Prototyp 6 · criticalmass.in</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@500;600&display=swap" rel="stylesheet">
+<style>
+:root {
+  --bg: #f2f3f5;
+  --card: #ffffff;
+  --line: #e3e5e8;
+  --ink: #16181c;
+  --dim: #707684;
+  --accent: #f4581c;
+  --accent-deep: #d8450e;
+  --green: #1e7d4f;
+  --sans: "Archivo", "Helvetica Neue", Arial, sans-serif;
+  --mono: "IBM Plex Mono", Menlo, monospace;
+}
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html, body { overflow-x: clip; }
+body {
+  font-family: var(--sans);
+  background: var(--bg);
+  color: var(--ink);
+  line-height: 1.5;
+  font-size: 15px;
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+}
+a { color: inherit; text-decoration: none; }
+button { font-family: inherit; cursor: pointer; }
+
+.top { background: var(--card); border-bottom: 1px solid var(--line); }
+.top-inner { max-width: 1080px; margin: 0 auto; display: flex; align-items: center; gap: 22px; padding: 0 16px; height: 56px; }
+.brand { display: flex; align-items: center; gap: 9px; font-weight: 800; font-size: 1.05rem; letter-spacing: -.01em; }
+.brand .mark { width: 28px; height: 28px; border-radius: 8px; background: var(--accent); display: grid; place-items: center; }
+.top .back { margin-left: auto; font-size: .88rem; font-weight: 600; color: var(--dim); }
+.top .back:hover { color: var(--ink); }
+
+.stage { flex: 1; display: grid; place-items: center; padding: 36px 16px 48px; }
+.auth { width: 100%; max-width: 420px; }
+.authcard { background: var(--card); border: 1px solid var(--line); border-radius: 18px; padding: 26px 26px 24px; box-shadow: 0 10px 30px rgba(22,24,28,.06); }
+.authcard .mark { width: 46px; height: 46px; border-radius: 14px; background: var(--accent); display: grid; place-items: center; margin: 0 auto 14px; }
+.authcard h1 { text-align: center; font-size: 1.3rem; font-weight: 800; letter-spacing: -.01em; }
+.authcard .sub { text-align: center; color: var(--dim); font-size: .88rem; margin-top: 3px; }
+.switch { display: flex; gap: 2px; background: #f2f3f5; border-radius: 11px; padding: 4px; margin: 18px 0 16px; }
+.switch a { flex: 1; text-align: center; font-weight: 700; font-size: .88rem; color: var(--dim); border-radius: 8px; padding: 8px; }
+.switch a.on { background: var(--card); color: var(--ink); box-shadow: 0 1px 3px rgba(22,24,28,.1); }
+
+.steps { display: flex; gap: 8px; margin-bottom: 18px; }
+.stepchip {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 8px 11px;
+  font-size: .78rem;
+  font-weight: 700;
+  color: var(--dim);
+}
+.stepchip .n {
+  width: 20px; height: 20px;
+  border-radius: 99px;
+  display: grid;
+  place-items: center;
+  font-family: var(--mono);
+  font-size: .68rem;
+  font-weight: 600;
+  background: #e9ebee;
+  color: var(--dim);
+  flex: none;
+}
+.stepchip.done { border-color: #cfe5d8; background: #f4faf6; color: var(--green); }
+.stepchip.done .n { background: var(--green); color: #fff; }
+.stepchip.now { border-color: var(--accent); color: var(--ink); }
+.stepchip.now .n { background: var(--accent); color: #fff; }
+
+.field { margin-bottom: 13px; }
+.field label { display: block; font-size: .72rem; font-weight: 800; text-transform: uppercase; letter-spacing: .1em; color: var(--dim); margin-bottom: 5px; }
+.field input {
+  width: 100%;
+  border: 1px solid var(--line);
+  background: #fafbfc;
+  border-radius: 10px;
+  padding: 11px 14px;
+  font: inherit;
+  color: var(--ink);
+}
+.field input:focus { outline: 2px solid rgba(244,88,28,.4); border-color: var(--accent); }
+.field input.ok { border-color: #cfe5d8; background: #f7fbf8; }
+.field .hint { font-size: .76rem; color: var(--dim); margin-top: 5px; }
+.field .hint b { color: var(--green); font-weight: 700; }
+.strength { display: flex; gap: 4px; margin-top: 7px; }
+.strength i { flex: 1; height: 4px; border-radius: 4px; background: #e9ebee; }
+.strength i.on { background: var(--green); }
+
+.go { width: 100%; background: var(--accent); border: 0; color: #fff; font-weight: 800; font-size: 1rem; border-radius: 11px; padding: 13px; margin-top: 4px; }
+.go:hover { background: var(--accent-deep); }
+.captcha { margin-top: 13px; border: 1px dashed var(--line); border-radius: 10px; padding: 10px 14px; display: flex; gap: 10px; align-items: center; font-size: .78rem; color: var(--dim); }
+.captcha .tick { width: 18px; height: 18px; border-radius: 6px; background: #e8f3ed; color: var(--green); display: grid; place-items: center; font-weight: 800; font-size: .7rem; flex: none; }
+.consent { font-size: .76rem; color: var(--dim); text-align: center; margin-top: 12px; }
+.consent a { text-decoration: underline; text-decoration-color: #d4d7db; }
+
+.below { text-align: center; font-size: .85rem; color: var(--dim); margin-top: 18px; }
+.below a { color: var(--accent); font-weight: 700; }
+.promise { margin-top: 22px; display: grid; gap: 8px; }
+.promise .p { display: flex; gap: 10px; align-items: baseline; font-size: .84rem; color: #3c4048; }
+.promise .nr { font-family: var(--mono); font-size: .7rem; font-weight: 600; color: var(--accent); flex: none; }
+footer { text-align: center; font-size: .75rem; color: var(--dim); padding: 0 16px 26px; }
+footer a { text-decoration: underline; text-decoration-color: #d4d7db; }
+.proto-back { position: fixed; bottom: 14px; right: 14px; z-index: 60; font-size: .75rem; font-weight: 700; background: var(--card); border: 1px solid var(--line); border-radius: 99px; padding: 6px 12px; color: var(--dim); }
+</style>
+</head>
+<body>
+
+<header class="top">
+  <div class="top-inner">
+    <a class="brand" href="06-feed-aktiv.html">
+      <span class="mark">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.4"><circle cx="6" cy="17" r="3.2"/><circle cx="18" cy="17" r="3.2"/><path d="M6 17 9.5 9H8m1.5 0h5L18 17M12 17l-1.5-6"/></svg>
+      </span>
+      criticalmass.in
+    </a>
+    <a class="back" href="06-feed-aktiv.html">Ohne Konto weiterstöbern →</a>
+  </div>
+</header>
+
+<main class="stage">
+  <div class="auth">
+    <div class="authcard">
+      <span class="mark">
+        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.2"><circle cx="6" cy="17" r="3.2"/><circle cx="18" cy="17" r="3.2"/><path d="M6 17 9.5 9H8m1.5 0h5L18 17M12 17l-1.5-6"/></svg>
+      </span>
+      <h1>Steig auf.</h1>
+      <p class="sub">Ein Konto, zwei Schritte — mehr braucht es nicht.</p>
+
+      <nav class="switch">
+        <a href="06k-anmelden.html">Anmelden</a>
+        <a class="on" href="#">Konto anlegen</a>
+      </nav>
+
+      <div class="steps">
+        <span class="stepchip done"><span class="n">✓</span>E-Mail bestätigt</span>
+        <span class="stepchip now"><span class="n">2</span>Name &amp; Passwort</span>
+      </div>
+
+      <div class="field">
+        <label for="em">E-Mail</label>
+        <input id="em" type="email" value="malte@beispiel.de" class="ok" readonly>
+        <p class="hint"><b>✓ bestätigt</b> — Link aus der Mail geklickt</p>
+      </div>
+      <div class="field">
+        <label for="nick">Nutzername</label>
+        <input id="nick" type="text" value="malte">
+        <p class="hint">So sieht dich die Masse — ein Klarname ist nicht nötig.</p>
+      </div>
+      <div class="field">
+        <label for="pw">Passwort</label>
+        <input id="pw" type="password" value="••••••••••••••">
+        <span class="strength"><i class="on"></i><i class="on"></i><i class="on"></i><i></i></span>
+        <p class="hint">Lang schlägt kompliziert — am besten 12+ Zeichen.</p>
+      </div>
+
+      <button class="go">Konto anlegen</button>
+      <div class="captcha">
+        <span class="tick">✓</span>
+        Anti-Roboter-Prüfung bestanden (FriendlyCaptcha — läuft lokal, ohne Google)
+      </div>
+      <p class="consent">Mit dem Anlegen akzeptierst du <a href="#">Datenschutz</a> und <a href="#">Hausordnung</a>. Mehr Kleingedrucktes gibt es nicht.</p>
+    </div>
+
+    <p class="below">Schon dabei? <a href="06k-anmelden.html">Anmelden</a></p>
+
+    <div class="promise">
+      <p class="p"><span class="nr">01</span>Keine Klarnamenpflicht — nenn dich, wie dich die Masse kennt.</p>
+      <p class="p"><span class="nr">02</span>Keine Werbung, kein Tracking, keine Weitergabe. Punkt.</p>
+      <p class="p"><span class="nr">03</span>Konto löschen geht jederzeit selbst — mitsamt allen Daten.</p>
+    </div>
+  </div>
+</main>
+
+<footer>
+  <a href="#">Impressum</a> · <a href="#">Datenschutz</a> · <a href="#">FAQ</a>
+</footer>
+
+<a class="proto-back" href="index.html">← Übersicht</a>
+
+</body>
+</html>

--- a/design-prototypes/07-feed-app.html
+++ b/design-prototypes/07-feed-app.html
@@ -1,0 +1,665 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Prototyp 7 · Feed App — criticalmass.in</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+:root {
+  --bg: #0e0f12;
+  --fg: #eceef2;
+  --dim: #8b93a1;
+  --hair: #23252b;
+  --raise: #16181d;
+  --accent: #d9ff3d;
+  --live: #ff4a3a;
+  --sans: "Space Grotesk", "Helvetica Neue", Arial, sans-serif;
+}
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html { color-scheme: dark; }
+html, body { overflow-x: clip; }
+body {
+  font-family: var(--sans);
+  background: var(--bg);
+  color: var(--fg);
+  line-height: 1.5;
+  font-size: 15px;
+  padding-bottom: 72px;
+}
+a { color: inherit; text-decoration: none; }
+button { font-family: inherit; cursor: pointer; }
+.col { max-width: 620px; margin: 0 auto; padding: 0 16px; }
+
+/* ---------- Topbar ---------- */
+.top {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: rgba(14,15,18,.88);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--hair);
+}
+.top .col { display: flex; align-items: center; gap: 14px; height: 54px; }
+.brand { display: flex; align-items: center; gap: 9px; font-weight: 700; font-size: 1.02rem; }
+.brand .patch {
+  width: 13px; height: 20px;
+  background: var(--accent);
+  clip-path: polygon(0 0, 100% 12%, 100% 100%, 0 88%);
+  box-shadow: 0 0 12px rgba(217,255,61,.5);
+}
+.top .icons { margin-left: auto; display: flex; gap: 6px; }
+.iconbtn {
+  width: 36px; height: 36px;
+  border-radius: 99px;
+  border: 0;
+  background: transparent;
+  color: var(--fg);
+  display: grid;
+  place-items: center;
+  position: relative;
+}
+.iconbtn:hover { background: var(--raise); }
+.iconbtn .dot {
+  position: absolute;
+  top: 7px; right: 7px;
+  width: 8px; height: 8px;
+  border-radius: 99px;
+  background: var(--accent);
+  border: 2px solid var(--bg);
+}
+
+/* ---------- Stories ---------- */
+.stories {
+  display: flex;
+  gap: 16px;
+  overflow-x: auto;
+  padding: 16px 16px 14px;
+  scrollbar-width: none;
+  border-bottom: 1px solid var(--hair);
+}
+.stories::-webkit-scrollbar { display: none; }
+.story { flex: none; width: 66px; text-align: center; }
+.story .ring {
+  width: 62px; height: 62px;
+  margin: 0 auto;
+  border-radius: 99px;
+  padding: 3px;
+  background: linear-gradient(135deg, #3a3f49, #23252b);
+}
+.story.today .ring { background: linear-gradient(135deg, var(--accent), #6f9c1f); }
+.story.live .ring { background: linear-gradient(135deg, var(--live), #ff8a3a); animation: pulse 2s ease infinite; }
+@keyframes pulse { 50% { box-shadow: 0 0 0 5px rgba(255,74,58,.12); } }
+@media (prefers-reduced-motion: reduce) { .story.live .ring { animation: none; } }
+.story .face {
+  width: 100%; height: 100%;
+  border-radius: 99px;
+  background: var(--raise);
+  border: 2.5px solid var(--bg);
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  font-size: .82rem;
+}
+.story .name { font-size: .68rem; font-weight: 600; margin-top: 5px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.story .t { font-size: .64rem; color: var(--dim); }
+.story.live .t { color: var(--live); font-weight: 700; }
+.story.today .t { color: var(--accent); }
+
+/* ---------- Compose ---------- */
+.compose {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--hair);
+}
+.ava {
+  width: 40px; height: 40px;
+  border-radius: 99px;
+  flex: none;
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  font-size: .85rem;
+  color: #0e0f12;
+}
+.ava.s { width: 22px; height: 22px; font-size: .58rem; border: 2px solid var(--bg); }
+.ava.kk { background: #6fd3c7; }
+.ava.bb { background: #b3a6ff; }
+.ava.cb { background: #f0a6e8; }
+.ava.lk { background: #ffd27d; }
+.ava.mh { background: #c5ccd9; }
+.ava.st { background: #9fe8b0; }
+.compose input {
+  flex: 1;
+  background: var(--raise);
+  border: 1px solid var(--hair);
+  border-radius: 99px;
+  padding: 10px 18px;
+  font: inherit;
+  color: var(--fg);
+  min-width: 0;
+}
+.compose input::placeholder { color: var(--dim); }
+.compose .go {
+  flex: none;
+  width: 40px; height: 40px;
+  border-radius: 99px;
+  border: 0;
+  background: var(--accent);
+  color: #11130a;
+  display: grid;
+  place-items: center;
+}
+
+/* ---------- Posts ---------- */
+.post { padding: 16px 16px 10px; border-bottom: 1px solid var(--hair); }
+.post-head { display: flex; gap: 11px; }
+.post-head .who { font-size: .95rem; line-height: 1.35; min-width: 0; }
+.post-head .who b { font-weight: 700; }
+.post-head .who .what { color: #c4c9d4; }
+.post-head .time { margin-left: auto; color: var(--dim); font-size: .8rem; white-space: nowrap; }
+.kind {
+  display: inline-block;
+  font-size: .68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .1em;
+  color: var(--accent);
+  margin-bottom: 2px;
+}
+.kind.live { color: var(--live); }
+.post-body { margin: 10px 0 6px 51px; }
+.post-body p.txt { color: #c4c9d4; font-size: .94rem; margin-bottom: 10px; }
+
+/* Inhalte */
+.ridecard {
+  border: 1px solid var(--hair);
+  background: var(--raise);
+  border-radius: 16px;
+  padding: 14px 16px;
+}
+.ridecard .row { display: flex; gap: 14px; align-items: center; }
+.datebox {
+  flex: none;
+  width: 56px;
+  text-align: center;
+  border: 1.5px solid var(--accent);
+  border-radius: 12px;
+  overflow: hidden;
+}
+.datebox .m { background: var(--accent); color: #11130a; font-size: .6rem; font-weight: 700; letter-spacing: .14em; text-transform: uppercase; padding: 2.5px 0; }
+.datebox .d { font-size: 1.35rem; font-weight: 700; padding: 3px 0 4px; }
+.ridecard h3 { font-size: 1.05rem; font-weight: 700; }
+.ridecard .sub { color: var(--dim); font-size: .84rem; margin-top: 1px; }
+.ridecard .join { display: flex; gap: 8px; margin-top: 12px; flex-wrap: wrap; align-items: center; }
+.pillbtn {
+  border: 1px solid var(--hair);
+  background: transparent;
+  color: var(--fg);
+  border-radius: 99px;
+  padding: 7px 15px;
+  font-weight: 600;
+  font-size: .85rem;
+}
+.pillbtn.hot { background: var(--accent); border-color: var(--accent); color: #11130a; font-weight: 700; }
+.ridecard .join .n { color: var(--dim); font-size: .8rem; margin-left: auto; }
+
+.darkmap { border-radius: 16px; display: block; width: 100%; height: auto; border: 1px solid var(--hair); }
+.statline {
+  display: flex;
+  gap: 18px;
+  margin-top: 10px;
+  font-size: .86rem;
+  color: var(--dim);
+  flex-wrap: wrap;
+}
+.statline b { color: var(--fg); font-weight: 700; font-feature-settings: "tnum"; }
+
+.photos2 { display: grid; grid-template-columns: 1fr 1fr; gap: 5px; border-radius: 16px; overflow: hidden; }
+.photos2 .ph { aspect-ratio: 4/3; position: relative; }
+.photos2 .ph::after { content: ""; position: absolute; inset: 0; background-image: radial-gradient(rgba(0,0,0,.5) 1px, transparent 1.4px); background-size: 4px 4px; opacity: .5; }
+.ph.q1 { background: linear-gradient(140deg, #41523c, #1d2b22); }
+.ph.q2 { background: linear-gradient(150deg, #4f4434, #2b2118); }
+.ph.q3 { background: linear-gradient(150deg, #34414f, #1a242e); }
+.ph.q4 { background: linear-gradient(130deg, #4d3a47, #281c26); display: grid; place-items: center; color: #fff; font-weight: 700; }
+.ph.q4::before { content: "+1"; font-size: 1.1rem; position: relative; z-index: 1; }
+
+.estrow {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  border: 1px solid var(--hair);
+  background: var(--raise);
+  border-radius: 16px;
+  padding: 13px 16px;
+}
+.estrow .big {
+  font-weight: 700;
+  font-size: 1.9rem;
+  letter-spacing: .04em;
+  color: var(--accent);
+  font-feature-settings: "tnum";
+}
+.estrow .lbl { font-size: .88rem; color: #c4c9d4; }
+.estrow .lbl b { color: var(--fg); }
+
+/* Aktionen */
+.acts { display: flex; gap: 2px; margin: 6px 0 2px 40px; }
+.acts button {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  background: transparent;
+  border: 0;
+  color: var(--dim);
+  font-size: .84rem;
+  font-weight: 600;
+  border-radius: 99px;
+  padding: 7px 12px;
+}
+.acts button:hover { background: var(--raise); color: var(--fg); }
+.acts button svg { stroke: currentColor; }
+.acts button.rang { color: var(--accent); }
+
+/* ---------- Tabbar ---------- */
+.tabbar {
+  position: fixed;
+  bottom: 0; left: 0; right: 0;
+  z-index: 50;
+  background: rgba(14,15,18,.92);
+  backdrop-filter: blur(12px);
+  border-top: 1px solid var(--hair);
+  display: flex;
+  padding: 6px 10px calc(6px + env(safe-area-inset-bottom));
+}
+.tabbar .col-inner { max-width: 620px; margin: 0 auto; display: flex; flex: 1; }
+.tabbar a {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  color: var(--dim);
+  font-size: .6rem;
+  font-weight: 600;
+  letter-spacing: .04em;
+  padding: 4px 0;
+}
+.tabbar a svg { stroke: currentColor; }
+.tabbar a.on { color: var(--accent); }
+
+.proto-back {
+  position: fixed;
+  bottom: 84px;
+  right: 14px;
+  z-index: 60;
+  font-size: .72rem;
+  font-weight: 600;
+  background: var(--raise);
+  border: 1px solid var(--hair);
+  border-radius: 99px;
+  padding: 6px 12px;
+  color: var(--dim);
+}
+
+@media (min-width: 720px) {
+  body { padding-bottom: 24px; }
+  .tabbar { display: none; }
+  .top .icons { gap: 2px; }
+  .top nav.deskt { display: flex; gap: 2px; margin-left: 18px; }
+  .top nav.deskt a {
+    color: var(--dim);
+    font-size: .88rem;
+    font-weight: 600;
+    padding: 6px 11px;
+    border-radius: 99px;
+  }
+  .top nav.deskt a:hover { background: var(--raise); color: var(--fg); }
+  .top nav.deskt a.on { color: var(--fg); background: var(--raise); }
+  .proto-back { bottom: 14px; }
+}
+@media (max-width: 719px) {
+  .top nav.deskt { display: none; }
+}
+</style>
+</head>
+<body>
+
+<header class="top">
+  <div class="col">
+    <a class="brand" href="#"><span class="patch"></span>criticalmass.in</a>
+    <nav class="deskt">
+      <a class="on" href="#">Feed</a>
+      <a href="#">Karte</a>
+      <a href="#">Kalender</a>
+      <a href="#">Forum</a>
+    </nav>
+    <span class="icons">
+      <button class="iconbtn" aria-label="Suche">
+        <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="m20 20-4-4"/></svg>
+      </button>
+      <button class="iconbtn" aria-label="Mitteilungen">
+        <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 4a5.5 5.5 0 0 0-5.5 5.5c0 4-1.6 5.4-2.5 6h16c-.9-.6-2.5-2-2.5-6A5.5 5.5 0 0 0 12 4z"/><path d="M10 19a2 2 0 0 0 4 0"/></svg>
+        <span class="dot"></span>
+      </button>
+      <span class="ava mh" style="width:32px;height:32px;font-size:.72rem">MH</span>
+    </span>
+  </div>
+</header>
+
+<main class="col" style="padding:0">
+
+  <!-- Stories: Heute unterwegs -->
+  <div class="stories" aria-label="Heute unterwegs">
+    <a class="story live" href="#">
+      <span class="ring"><span class="face">LX</span></span>
+      <span class="name">Lisboa</span>
+      <span class="t">rollt jetzt</span>
+    </a>
+    <a class="story today" href="#">
+      <span class="ring"><span class="face">FK</span></span>
+      <span class="name">Falkensee</span>
+      <span class="t">17:00</span>
+    </a>
+    <a class="story today" href="#">
+      <span class="ring"><span class="face">DN</span></span>
+      <span class="name">Düren</span>
+      <span class="t">18:00</span>
+    </a>
+    <a class="story today" href="#">
+      <span class="ring"><span class="face">PIT</span></span>
+      <span class="name">Pittsburgh</span>
+      <span class="t">18:00</span>
+    </a>
+    <a class="story today" href="#">
+      <span class="ring"><span class="face">D</span></span>
+      <span class="name">Düsseldorf</span>
+      <span class="t">19:00</span>
+    </a>
+    <a class="story today" href="#">
+      <span class="ring"><span class="face">F</span></span>
+      <span class="name">Frankfurt</span>
+      <span class="t">19:00</span>
+    </a>
+    <a class="story today" href="#">
+      <span class="ring"><span class="face">TK</span></span>
+      <span class="name">T-Köpenick</span>
+      <span class="t">19:00</span>
+    </a>
+    <a class="story" href="#">
+      <span class="ring"><span class="face">HH</span></span>
+      <span class="name">Hamburg</span>
+      <span class="t">Fr 26.06.</span>
+    </a>
+    <a class="story" href="#">
+      <span class="ring"><span class="face">B</span></span>
+      <span class="name">Berlin</span>
+      <span class="t">Fr 26.06.</span>
+    </a>
+  </div>
+
+  <!-- Compose -->
+  <div class="compose">
+    <span class="ava mh">MH</span>
+    <input type="text" placeholder="Was rollt bei dir? Foto, Track oder Schätzung …">
+    <button class="go" aria-label="Beitragen">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M12 5v14M5 12h14"/></svg>
+    </button>
+  </div>
+
+  <!-- Tour der Woche -->
+  <article class="post">
+    <div class="post-head">
+      <span class="ava" style="background:var(--accent)">HH</span>
+      <div class="who">
+        <span class="kind">Tour der Woche</span><br>
+        <b>Critical Mass Hamburg</b> <span class="what">— letzter Freitag im Monat</span>
+      </div>
+      <span class="time">in 14 Tagen</span>
+    </div>
+    <div class="post-body">
+      <div class="ridecard">
+        <div class="row">
+          <div class="datebox"><div class="m">Juni</div><div class="d">26</div></div>
+          <div>
+            <h3>19:00 · Alstervorland</h3>
+            <p class="sub">Höhe Milchstraße · zuletzt ~ 2.400 Räder</p>
+          </div>
+        </div>
+        <div class="join">
+          <button class="pillbtn hot">Dabei!</button>
+          <button class="pillbtn">Vielleicht</button>
+          <button class="pillbtn">iCal</button>
+          <span class="n">132 dabei · 41 vielleicht</span>
+        </div>
+      </div>
+    </div>
+  </article>
+
+  <!-- Live -->
+  <article class="post">
+    <div class="post-head">
+      <span class="ava" style="background:#ff9d8a">LX</span>
+      <div class="who">
+        <span class="kind live">● Live</span><br>
+        <b>Lisboa</b> <span class="what">rollt — seit 21:00 ab Marquês de Pombal</span>
+      </div>
+      <span class="time">jetzt</span>
+    </div>
+    <div class="post-body">
+      <p class="txt">Dienstags-Masse mit lauer Luft. Telegram-Gruppe meldet ~ 200 Räder am Start.</p>
+    </div>
+    <div class="acts">
+      <button class="rang">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M12 4a5.5 5.5 0 0 0-5.5 5.5c0 4-1.6 5.4-2.5 6h16c-.9-.6-2.5-2-2.5-6A5.5 5.5 0 0 0 12 4z"/><path d="M10 19a2 2 0 0 0 4 0"/></svg>
+        28
+      </button>
+      <button>
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M20 12a8 8 0 1 0-3.1 6.3L20 19.5l-.8-3A8 8 0 0 0 20 12z"/></svg>
+        6
+      </button>
+      <button>
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M14 9V5l7 7-7 7v-4c-7 0-10 2-11 5 0-7 4-11 11-11z"/></svg>
+      </button>
+    </div>
+  </article>
+
+  <!-- Track -->
+  <article class="post">
+    <div class="post-head">
+      <span class="ava bb">b</span>
+      <div class="who">
+        <b>birnenblau</b> <span class="what">hat einen Track nachgetragen</span><br>
+        <span class="what" style="color:var(--dim);font-size:.84rem">Critical Mass Berlin · 28.11.2025</span>
+      </div>
+      <span class="time">vor 8 Tg</span>
+    </div>
+    <div class="post-body">
+      <svg class="darkmap" viewBox="0 0 600 220" aria-hidden="true">
+        <rect width="600" height="220" fill="#13151a"/>
+        <g stroke="#1e2127" stroke-width="1.5">
+          <line x1="80" y1="0" x2="80" y2="220"/><line x1="180" y1="0" x2="180" y2="220"/>
+          <line x1="300" y1="0" x2="300" y2="220"/><line x1="420" y1="0" x2="420" y2="220"/>
+          <line x1="520" y1="0" x2="520" y2="220"/>
+          <line x1="0" y1="60" x2="600" y2="60"/><line x1="0" y1="120" x2="600" y2="120"/>
+          <line x1="0" y1="175" x2="600" y2="175"/>
+        </g>
+        <defs>
+          <filter id="g7" x="-30%" y="-30%" width="160%" height="160%">
+            <feGaussianBlur stdDeviation="5" result="b"/>
+            <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
+          </filter>
+        </defs>
+        <path d="M70,170 L140,158 L180,105 L265,92 L330,125 L415,108 L480,62 L545,82"
+          fill="none" stroke="#d9ff3d" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" filter="url(#g7)"/>
+        <circle cx="70" cy="170" r="5.5" fill="#ff4a3a"/>
+        <circle cx="545" cy="82" r="5.5" fill="#eceef2"/>
+      </svg>
+      <p class="statline">
+        <span><b>25,58 km</b> Strecke</span>
+        <span><b>2:14 h</b> Fahrzeit</span>
+        <span><b>11,4 km/h</b> Masse-Tempo</span>
+      </p>
+    </div>
+    <div class="acts">
+      <button class="rang">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M12 4a5.5 5.5 0 0 0-5.5 5.5c0 4-1.6 5.4-2.5 6h16c-.9-.6-2.5-2-2.5-6A5.5 5.5 0 0 0 12 4z"/><path d="M10 19a2 2 0 0 0 4 0"/></svg>
+        9
+      </button>
+      <button>
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M20 12a8 8 0 1 0-3.1 6.3L20 19.5l-.8-3A8 8 0 0 0 20 12z"/></svg>
+        2
+      </button>
+      <button>
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M14 9V5l7 7-7 7v-4c-7 0-10 2-11 5 0-7 4-11 11-11z"/></svg>
+      </button>
+    </div>
+  </article>
+
+  <!-- Fotos -->
+  <article class="post">
+    <div class="post-head">
+      <span class="ava cb">CB</span>
+      <div class="who">
+        <b>CM Bonn</b> <span class="what">hat 4 Fotos zur Maimasse hochgeladen</span><br>
+        <span class="what" style="color:var(--dim);font-size:.84rem">Tour vom 29.05.2026 · Rheinufer</span>
+      </div>
+      <span class="time">vor 1 Wo</span>
+    </div>
+    <div class="post-body">
+      <div class="photos2">
+        <a class="ph q1" href="#"></a>
+        <a class="ph q2" href="#"></a>
+        <a class="ph q3" href="#"></a>
+        <a class="ph q4" href="#"></a>
+      </div>
+    </div>
+    <div class="acts">
+      <button class="rang">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M12 4a5.5 5.5 0 0 0-5.5 5.5c0 4-1.6 5.4-2.5 6h16c-.9-.6-2.5-2-2.5-6A5.5 5.5 0 0 0 12 4z"/><path d="M10 19a2 2 0 0 0 4 0"/></svg>
+        14
+      </button>
+      <button>
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M20 12a8 8 0 1 0-3.1 6.3L20 19.5l-.8-3A8 8 0 0 0 20 12z"/></svg>
+        3
+      </button>
+      <button>
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M14 9V5l7 7-7 7v-4c-7 0-10 2-11 5 0-7 4-11 11-11z"/></svg>
+      </button>
+    </div>
+  </article>
+
+  <!-- Schätzung -->
+  <article class="post">
+    <div class="post-head">
+      <span class="ava kk">KK</span>
+      <div class="who">
+        <b>Katrin Kiesel</b> <span class="what">hat die Masse in Norderstedt geschätzt</span><br>
+        <span class="what" style="color:var(--dim);font-size:.84rem">Tour vom 05.06.2026</span>
+      </div>
+      <span class="time">vor 3 Tg</span>
+    </div>
+    <div class="post-body">
+      <div class="estrow">
+        <span class="big">12</span>
+        <span class="lbl"><b>Radfahrende.</b> Der Mittelwert aller Schätzungen
+        wird zur offiziellen Teilnehmendenzahl.</span>
+        <button class="pillbtn" style="flex:none">Mitschätzen</button>
+      </div>
+    </div>
+    <div class="acts">
+      <button>
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M12 4a5.5 5.5 0 0 0-5.5 5.5c0 4-1.6 5.4-2.5 6h16c-.9-.6-2.5-2-2.5-6A5.5 5.5 0 0 0 12 4z"/><path d="M10 19a2 2 0 0 0 4 0"/></svg>
+        3
+      </button>
+      <button>
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M20 12a8 8 0 1 0-3.1 6.3L20 19.5l-.8-3A8 8 0 0 0 20 12z"/></svg>
+        1
+      </button>
+    </div>
+  </article>
+
+  <!-- Forum -->
+  <article class="post">
+    <div class="post-head">
+      <span class="ava lk">LK</span>
+      <div class="who">
+        <b>Lotte</b> <span class="what">im Board Hamburg:</span>
+      </div>
+      <span class="time">vor 5 Std</span>
+    </div>
+    <div class="post-body">
+      <p class="txt">„Route im Juni mal Richtung Hafen? Beim letzten Mal war auf der
+      Kennedybrücke ordentlich was los — Vorschläge für den Treffpunkt danach?"</p>
+      <p class="statline"><span><b>14</b> Antworten</span><span>zuletzt vor 40 min</span></p>
+    </div>
+    <div class="acts">
+      <button>
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M12 4a5.5 5.5 0 0 0-5.5 5.5c0 4-1.6 5.4-2.5 6h16c-.9-.6-2.5-2-2.5-6A5.5 5.5 0 0 0 12 4z"/><path d="M10 19a2 2 0 0 0 4 0"/></svg>
+        7
+      </button>
+      <button>
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M20 12a8 8 0 1 0-3.1 6.3L20 19.5l-.8-3A8 8 0 0 0 20 12z"/></svg>
+        Antworten
+      </button>
+    </div>
+  </article>
+
+  <!-- Neue Stadt -->
+  <article class="post" style="border-bottom:0">
+    <div class="post-head">
+      <span class="ava st">ST</span>
+      <div class="who">
+        <span class="kind">Neue Stadt</span><br>
+        <b>Stirling</b> <span class="what">ist neu dabei — erste Masse Sa, 20. Juni, 10:00</span>
+      </div>
+      <span class="time">vor 2 Tg</span>
+    </div>
+    <div class="acts" style="margin-top:10px">
+      <button class="rang">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M12 4a5.5 5.5 0 0 0-5.5 5.5c0 4-1.6 5.4-2.5 6h16c-.9-.6-2.5-2-2.5-6A5.5 5.5 0 0 0 12 4z"/><path d="M10 19a2 2 0 0 0 4 0"/></svg>
+        21
+      </button>
+      <button>
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M12 5v14M5 12h14"/></svg>
+        Folgen
+      </button>
+    </div>
+  </article>
+
+</main>
+
+<!-- Tabbar mobil -->
+<nav class="tabbar">
+  <div class="col-inner">
+    <a class="on" href="#">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M3 11.2 12 4l9 7.2M5.5 9.8V20h13V9.8"/></svg>
+      Feed
+    </a>
+    <a href="#">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M12 21s7-6 7-11a7 7 0 0 0-14 0c0 5 7 11 7 11z"/><circle cx="12" cy="9.8" r="2.4"/></svg>
+      Karte
+    </a>
+    <a href="#">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><path d="M12 5v14M5 12h14"/></svg>
+      Beitragen
+    </a>
+    <a href="#">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><rect x="3.5" y="5" width="17" height="15.5" rx="2.5"/><path d="M3.5 9.5h17M8 3v4M16 3v4"/></svg>
+      Kalender
+    </a>
+    <a href="#">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke-width="2"><circle cx="12" cy="8.4" r="3.4"/><path d="M5 20c.8-3.4 3.6-5.2 7-5.2s6.2 1.8 7 5.2"/></svg>
+      Profil
+    </a>
+  </div>
+</nav>
+
+<a class="proto-back" href="index.html">← Übersicht</a>
+
+</body>
+</html>

--- a/design-prototypes/UMSETZUNG.md
+++ b/design-prototypes/UMSETZUNG.md
@@ -79,6 +79,12 @@ Alle aus denselben Bausteinen, kein neues Vokabular nötig:
 
 ## Schritte / PR-Schnitt
 
+> **Stand 13.06.2026:** PR 1 = [#1406](https://github.com/criticalmass-one/criticalmass-in/pull/1406) (offen) ·
+> PR 2 = [#1407](https://github.com/criticalmass-one/criticalmass-in/pull/1407) (offen, gestapelt) ·
+> Arbeitspakete als Issues: PR 3 → #1408 · PR 4 → #1409 · PR 5 → #1410 · PR 6 → #1411 ·
+> PR 7 → #1412 · PR 8 → #1413 · PR 9 → #1414 · PR 10 → #1415 · PR 11 → #1416 ·
+> Übersicht/Epic: #1417
+
 1. **PR 1 — Fundament (rein additiv, bricht nichts):**
    Branch `feature/redesign-activity`. Fonts via @fontsource; Bootstrap-Variablen in
    `assets/scss/bootstrap5.scss` überschreiben (`$primary`, `$font-family-base`,

--- a/design-prototypes/UMSETZUNG.md
+++ b/design-prototypes/UMSETZUNG.md
@@ -1,0 +1,124 @@
+# Umsetzungsplan: Redesign „Aktivität" (06-Serie)
+
+Referenz-Prototypen (untereinander verlinkt, responsive verifiziert bei 1440 px und 390 px):
+
+| Seite | Datei | Status |
+|---|---|---|
+| Timeline (Startseite) | `06-feed-aktiv.html` | ✔ Prototyp |
+| Tourseite | `06a-tour.html` | ✔ Prototyp |
+| Stadtseite | `06b-stadt.html` | ✔ Prototyp |
+| Kalender | `06c-kalender.html` | ✔ Prototyp (mobil: Agenda statt Raster) |
+| Profil & Konto | `06d-profil.html` | ✔ Prototyp |
+| Karte / Entdecken | `06e-karte.html` | ✔ Prototyp (mobil: Bottom-Sheet) |
+| Forum | `06f-forum.html` | ✔ Prototyp |
+| Foto-Galerie | `06g-galerie.html` | ✔ Prototyp |
+| Hochladen (Tracks/Fotos/Schätzung) | `06h-hochladen.html` | ✔ Prototyp |
+| Statistik | `06i-statistik.html` | ✔ Prototyp |
+| Suche | `06j-suche.html` | ✔ Prototyp |
+| Anmelden | `06k-anmelden.html` | ✔ Prototyp |
+| Registrieren (2 Schritte) | `06o-registrieren.html` | ✔ Prototyp |
+| Städte-Verzeichnis | `06l-verzeichnis.html` | ✔ Prototyp |
+| Mitteilungen | `06m-mitteilungen.html` | ✔ Prototyp |
+| Tour eintragen (Formular) | `06n-tour-anlegen.html` | ✔ Prototyp |
+
+Damit ist **jede Hauptseite der Plattform** als Prototyp im 06-System vorhanden.
+Die Abschnitte unten dokumentieren die Gestaltungsentscheidungen.
+
+## Design-Tokens
+
+| Token | Wert | Anmerkung |
+|---|---|---|
+| Akzent (`$primary`) | `#f4581c` | Warnwesten-Orange, Hover `#d8450e` |
+| Tinte / Text | `#16181c` | statt Bootstrap-Schwarz |
+| Hintergrund | `#f2f3f5` | kühles Grau, Karten weiß |
+| Linien | `#e3e5e8` | 1px-Borders statt Schatten |
+| Grün (Erfolg/gefahren) | `#1e7d4f` | |
+| Schrift Fließtext | Archivo (400–800) | |
+| Schrift Zahlen/Daten | IBM Plex Mono (500/600) | Statistikbänder, Zeiten, Countdown |
+| Radius | 14 px Karten, 9 px Buttons, 99 px Pills | |
+
+**Fonts unbedingt selbst hosten** (DSGVO — kein Google-Fonts-CDN):
+`yarn add @fontsource/archivo @fontsource/ibm-plex-mono`, Import in `assets/app.js`.
+
+## Wiederkehrende Komponenten (aus den Prototypen extrahierbar)
+
+`.activity` (Feed-Karte) · `.statband`/`.statrow` (Mono-Kennzahlen) · `.kudosbar` + „Klingeln"
+(Glocken-Icon statt Like) · `.ava`/`.facepile` (Initialen-Avatare) · `.kbtn` (Button-Familie) ·
+`.tabs` (Segmented Control) · `.uprow` („Bald unterwegs"-Zeile) · `.datebadge` ·
+`.rankrow` (Städte-Ranking mit Balken) · Tabbar mobil (fixed bottom).
+
+Die CSS-Klassen in den Prototypen sind bewusst so geschrieben, dass sie 1:1 als
+SCSS-Partials übernommen werden können.
+
+## Designentscheidungen der Seiten 06i–06n
+
+Alle aus denselben Bausteinen, kein neues Vokabular nötig:
+
+- **Statistik** (`templates/Statistic/`): Seitenkopf + großes `.statband`, darunter
+  Chart.js-Liniendiagramm (Teilnehmende über Zeit, Akzent-Orange auf Grau) und das
+  `.rankrow`-Ranking (Top 10 wie in der Feed-Rail, nur länger). Stadtstatistik =
+  Monats-Balken aus `06b` in groß. Tabellen mit `font-feature-settings: "tnum"`.
+- **Suche** (`templates/Search/`): Großes Suchfeld als `.float-search`-Pill, Ergebnisse in
+  zwei Tabs (Städte | Touren) als `.crow`-Zeilen aus `06e` (Treffer-Begriff fett markiert).
+  Mobil identisch, eine Spalte.
+- **Anmelden / Registrieren** (`templates/Security/`): Eine zentrierte Karte (max. 420 px)
+  auf `--bg`, Logo-Mark oben, große Eingabefelder im `.compose input`-Stil,
+  Primärbutton `.kbtn.solid`. Registrierung in 2 Schritten (E-Mail → Name/Passwort),
+  FriendlyCaptcha unauffällig unterm Button. Keine Ablenkung, kein Rail.
+- **Städte-Verzeichnis / Regionen** (`templates/Region/`): Kontinente als `.tabs`,
+  darunter Regionen-Karten im `.board`-Stil aus `06f` (Initial-Icon, Name, Städtezahl),
+  Städte als `.crow`-Liste. Alternativ direkt auf `06e-karte` verweisen — Karte und
+  Verzeichnis sind dieselbe Datenbasis.
+- **Mitteilungen**: Dropdown unter dem Topbar-Glocken-Icon + eigene Seite als schmale
+  `.thread`-Liste (Avatar, Text, Zeit, ungelesen = Orange-Punkt). Typen: geklingelt,
+  geantwortet, Tour in deiner Stadt angelegt, Track zugeordnet.
+- **Formulare (Tour/Stadt anlegen & bearbeiten)**: `.box` mit Abschnitts-Überschriften,
+  Felder gruppiert wie die `dl`-Zeilen der Tourseite; Karten-Picker (bestehender
+  `map--form-map`-Controller) bekommt den 14-px-Radius-Rahmen. „Drei Felder genügen"-Promise:
+  Pflicht sind nur Stadt, Datum, Uhrzeit — Rest einklappbar („Mehr Details").
+
+## Schritte / PR-Schnitt
+
+1. **PR 1 — Fundament (rein additiv, bricht nichts):**
+   Branch `feature/redesign-activity`. Fonts via @fontsource; Bootstrap-Variablen in
+   `assets/scss/bootstrap5.scss` überschreiben (`$primary`, `$font-family-base`,
+   `$border-radius`, Grautöne); neues Verzeichnis `assets/scss/redesign/` mit
+   `_tokens.scss` + `_components.scss` (Komponenten von oben).
+2. **PR 2 — Chrome:** Navbar (`templates/Template/Navigation/`) zur Topbar des Prototyps
+   (Logo-Mark, Suche, „Hochladen"-Button, Avatar), Footer verschlanken. Buttons/Karten
+   wirken durch PR 1 bereits neu.
+3. **PR 3 — Startseite = Timeline:** `templates/Frontpage/index.html.twig` auf
+   Feed-Layout (Hauptspalte + Rail) umbauen; Timeline-Item-Templates
+   (`templates/Timeline/`) als `.activity`-Karten mit Statistikband; „Bald unterwegs"
+   als `.uprow`-Widget; dunkle „Nächste Masse"-Leiste oben.
+4. **PR 4 — Tourseite** (`templates/Ride/`): Hero-Karte mit Treffpunkt-Map (bestehender
+   `map--ride-map`-Controller bleibt!), Dabei-Leiste, Statistikband, Tabs wie gehabt.
+5. **PR 5 — Stadtseite** (`templates/City/`): Cover, Folgen-Button (neues Feature oder
+   vorerst weglassen), Stadt-Feed, Monats-Chart (Chart.js vorhanden).
+6. **PR 6 — Kalender** (`templates/Calendar/`): Desktop-Raster restylen, mobil
+   Agenda-Liste ergänzen (`_calendar.scss` ersetzen).
+7. **PR 7 — Profil** (`templates/ProfileManagement/`): Kartenstapel → Profilseite.
+8. **PR 8 — Karte/Entdecken** (`templates/Explore/`): Panel-Layout aus `06e`,
+   bestehender `map--explore-map`-Controller bleibt; mobil Bottom-Sheet.
+9. **PR 9 — Forum** (`templates/Board/`): Board-Karten + Thread-Zeilen aus `06f`.
+10. **PR 10 — Galerie & Hochladen** (`templates/PhotoGallery/`, `templates/Track/`):
+    Masonry-Galerie aus `06g` (CSS columns), Upload-Flow aus `06h` auf den bestehenden
+    Dropzone-/TrackDecider-Unterbau.
+11. **PR 11 — Rest:** Statistik, Suche, Anmelden, Verzeichnis, Mitteilungen, Formulare
+    nach den Designvorgaben oben; danach Bootstrap-3-Kompat-Layer entfernen.
+
+## Nicht anfassen
+
+Leaflet/MapLibre-Stimulus-Controller, Custom-Entity-Router, Datenmodell, API.
+FontAwesome Pro vorerst behalten (Inline-SVGs der Prototypen sind optional, kein Muss).
+
+## Bekannte Stolpersteine
+
+- Bootstrap-3-Kompat-Layer (`.panel`, `.well` …) wird noch von Alt-Templates genutzt —
+  erst nach PR 3–7 entfernen.
+- `$primary`-Wechsel färbt sofort alle Links/Buttons — gewollt, aber einmal komplett
+  durchklicken (v. a. Formulare, Pagination, Modals).
+- „Klingeln" braucht Backend (neue Entity ähnlich Like/Kudos) — fürs Erste kann die
+  Kudosbar ohne Funktion gerendert oder weggelassen werden.
+- Neue Features in den Prototypen, die es noch nicht gibt: Städten folgen,
+  Spoke-Card-Abzeichen, Live-Status. Alles optional, Design funktioniert ohne.

--- a/design-prototypes/_mobile-check.html
+++ b/design-prototypes/_mobile-check.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Mobil-Vorschau — Design-Prototypen criticalmass.in</title>
+<style>
+* { box-sizing: border-box; margin: 0; padding: 0; }
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  background: #2a2a28;
+  color: #eee;
+  padding: 2rem 1.5rem 3rem;
+}
+h1 { font-size: 1.2rem; font-weight: 600; }
+p.hint { color: #aaa; font-size: .85rem; margin: .4rem 0 1.8rem; }
+p.hint a { color: #ddd; }
+h2 { font-size: .9rem; font-weight: 600; color: #c9c9c2; margin: 1.6rem 0 .9rem; text-transform: uppercase; letter-spacing: .08em; }
+.row {
+  display: flex;
+  gap: 2rem;
+  overflow-x: auto;
+  padding-bottom: 1.5rem;
+  align-items: flex-start;
+}
+.phone { flex: none; }
+.phone .label {
+  font-size: .8rem;
+  color: #bbb;
+  margin-bottom: .6rem;
+  display: flex;
+  justify-content: space-between;
+  width: 390px;
+}
+.phone .frame {
+  width: 390px;
+  height: 760px;
+  border-radius: 28px;
+  border: 6px solid #111;
+  overflow: hidden;
+  background: #fff;
+  box-shadow: 0 18px 50px rgba(0,0,0,.45);
+}
+.phone iframe { width: 390px; height: 748px; border: 0; }
+</style>
+</head>
+<body>
+  <h1>Mobil-Vorschau (390 px Breite)</h1>
+  <p class="hint">Jeder Rahmen ist live scroll- und klickbar. Horizontal scrollen für alle.
+    <a href="index.html">← Zurück zur Übersicht</a></p>
+
+  <h2>Runde 2 — Netzwerk-Richtung</h2>
+  <div class="row">
+    <div class="phone">
+      <div class="label"><span>5 · Community</span><a href="05-feed-hell.html" style="color:#999">öffnen ↗</a></div>
+      <div class="frame"><iframe src="05-feed-hell.html" title="Feed Community mobil"></iframe></div>
+    </div>
+    <div class="phone">
+      <div class="label"><span>6 · Aktivität</span><a href="06-feed-aktiv.html" style="color:#999">öffnen ↗</a></div>
+      <div class="frame"><iframe src="06-feed-aktiv.html" title="Feed Aktivität mobil"></iframe></div>
+    </div>
+    <div class="phone">
+      <div class="label"><span>7 · App</span><a href="07-feed-app.html" style="color:#999">öffnen ↗</a></div>
+      <div class="frame"><iframe src="07-feed-app.html" title="Feed App mobil"></iframe></div>
+    </div>
+    <div class="phone">
+      <div class="label"><span>6a · Tourseite</span><a href="06a-tour.html" style="color:#999">öffnen ↗</a></div>
+      <div class="frame"><iframe src="06a-tour.html" title="Tourseite mobil"></iframe></div>
+    </div>
+    <div class="phone">
+      <div class="label"><span>6b · Stadtseite</span><a href="06b-stadt.html" style="color:#999">öffnen ↗</a></div>
+      <div class="frame"><iframe src="06b-stadt.html" title="Stadtseite mobil"></iframe></div>
+    </div>
+    <div class="phone">
+      <div class="label"><span>6c · Kalender</span><a href="06c-kalender.html" style="color:#999">öffnen ↗</a></div>
+      <div class="frame"><iframe src="06c-kalender.html" title="Kalender mobil"></iframe></div>
+    </div>
+    <div class="phone">
+      <div class="label"><span>6d · Profil</span><a href="06d-profil.html" style="color:#999">öffnen ↗</a></div>
+      <div class="frame"><iframe src="06d-profil.html" title="Profil mobil"></iframe></div>
+    </div>
+    <div class="phone">
+      <div class="label"><span>6e · Karte</span><a href="06e-karte.html" style="color:#999">öffnen ↗</a></div>
+      <div class="frame"><iframe src="06e-karte.html" title="Karte mobil"></iframe></div>
+    </div>
+    <div class="phone">
+      <div class="label"><span>6f · Forum</span><a href="06f-forum.html" style="color:#999">öffnen ↗</a></div>
+      <div class="frame"><iframe src="06f-forum.html" title="Forum mobil"></iframe></div>
+    </div>
+    <div class="phone">
+      <div class="label"><span>6g · Galerie</span><a href="06g-galerie.html" style="color:#999">öffnen ↗</a></div>
+      <div class="frame"><iframe src="06g-galerie.html" title="Galerie mobil"></iframe></div>
+    </div>
+    <div class="phone">
+      <div class="label"><span>6h · Hochladen</span><a href="06h-hochladen.html" style="color:#999">öffnen ↗</a></div>
+      <div class="frame"><iframe src="06h-hochladen.html" title="Hochladen mobil"></iframe></div>
+    </div>
+    <div class="phone">
+      <div class="label"><span>6i · Statistik</span><a href="06i-statistik.html" style="color:#999">öffnen ↗</a></div>
+      <div class="frame"><iframe src="06i-statistik.html" title="Statistik mobil" loading="lazy"></iframe></div>
+    </div>
+    <div class="phone">
+      <div class="label"><span>6j · Suche</span><a href="06j-suche.html" style="color:#999">öffnen ↗</a></div>
+      <div class="frame"><iframe src="06j-suche.html" title="Suche mobil" loading="lazy"></iframe></div>
+    </div>
+    <div class="phone">
+      <div class="label"><span>6k · Anmelden</span><a href="06k-anmelden.html" style="color:#999">öffnen ↗</a></div>
+      <div class="frame"><iframe src="06k-anmelden.html" title="Anmelden mobil" loading="lazy"></iframe></div>
+    </div>
+    <div class="phone">
+      <div class="label"><span>6o · Registrieren</span><a href="06o-registrieren.html" style="color:#999">öffnen ↗</a></div>
+      <div class="frame"><iframe src="06o-registrieren.html" title="Registrieren mobil" loading="lazy"></iframe></div>
+    </div>
+    <div class="phone">
+      <div class="label"><span>6l · Verzeichnis</span><a href="06l-verzeichnis.html" style="color:#999">öffnen ↗</a></div>
+      <div class="frame"><iframe src="06l-verzeichnis.html" title="Verzeichnis mobil" loading="lazy"></iframe></div>
+    </div>
+    <div class="phone">
+      <div class="label"><span>6m · Mitteilungen</span><a href="06m-mitteilungen.html" style="color:#999">öffnen ↗</a></div>
+      <div class="frame"><iframe src="06m-mitteilungen.html" title="Mitteilungen mobil" loading="lazy"></iframe></div>
+    </div>
+    <div class="phone">
+      <div class="label"><span>6n · Tour eintragen</span><a href="06n-tour-anlegen.html" style="color:#999">öffnen ↗</a></div>
+      <div class="frame"><iframe src="06n-tour-anlegen.html" title="Tour eintragen mobil" loading="lazy"></iframe></div>
+    </div>
+  </div>
+
+  <h2>Runde 1 — Archiv</h2>
+  <div class="row">
+    <div class="phone">
+      <div class="label"><span>1 · Plakat</span><a href="01-plakat.html" style="color:#999">öffnen ↗</a></div>
+      <div class="frame"><iframe src="01-plakat.html" title="Plakat mobil" loading="lazy"></iframe></div>
+    </div>
+    <div class="phone">
+      <div class="label"><span>2 · Nachtfahrt</span><a href="02-nachtfahrt.html" style="color:#999">öffnen ↗</a></div>
+      <div class="frame"><iframe src="02-nachtfahrt.html" title="Nachtfahrt mobil" loading="lazy"></iframe></div>
+    </div>
+    <div class="phone">
+      <div class="label"><span>3 · Fahrplan</span><a href="03-fahrplan.html" style="color:#999">öffnen ↗</a></div>
+      <div class="frame"><iframe src="03-fahrplan.html" title="Fahrplan mobil" loading="lazy"></iframe></div>
+    </div>
+    <div class="phone">
+      <div class="label"><span>4 · Atlas</span><a href="04-atlas.html" style="color:#999">öffnen ↗</a></div>
+      <div class="frame"><iframe src="04-atlas.html" title="Atlas mobil" loading="lazy"></iframe></div>
+    </div>
+  </div>
+</body>
+</html>

--- a/design-prototypes/index.html
+++ b/design-prototypes/index.html
@@ -1,0 +1,483 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Design-Prototypen — criticalmass.in</title>
+<style>
+:root {
+  --bg: #f5f5f2;
+  --fg: #1d1d1b;
+  --dim: #65655e;
+  --line: #d9d9d2;
+  --card: #ffffff;
+  --accent: #d9492c;
+}
+* { box-sizing: border-box; margin: 0; padding: 0; }
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  background: var(--bg);
+  color: var(--fg);
+  line-height: 1.55;
+  padding: 2.5rem 1.25rem 4rem;
+}
+.wrap { max-width: 1080px; margin: 0 auto; }
+h1 { font-size: 1.9rem; letter-spacing: -.01em; }
+.sub { color: var(--dim); margin: .5rem 0 0; max-width: 50rem; }
+h2.round {
+  margin-top: 2.6rem;
+  font-size: 1.15rem;
+  display: flex;
+  align-items: baseline;
+  gap: .8rem;
+}
+h2.round .tag {
+  font-size: .68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .1em;
+  color: #fff;
+  background: var(--accent);
+  border-radius: 99px;
+  padding: .2rem .65rem;
+}
+h2.round .tag.old { background: #9a9a90; }
+h2.round small { color: var(--dim); font-weight: 400; font-size: .85rem; }
+.grid {
+  margin-top: 1.4rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(440px, 1fr));
+  gap: 1.6rem;
+}
+.grid.three { grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); }
+.proto {
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+.preview {
+  height: 280px;
+  overflow: hidden;
+  position: relative;
+  border-bottom: 1px solid var(--line);
+  background: #eee;
+}
+.preview iframe {
+  width: 1280px;
+  height: 1120px;
+  border: 0;
+  transform: scale(0.40625);
+  transform-origin: top left;
+  pointer-events: none;
+}
+.preview a.cover { position: absolute; inset: 0; }
+.body { padding: 1.3rem 1.4rem 1.5rem; display: flex; flex-direction: column; flex: 1; }
+.body .nr { font-size: .72rem; font-weight: 600; letter-spacing: .14em; text-transform: uppercase; color: var(--dim); }
+.body h3 { font-size: 1.25rem; margin: .25rem 0 .15rem; }
+.body .claim { font-size: .9rem; color: var(--dim); font-style: italic; }
+.swatches { display: flex; gap: .4rem; margin: .9rem 0; }
+.swatches i { width: 26px; height: 26px; border-radius: 6px; border: 1px solid rgba(0,0,0,.12); }
+.body p.why { font-size: .92rem; margin-bottom: .6rem; }
+.facts { font-size: .82rem; color: var(--dim); margin-bottom: 1rem; }
+.body .open {
+  margin-top: auto;
+  align-self: start;
+  text-decoration: none;
+  font-weight: 600;
+  font-size: .9rem;
+  color: #fff;
+  background: var(--fg);
+  border-radius: 8px;
+  padding: .55rem 1rem;
+}
+.body .open:hover { opacity: .85; }
+.mobilelink {
+  margin-top: 2.2rem;
+  display: block;
+  background: var(--card);
+  border: 1px dashed var(--line);
+  border-radius: 10px;
+  padding: 1.1rem 1.4rem;
+  font-size: .92rem;
+  color: var(--dim);
+  text-decoration: none;
+}
+.mobilelink b { color: var(--fg); }
+details.older { margin-top: 2.4rem; }
+details.older summary {
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 1rem;
+  padding: 1rem 1.2rem;
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  color: var(--dim);
+}
+details.older[open] summary { border-radius: 10px 10px 0 0; }
+details.older .inner {
+  border: 1px solid var(--line);
+  border-top: 0;
+  border-radius: 0 0 10px 10px;
+  background: #fafaf7;
+  padding: 1.2rem 1.4rem 1.6rem;
+}
+@media (max-width: 980px) { .grid, .grid.three { grid-template-columns: 1fr; } }
+@media (max-width: 560px) {
+  .preview { height: 220px; }
+  .preview iframe { transform: scale(0.30); }
+}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <h1>Design-Prototypen für criticalmass.in</h1>
+  <p class="sub">Klickbare, responsive HTML-Prototypen mit echten Inhalten der Plattform.
+  Aktuelle Richtung: <strong>soziales Netzwerk mit Timeline auf der Startseite</strong> —
+  der bestehende Aktivitäten-Feed (Schätzungen, Fotos, Tracks, Stadt-News) wird vom Anhängsel
+  zum Herzstück. Drei Varianten, gleiche Inhalte, unterschiedlicher Charakter.</p>
+
+  <h2 class="round"><span class="tag">Runde 2 · aktuell</span> Netzwerk-Richtung <small>Timeline zuerst, „Klingeln" statt Likes</small></h2>
+  <div class="grid three">
+
+    <article class="proto">
+      <div class="preview">
+        <iframe src="05-feed-hell.html" title="Vorschau Feed Community" loading="lazy" tabindex="-1"></iframe>
+        <a class="cover" href="05-feed-hell.html" aria-label="Prototyp Feed Community öffnen"></a>
+      </div>
+      <div class="body">
+        <span class="nr">Prototyp 5</span>
+        <h3>Community</h3>
+        <p class="claim">Drei Spalten, hell, freundlich — das klassische Netzwerk.</p>
+        <div class="swatches">
+          <i style="background:#faf9f6"></i><i style="background:#211f1b"></i>
+          <i style="background:#d9492c"></i><i style="background:#2e7d54"></i>
+          <i style="background:#3563a8"></i>
+        </div>
+        <p class="why">Navigation links, Timeline in der Mitte, „Bald unterwegs" rechts.
+        Beitragstypen als farbige Chips (Track, Fotos, Schätzung, Forum, Stadt), Verfassen-Box
+        mit „Was rollt bei dir?", Tour der Woche angepinnt. Statt Like: <strong>Klingeln</strong>.
+        Mobil: Tab-Leiste mit zentralem Beitragen-Knopf.</p>
+        <p class="facts">Hanken Grotesk · warmes Weiß + Klingel-Rot · 3 Spalten → 1 Spalte</p>
+        <a class="open" href="05-feed-hell.html">Prototyp öffnen</a>
+      </div>
+    </article>
+
+    <article class="proto">
+      <div class="preview">
+        <iframe src="06-feed-aktiv.html" title="Vorschau Feed Aktivität" loading="lazy" tabindex="-1"></iframe>
+        <a class="cover" href="06-feed-aktiv.html" aria-label="Prototyp Feed Aktivität öffnen"></a>
+      </div>
+      <div class="body">
+        <span class="nr">Prototyp 6 · ★ Favorit</span>
+        <h3>Aktivität</h3>
+        <p class="claim">Der Feed als Fahrtenbuch — Karten und Zahlen im Mittelpunkt.</p>
+        <div class="swatches">
+          <i style="background:#f2f3f5"></i><i style="background:#16181c"></i>
+          <i style="background:#f4581c"></i><i style="background:#1e7d4f"></i>
+          <i style="background:#ffffff"></i>
+        </div>
+        <p class="why">Jeder Beitrag ist eine Aktivität mit großer Routenkarte, Statistikband
+        (km, Fahrzeit, Masse-Tempo, Wetter) und Kudos-Leiste mit Avataren. Rechts das
+        Städte-Ranking („Mai-Bilanz") und kommende Touren. Vertraut für alle, die
+        Sport-Plattformen kennen — aber fürs Kollektiv statt fürs Ego.</p>
+        <p class="facts">Archivo + Plex Mono · kühles Grau + Warnwesten-Orange · 2 Spalten → 1 Spalte</p>
+        <a class="open" href="06-feed-aktiv.html">Prototyp öffnen</a>
+      </div>
+    </article>
+
+    <article class="proto">
+      <div class="preview">
+        <iframe src="07-feed-app.html" title="Vorschau Feed App" loading="lazy" tabindex="-1"></iframe>
+        <a class="cover" href="07-feed-app.html" aria-label="Prototyp Feed App öffnen"></a>
+      </div>
+      <div class="body">
+        <span class="nr">Prototyp 7</span>
+        <h3>App</h3>
+        <p class="claim">Eine zentrierte dunkle Spalte — fühlt sich nach App an, ist aber Web.</p>
+        <div class="swatches">
+          <i style="background:#0e0f12"></i><i style="background:#16181d"></i>
+          <i style="background:#d9ff3d"></i><i style="background:#ff4a3a"></i>
+          <i style="background:#eceef2"></i>
+        </div>
+        <p class="why">Oben eine <strong>Stories-Leiste „Heute unterwegs"</strong>: Städte,
+        die heute fahren, als Ringe — live = rot, heute = gelbgrün. Darunter der kompakte Feed
+        mit Hairline-Trennern, leuchtenden Track-Karten und Live-Beiträgen. Dark-Mode-first,
+        weil die Masse abends rollt. Mobil wie Desktop dieselbe ruhige Spalte.</p>
+        <p class="facts">Space Grotesk · Asphalt + Reflektor-Gelbgrün · Stories + Tab-Leiste</p>
+        <a class="open" href="07-feed-app.html">Prototyp öffnen</a>
+      </div>
+    </article>
+
+  </div>
+
+  <h2 class="round"><span class="tag">Vertiefung</span> Prototyp 6 als System <small>Tour- und Stadtseite im selben Stil, klickbar verlinkt</small></h2>
+  <div class="grid">
+
+    <article class="proto">
+      <div class="preview">
+        <iframe src="06a-tour.html" title="Vorschau Tourseite" loading="lazy" tabindex="-1"></iframe>
+        <a class="cover" href="06a-tour.html" aria-label="Tourseite öffnen"></a>
+      </div>
+      <div class="body">
+        <span class="nr">Prototyp 6a</span>
+        <h3>Tourseite</h3>
+        <p class="claim">Critical Mass Hamburg, 26. Juni — die wichtigste Seite der Plattform.</p>
+        <p class="why">Treffpunkt-Karte mit pulsierendem Pin, Dabei!-Leiste mit Facepile,
+        Statistikband (zuletzt ~2.400, Ø Strecke, 178. Masse), Tabs wie im Bestand
+        (Details, Kommentare, Mini-Masses, Galerie, Tracks), „Critical Love Story" als
+        nummerierte Regeln. Rechts: Treffpunkt mit ÖPNV-Linien, Wetter, letzte Massen.</p>
+        <a class="open" href="06a-tour.html">Seite öffnen</a>
+      </div>
+    </article>
+
+    <article class="proto">
+      <div class="preview">
+        <iframe src="06b-stadt.html" title="Vorschau Stadtseite" loading="lazy" tabindex="-1"></iframe>
+        <a class="cover" href="06b-stadt.html" aria-label="Stadtseite öffnen"></a>
+      </div>
+      <div class="body">
+        <span class="nr">Prototyp 6b</span>
+        <h3>Stadtseite</h3>
+        <p class="claim">Hamburg als folgbares Profil mit eigenem Feed.</p>
+        <p class="why">Cover mit Routenlinien, Stadt-Avatar, Folgen-Button und Follower-Zeile,
+        Statistikband, Tabs (Feed, Touren, Statistik, Infos). Der Stadt-Feed zeigt Tour-Ankündigung,
+        Tracks, Fotos und die ausgezählte Maimasse. Rechts: Monats-Balkendiagramm,
+        rotierende Treffpunkte, Social-Links, Nachbarstädte.</p>
+        <a class="open" href="06b-stadt.html">Seite öffnen</a>
+      </div>
+    </article>
+
+    <article class="proto">
+      <div class="preview">
+        <iframe src="06c-kalender.html" title="Vorschau Kalender" loading="lazy" tabindex="-1"></iframe>
+        <a class="cover" href="06c-kalender.html" aria-label="Kalender öffnen"></a>
+      </div>
+      <div class="body">
+        <span class="nr">Prototyp 6c</span>
+        <h3>Kalender</h3>
+        <p class="claim">Juni 2026 als Monatsraster — der große Freitag sticht heraus.</p>
+        <p class="why">Desktop: klassisches Monatsgitter mit Touren-Chips pro Tag, „Heute"
+        orange umrandet, der 26. Juni als hervorgehobener „Großer Freitag" (43 Touren),
+        gefahrene Massen grün abgehakt (Norderstedt: 12 Räder). Mobil wird daraus bewusst
+        eine Agenda-Liste — ein 7-Spalten-Raster taugt nicht für 390 px.</p>
+        <a class="open" href="06c-kalender.html">Seite öffnen</a>
+      </div>
+    </article>
+
+    <article class="proto">
+      <div class="preview">
+        <iframe src="06d-profil.html" title="Vorschau Profil" loading="lazy" tabindex="-1"></iframe>
+        <a class="cover" href="06d-profil.html" aria-label="Profil öffnen"></a>
+      </div>
+      <div class="body">
+        <span class="nr">Prototyp 6d</span>
+        <h3>Profil</h3>
+        <p class="claim">Das eigene Fahrtenbuch — Massen, Tracks, Fotos, Spoke Cards.</p>
+        <p class="why">Profilkopf mit Statistikband (34 Massen, 612 km in der Masse 2026),
+        „Spoke Cards" als augenzwinkernde Abzeichen (12 Monate in Folge, Allwetter),
+        eigene Aktivitäten als Feed, Jahres-Balkendiagramm der Masse-Kilometer.
+        Rechts: Deine Städte und der Konto-Bereich inkl. Datenexport — Tracks gehören dir.</p>
+        <a class="open" href="06d-profil.html">Seite öffnen</a>
+      </div>
+    </article>
+
+    <article class="proto">
+      <div class="preview">
+        <iframe src="06e-karte.html" title="Vorschau Karte" loading="lazy" tabindex="-1"></iframe>
+        <a class="cover" href="06e-karte.html" aria-label="Karte öffnen"></a>
+      </div>
+      <div class="body">
+        <span class="nr">Prototyp 6e</span>
+        <h3>Karte / Entdecken</h3>
+        <p class="claim">612 Städte auf einen Blick — sortiert nach Entfernung.</p>
+        <p class="why">Vollflächige Karte mit Cluster-Pins (Orange) und Stadt-Pins, links das
+        Listen-Panel mit Filterchips (Alle, Heute, Großer Freitag, Neu) und „deine Stadt"
+        hervorgehoben. Mobil wird das Panel zum Bottom-Sheet unter der halben Karte —
+        wie man es von Karten-Apps kennt.</p>
+        <a class="open" href="06e-karte.html">Seite öffnen</a>
+      </div>
+    </article>
+
+    <article class="proto">
+      <div class="preview">
+        <iframe src="06f-forum.html" title="Vorschau Forum" loading="lazy" tabindex="-1"></iframe>
+        <a class="cover" href="06f-forum.html" aria-label="Forum öffnen"></a>
+      </div>
+      <div class="body">
+        <span class="nr">Prototyp 6f</span>
+        <h3>Forum</h3>
+        <p class="claim">„Gerade diskutiert" zuerst, Boards danach.</p>
+        <p class="why">Aktive Threads als Zeilen mit Board-Chip, Avatar und Antwortzahl
+        (heiße Themen mit Orange-Punkt), darunter die Boards als Karten — Allgemein plus
+        ein Board je Stadt, wie im Bestand. Rechts: Neues Thema, kurze Hausordnung,
+        aktivste Boards der letzten 30 Tage.</p>
+        <a class="open" href="06f-forum.html">Seite öffnen</a>
+      </div>
+    </article>
+
+    <article class="proto">
+      <div class="preview">
+        <iframe src="06g-galerie.html" title="Vorschau Galerie" loading="lazy" tabindex="-1"></iframe>
+        <a class="cover" href="06g-galerie.html" aria-label="Galerie öffnen"></a>
+      </div>
+      <div class="body">
+        <span class="nr">Prototyp 6g</span>
+        <h3>Foto-Galerie</h3>
+        <p class="claim">Die Maimasse in 23 Bildern — mit Fotograf:in an jedem Bild.</p>
+        <p class="why">Masonry-Raster mit gemischten Formaten, Credit-Pill auf jedem Foto,
+        Kopf mit Statistikband (Fotos, Fotograf:innen, Klingeln, Lizenz). Rechts die
+        Foto-Hausordnung (Gesichter verpixeln, Kennzeichen automatisch) und weitere
+        Galerien. Mobil zweispaltig.</p>
+        <a class="open" href="06g-galerie.html">Seite öffnen</a>
+      </div>
+    </article>
+
+    <article class="proto">
+      <div class="preview">
+        <iframe src="06h-hochladen.html" title="Vorschau Hochladen" loading="lazy" tabindex="-1"></iframe>
+        <a class="cover" href="06h-hochladen.html" aria-label="Hochladen öffnen"></a>
+      </div>
+      <div class="body">
+        <span class="nr">Prototyp 6h</span>
+        <h3>Hochladen</h3>
+        <p class="claim">Reinwerfen, zuordnen lassen, fertig — der echte Upload-Flow.</p>
+        <p class="why">Dropzone für GPX/FIT (FIT wird automatisch zu GPX), darunter die
+        Upload-Liste mit den drei echten Zuständen der automatischen Tour-Zuordnung:
+        sicher zugeordnet (grün), bitte prüfen mit Auswahl (gelb), geparkt (grau).
+        Tabs für Fotos und Schätzungen. Rechts erklärt, wie der Abgleich funktioniert.</p>
+        <a class="open" href="06h-hochladen.html">Seite öffnen</a>
+      </div>
+    </article>
+
+    <article class="proto">
+      <div class="preview">
+        <iframe src="06i-statistik.html" title="Vorschau Statistik" loading="lazy" tabindex="-1"></iframe>
+        <a class="cover" href="06i-statistik.html" aria-label="Statistik öffnen"></a>
+      </div>
+      <div class="body">
+        <span class="nr">Prototyp 6i</span>
+        <h3>Statistik</h3>
+        <p class="claim">15 Jahre Daten — Kurve, Top 10 und Rekorde.</p>
+        <p class="why">Gesamtzahlen als großes Statistikband, Monatskurve über zwei Jahre
+        (Sommerberge, Wintertäler), Top 10 mit Balken. Rechts die Rekorde: größte Masse,
+        längster Track, kälteste Masse mit Track. Alles aus Community-Daten — steht auch dran.</p>
+        <a class="open" href="06i-statistik.html">Seite öffnen</a>
+      </div>
+    </article>
+
+    <article class="proto">
+      <div class="preview">
+        <iframe src="06j-suche.html" title="Vorschau Suche" loading="lazy" tabindex="-1"></iframe>
+        <a class="cover" href="06j-suche.html" aria-label="Suche öffnen"></a>
+      </div>
+      <div class="body">
+        <span class="nr">Prototyp 6j</span>
+        <h3>Suche</h3>
+        <p class="claim">„ham" → Hamburg, Hamm, vier Touren und ein Forumsthread.</p>
+        <p class="why">Eine zentrierte Spalte: großes Suchfeld, Ergebnis-Tabs
+        (Alle/Städte/Touren/Forum), Treffer als Zeilen mit markiertem Suchbegriff und
+        Kontext (nächster Termin orange). Unten Suchtipps für Datum, Personen, Tracks.</p>
+        <a class="open" href="06j-suche.html">Seite öffnen</a>
+      </div>
+    </article>
+
+    <article class="proto">
+      <div class="preview">
+        <iframe src="06k-anmelden.html" title="Vorschau Anmelden" loading="lazy" tabindex="-1"></iframe>
+        <a class="cover" href="06k-anmelden.html" aria-label="Anmelden öffnen"></a>
+      </div>
+      <div class="body">
+        <span class="nr">Prototyp 6k + 6o</span>
+        <h3>Anmelden &amp; Registrieren</h3>
+        <p class="claim">Eine Karte, zwei Felder, drei Versprechen.</p>
+        <p class="why">Zentrierte Auth-Karte mit Umschalter: Anmelden (6k) und die
+        Registrierung als Zwei-Schritte-Flow (6o — E-Mail bestätigen, dann Name &amp;
+        Passwort mit Stärke-Anzeige). FriendlyCaptcha-Hinweis („läuft lokal, ohne Google")
+        und drei Versprechen: keine Klarnamenpflicht, kein Tracking, Konto selbst löschbar.</p>
+        <a class="open" href="06k-anmelden.html">Anmelden öffnen</a>
+        &nbsp;
+        <a class="open" href="06o-registrieren.html" style="background:transparent;color:var(--fg);border:1px solid var(--line)">Registrieren öffnen</a>
+      </div>
+    </article>
+
+    <article class="proto">
+      <div class="preview">
+        <iframe src="06l-verzeichnis.html" title="Vorschau Verzeichnis" loading="lazy" tabindex="-1"></iframe>
+        <a class="cover" href="06l-verzeichnis.html" aria-label="Verzeichnis öffnen"></a>
+      </div>
+      <div class="body">
+        <span class="nr">Prototyp 6l</span>
+        <h3>Städte-Verzeichnis</h3>
+        <p class="claim">612 Städte, sortiert nach Kontinent, Land und Größe.</p>
+        <p class="why">Kontinent-Tabs mit Zählern, Länder als Karten (zuletzt neue Stadt
+        als Teaser), darunter die größten Städte des Landes als Liste. Rechts: Karten-CTA,
+        „Neu dabei" und der Einstieg „Deine Stadt fehlt?". Das Topbar-Menü „Städte" führt
+        jetzt hierher.</p>
+        <a class="open" href="06l-verzeichnis.html">Seite öffnen</a>
+      </div>
+    </article>
+
+    <article class="proto">
+      <div class="preview">
+        <iframe src="06m-mitteilungen.html" title="Vorschau Mitteilungen" loading="lazy" tabindex="-1"></iframe>
+        <a class="cover" href="06m-mitteilungen.html" aria-label="Mitteilungen öffnen"></a>
+      </div>
+      <div class="body">
+        <span class="nr">Prototyp 6m</span>
+        <h3>Mitteilungen</h3>
+        <p class="claim">Geklingelt, geantwortet, neue Tour — mit Typ-Icons am Avatar.</p>
+        <p class="why">Schmale Spalte, nach Tagen gruppiert, ungelesen mit Orange-Punkt
+        und zartem Hintergrund. Jeder Typ (Klingeln, Antwort, Tour, Track-Zuordnung) hat
+        ein kleines Icon am Avatar. Darunter die Einstellungen als Schalter-Liste —
+        E-Mail-Zusammenfassung standardmäßig aus.</p>
+        <a class="open" href="06m-mitteilungen.html">Seite öffnen</a>
+      </div>
+    </article>
+
+    <article class="proto">
+      <div class="preview">
+        <iframe src="06n-tour-anlegen.html" title="Vorschau Tour eintragen" loading="lazy" tabindex="-1"></iframe>
+        <a class="cover" href="06n-tour-anlegen.html" aria-label="Tour eintragen öffnen"></a>
+      </div>
+      <div class="body">
+        <span class="nr">Prototyp 6n</span>
+        <h3>Tour eintragen</h3>
+        <p class="claim">Drei Felder Pflicht, alles andere zum Aufklappen.</p>
+        <p class="why">Stadt, Datum, Uhrzeit — fertig. Treffpunkt mit Karten-Picker und
+        Titel/Beschreibung sind optionale Aufklapp-Abschnitte. Rechts die Live-Vorschau
+        als Datums-Badge-Karte und die Hinweise (Rhythmus-Automatik, keine Freigabe nötig,
+        „keine Route nötig — die entsteht unterwegs").</p>
+        <a class="open" href="06n-tour-anlegen.html">Seite öffnen</a>
+      </div>
+    </article>
+
+  </div>
+
+  <a class="mobilelink" href="_mobile-check.html">
+    <b>Mobil-Vorschau öffnen →</b> &nbsp; Alle Prototypen nebeneinander im
+    Smartphone-Rahmen (390 px), ohne das Browserfenster verkleinern zu müssen.
+  </a>
+
+  <details class="older">
+    <summary>Runde 1 — vier verworfene Richtungen (Plakat, Nachtfahrt, Fahrplan, Atlas)</summary>
+    <div class="inner">
+      <p style="font-size:.9rem;color:var(--dim);margin-bottom:1rem">Erste Erkundung mit vier
+      thematischen Metaphern. Zurückgestellt zugunsten der Netzwerk-Richtung — Elemente daraus
+      (Klingel-Interaktion, dunkle Track-Karten, Tab-Leiste) leben in Runde 2 weiter.</p>
+      <p style="font-size:.95rem">
+        <a href="01-plakat.html"><strong>1 · Plakat</strong></a> — DIY/Spoke-Card-Ästhetik, laut und plakativ &nbsp;·&nbsp;
+        <a href="02-nachtfahrt.html"><strong>2 · Nachtfahrt</strong></a> — dunkel, Lichtspuren, Countdown &nbsp;·&nbsp;
+        <a href="03-fahrplan.html"><strong>3 · Fahrplan</strong></a> — ÖPNV-Sprache, Abfahrtstafel, Mitfahrkarte &nbsp;·&nbsp;
+        <a href="04-atlas.html"><strong>4 · Atlas</strong></a> — redaktionelles Kartenwerk mit Tafeln und Register
+      </p>
+    </div>
+  </details>
+
+</div>
+</body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.1.0",
       "license": "ISC",
       "dependencies": {
+        "@fontsource/archivo": "^5.2.8",
+        "@fontsource/ibm-plex-mono": "^5.2.7",
         "@maplibre/maplibre-gl-leaflet": "^0.1.3",
         "@popperjs/core": "^2.11.8",
         "bootstrap": "^5.3.0",
@@ -37,26 +39,29 @@
         "webpack-cli": "^5.1.4"
       },
       "devDependencies": {
+        "@babel/core": "^7.29.7",
+        "@babel/preset-env": "^7.29.7",
         "@fortawesome/fontawesome-pro": "^5.15.3",
         "@hotwired/stimulus": "^3.2.2",
         "@symfony/stimulus-bridge": "^4.0.1",
         "@symfony/webpack-encore": "^6.0.0",
+        "babel-loader": "^10.1.1",
         "core-js": "^3.48.0",
         "regenerator-runtime": "^0.13.2",
         "sass": "^1.97.3",
         "sass-loader": "^16.0.6",
+        "webpack": "^5.107.2",
         "webpack-notifier": "^1.6.0"
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -65,33 +70,31 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.6.tgz",
-      "integrity": "sha512-2lfu57JtzctfIrcGMz992hyLlByuzgIk58+hhGCxjKZ3rWI82NnVLjXcaTqkI2NvlcvOskZaiZ5kjUALo3Lpxg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.6.tgz",
-      "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/generator": "^7.28.6",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -108,15 +111,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -126,28 +128,27 @@
       }
     },
     "node_modules/@babel/helper-annotate-as-pure": {
-      "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
-      "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.29.7.tgz",
+      "integrity": "sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.27.3"
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -157,19 +158,18 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.6.tgz",
-      "integrity": "sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.29.7.tgz",
+      "integrity": "sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.3",
-        "@babel/helper-member-expression-to-functions": "^7.28.5",
-        "@babel/helper-optimise-call-expression": "^7.27.1",
-        "@babel/helper-replace-supers": "^7.28.6",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-        "@babel/traverse": "^7.28.6",
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-member-expression-to-functions": "^7.29.7",
+        "@babel/helper-optimise-call-expression": "^7.29.7",
+        "@babel/helper-replace-supers": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -180,14 +180,13 @@
       }
     },
     "node_modules/@babel/helper-create-regexp-features-plugin": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.28.5.tgz",
-      "integrity": "sha512-N1EhvLtHzOvj7QQOUCCS3NrPJP8c5W6ZXCHDn7Yialuy1iu4r5EmIYkXlKNqT99Ciw+W0mDqWoR6HWMZlFP3hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.29.7.tgz",
+      "integrity": "sha512-907Uymvqgg1dwUA+7IGwFAOSYzQOuzPXKNJ1yxzwPffzkYFg2q2eHi1fIOs6sXkG9NbIUMunnUlkYsfRFNvomg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-annotate-as-pure": "^7.29.7",
         "regexpu-core": "^6.3.1",
         "semver": "^6.3.1"
       },
@@ -199,12 +198,11 @@
       }
     },
     "node_modules/@babel/helper-define-polyfill-provider": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.6.tgz",
-      "integrity": "sha512-mOAsxeeKkUKayvZR3HeTYD/fICpCPLJrU5ZjelT/PA6WHtNDBOE436YiaEUvHN454bRM3CebhDsIpieCc4texA==",
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.8.tgz",
+      "integrity": "sha512-47UwBLPpQi1NoWzLuHNjRoHlYXMwIJoBf7MFou6viC/sIHWYygpvr0B6IAyh5sBdA2nr2LPIRww8lfaUVQINBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.28.6",
         "@babel/helper-plugin-utils": "^7.28.6",
@@ -217,55 +215,53 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.28.5.tgz",
-      "integrity": "sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.29.7.tgz",
+      "integrity": "sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.5",
-        "@babel/types": "^7.28.5"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -275,40 +271,38 @@
       }
     },
     "node_modules/@babel/helper-optimise-call-expression": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz",
-      "integrity": "sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.29.7.tgz",
+      "integrity": "sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.27.1"
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
-      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-remap-async-to-generator": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.27.1.tgz",
-      "integrity": "sha512-7fiA521aVw8lSPeI4ZOD3vRFkoqkJcS+z4hFo82bFSH/2tNd6eJ5qCVMS5OzDmZh/kaHQeBaeyxK6wljcPtveA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.29.7.tgz",
+      "integrity": "sha512-16AMiW26DbXWBbr3B8wNozKM0ydMLB892vaOaJW/fPJdnT8vJk5sdkQcU/isqUxyCE0cEoa8wZOcbgDuC4b6Og==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.1",
-        "@babel/helper-wrap-function": "^7.27.1",
-        "@babel/traverse": "^7.27.1"
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-wrap-function": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -318,16 +312,15 @@
       }
     },
     "node_modules/@babel/helper-replace-supers": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.28.6.tgz",
-      "integrity": "sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.29.7.tgz",
+      "integrity": "sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-member-expression-to-functions": "^7.28.5",
-        "@babel/helper-optimise-call-expression": "^7.27.1",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-member-expression-to-functions": "^7.29.7",
+        "@babel/helper-optimise-call-expression": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -337,90 +330,86 @@
       }
     },
     "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz",
-      "integrity": "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.29.7.tgz",
+      "integrity": "sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-wrap-function": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.28.6.tgz",
-      "integrity": "sha512-z+PwLziMNBeSQJonizz2AGnndLsP2DeGHIxDAn+wdHOGuo4Fo1x1HBPPXeE9TAOPHNNWQKCSlA2VZyYyyibDnQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.29.7.tgz",
+      "integrity": "sha512-iES0Skag9ERIF68aXadpO6dbXa03mNWK3sEqJaMnLNs/eC3l0lkImdfoy6Y09/SfkpawdAB4RjQ7PVA7TcVGdw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -430,15 +419,14 @@
       }
     },
     "node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.28.5.tgz",
-      "integrity": "sha512-87GDMS3tsmMSi/3bWOte1UblL+YUTFMV8SZPZ2eSEL17s74Cw/l63rR6NmGVKMYW2GYi85nE+/d6Hw5N0bEk2Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.29.7.tgz",
+      "integrity": "sha512-j8SrR0zLZrRsC09DlszEx8FpMiwukKffYXMK0d5LmOglO7vGG6sz/BR/20yHqWH+Lnn31JTt2PE3hIWNgM2J6w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/traverse": "^7.28.5"
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -448,14 +436,13 @@
       }
     },
     "node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.27.1.tgz",
-      "integrity": "sha512-qNeq3bCKnGgLkEXUuFry6dPlGfCdQNZbn7yUAPCInwAJHMU7THJfrBSozkcWq5sNM6RcF3S8XyQL2A52KNR9IA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.29.7.tgz",
+      "integrity": "sha512-r8j8escF+U2FUHo0KOhPUdMzUO+jp9fInva6+ACVAF3Y97Ev+5iNZwiqTghmzNeWwDkOPlYuTcfb1vDaoZKmAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -465,14 +452,30 @@
       }
     },
     "node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.27.1.tgz",
-      "integrity": "sha512-g4L7OYun04N1WyqMNjldFwlfPCLVkgB54A/YCXICZYBsvJJE3kByKv9c9+R/nAfmIfjl2rKYLNyMHboYbZaWaA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.29.7.tgz",
+      "integrity": "sha512-GE1TFSiuFeGsCxmYXZl8HwoPrVlwe4rHPFE8weieGKZqnDORK+Ar3vgWMgW+AOxQ6/2TgLSKx9p6W7O4rC6qgQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array/-/plugin-bugfix-safari-rest-destructuring-rhs-array-7.29.7.tgz",
+      "integrity": "sha512-oBNVCvnO5tND+xSopWvV8WNGfpTfgP4Zr/YXXSj8zfmcPktp5Ku/aZlsIowgSD4fjmgHn6sGmB9APVsU5zOdhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -482,16 +485,15 @@
       }
     },
     "node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.27.1.tgz",
-      "integrity": "sha512-oO02gcONcD5O1iTLi/6frMJBIwWEHceWGSGqrpCmEL8nogiS6J9PBlE48CaK20/Jx1LuRml9aDftLgdjXT8+Cw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.29.7.tgz",
+      "integrity": "sha512-QQt9qKHZ2sg/kivaLr7lnQr8HVrQDdBNSfCsTjiDxRuX/K5ORyKq+Bu8Xr0cDE3Dfkv0cw28Ve0EKyKMvulkOw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-        "@babel/plugin-transform-optional-chaining": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
+        "@babel/plugin-transform-optional-chaining": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -501,15 +503,14 @@
       }
     },
     "node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.28.6.tgz",
-      "integrity": "sha512-a0aBScVTlNaiUe35UtfxAN7A/tehvvG4/ByO6+46VPKTRSlfnAFsgKy0FUh+qAkQrDTmhDkT+IBOKlOoMUxQ0g==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.29.7.tgz",
+      "integrity": "sha512-pn6QacGLgvCcwc+syUhKE/qSjV2D1IHDB84RNxWYSt1mW3K/SCtjinZ2p0cETJxAWBjPy3K/1lHwG5BjjPxNlw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -524,7 +525,6 @@
       "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       },
@@ -533,14 +533,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-import-assertions": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.28.6.tgz",
-      "integrity": "sha512-pSJUpFHdx9z5nqTSirOCMtYVP2wFgoWhP0p3g8ONK/4IHhLIBd0B9NYqAvIUAhq+OkhO4VM1tENCt0cjlsNShw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.29.7.tgz",
+      "integrity": "sha512-/An1OCBN93thpBAGyfsK2pcf0jvju1SAtKkL2Ny++B5Sy6sqgzXDQH1cZxWbF96Wuk+bn41MDA9bLd4VVAw6rw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -550,14 +549,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-import-attributes": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
-      "integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.29.7.tgz",
+      "integrity": "sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -572,7 +570,6 @@
       "integrity": "sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.18.6",
         "@babel/helper-plugin-utils": "^7.18.6"
@@ -585,14 +582,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-arrow-functions": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.27.1.tgz",
-      "integrity": "sha512-8Z4TGic6xW70FKThA5HYEKKyBpOOsucTOD1DjU3fZxDg+K3zBJcXMFnt/4yQiZnf5+MiOMSXQ9PaEK/Ilh1DeA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.29.7.tgz",
+      "integrity": "sha512-N7zArUXWzAMzm+/N0uPBeVB3Fam5lMxtUwMmDK5f/IBBS7a7p1qeUoxd/6CckXoxUdgsntq1Dh8xNW06maZbDQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -602,16 +598,15 @@
       }
     },
     "node_modules/@babel/plugin-transform-async-generator-functions": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.28.6.tgz",
-      "integrity": "sha512-9knsChgsMzBV5Yh3kkhrZNxH3oCYAfMBkNNaVN4cP2RVlFPe8wYdwwcnOsAbkdDoV9UjFtOXWrWB52M8W4jNeA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.29.7.tgz",
+      "integrity": "sha512-d98gXZkgswvkyohMBABkhm3GeXhYj8psWfwQ2C7gtfrKGTykQa/iOIi+JJhwMjPlZ6Vm2XN+DCf3Es1EoG4ZLA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/helper-remap-async-to-generator": "^7.27.1",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-remap-async-to-generator": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -621,16 +616,15 @@
       }
     },
     "node_modules/@babel/plugin-transform-async-to-generator": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.28.6.tgz",
-      "integrity": "sha512-ilTRcmbuXjsMmcZ3HASTe4caH5Tpo93PkTxF9oG2VZsSWsahydmcEHhix9Ik122RcTnZnUzPbmux4wh1swfv7g==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.29.7.tgz",
+      "integrity": "sha512-pcUb2SS+RMo9TWVBwKGI5ShtoG7R+zBsFmCKDa6fe8c+hPr3XJlZgoE5j6i8W7gDjhyvy+85vmYexanvXh3d1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/helper-remap-async-to-generator": "^7.27.1"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-remap-async-to-generator": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -640,14 +634,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-block-scoped-functions": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.27.1.tgz",
-      "integrity": "sha512-cnqkuOtZLapWYZUYM5rVIdv1nXYuFVIltZ6ZJ7nIj585QsjKM5dhL2Fu/lICXZ1OyIAFc7Qy+bvDAtTXqGrlhg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.29.7.tgz",
+      "integrity": "sha512-cUSmjh72N+rN4PrkFlN1dJwNCwjVp5d38/CQrEsFggkD10UiFlBFgdH3tv5dNsLuHY+3S8db2xCHjhZcv5WgvA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -657,14 +650,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-block-scoping": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.28.6.tgz",
-      "integrity": "sha512-tt/7wOtBmwHPNMPu7ax4pdPz6shjFrmHDghvNC+FG9Qvj7D6mJcoRQIF5dy4njmxR941l6rgtvfSB2zX3VlUIw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.29.7.tgz",
+      "integrity": "sha512-ONyr4+AZhKh8yKWInVxU9AXA9EbsyeLcL6V0dJy6M2/62vuvpGm29zzuymbTpdc451GEpDIdAyPLP3r+P61yKQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -674,15 +666,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-class-properties": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.28.6.tgz",
-      "integrity": "sha512-dY2wS3I2G7D697VHndN91TJr8/AAfXQNt5ynCTI/MpxMsSzHp+52uNivYT5wCPax3whc47DR8Ba7cmlQMg24bw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.29.7.tgz",
+      "integrity": "sha512-GtcpjFvanPfzNQi3eTitsCqtRRmmqzpy/A+yhTR1HaZo1Ly3EA8ZXxlPyHdR8/IuRMYc3E4wdGBewB2QKQjAaA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.28.6",
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-create-class-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -692,15 +683,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-class-static-block": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.28.6.tgz",
-      "integrity": "sha512-rfQ++ghVwTWTqQ7w8qyDxL1XGihjBss4CmTgGRCTAC9RIbhVpyp4fOeZtta0Lbf+dTNIVJer6ych2ibHwkZqsQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.29.7.tgz",
+      "integrity": "sha512-kibJgmEdX2iMwsHY2tSZNDgj8PwIlCQz7FK9KuGKO8zsuoUwSEhoNnNVp/emKWrbY4HeO6kkXfdMqRKKKXBm2A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.28.6",
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-create-class-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -710,19 +700,18 @@
       }
     },
     "node_modules/@babel/plugin-transform-classes": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.28.6.tgz",
-      "integrity": "sha512-EF5KONAqC5zAqT783iMGuM2ZtmEBy+mJMOKl2BCvPZ2lVrwvXnB6o+OBWCS+CoeCCpVRF2sA2RBKUxvT8tQT5Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.29.7.tgz",
+      "integrity": "sha512-qV0OGGBVacduzQHE649JyCneOFI/maT+YKsO+K4Yi3xv2wTPNjM/W2o2gdzMwEAZz7fXNTHAe0NcSg30bIN69g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.3",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/helper-replace-supers": "^7.28.6",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-replace-supers": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -732,15 +721,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-computed-properties": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.28.6.tgz",
-      "integrity": "sha512-bcc3k0ijhHbc2lEfpFHgx7eYw9KNXqOerKWfzbxEHUGKnS3sz9C4CNL9OiFN1297bDNfUiSO7DaLzbvHQQQ1BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.29.7.tgz",
+      "integrity": "sha512-RK7/IyU5phpuCdBAuig5VkzG/EnbDaui5SQGdU9BFrHdV+mV4cUjLMQ9lJDjLNtWHsqtiefpGZUXQP2BiTYMsA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/template": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/template": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -750,15 +738,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-destructuring": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.28.5.tgz",
-      "integrity": "sha512-Kl9Bc6D0zTUcFUvkNuQh4eGXPKKNDOJQXVyyM4ZAQPMveniJdxi8XMJwLo+xSoW3MIq81bD33lcUe9kZpl0MCw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.29.7.tgz",
+      "integrity": "sha512-iPX8aD6H9zV5s7ZsqTdNocPN/MGQ5sSMnElKrktxjJRMnB2jN/1p2+R7GkfD6CAYoVFqy5A4XnSIUeGgJzIWpg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/traverse": "^7.28.5"
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -768,15 +755,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-dotall-regex": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.28.6.tgz",
-      "integrity": "sha512-SljjowuNKB7q5Oayv4FoPzeB74g3QgLt8IVJw9ADvWy3QnUb/01aw8I4AVv8wYnPvQz2GDDZ/g3GhcNyDBI4Bg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.29.7.tgz",
+      "integrity": "sha512-3qc18hsD2RdZiyJNDNc7HQpv6xbncwh8FYtxNFFzclSyh/trPD9KkVR9BDECUjDLvb7yJVF15GfYUuC+LMkkiQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -786,14 +772,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-duplicate-keys": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.27.1.tgz",
-      "integrity": "sha512-MTyJk98sHvSs+cvZ4nOauwTTG1JeonDjSGvGGUNHreGQns+Mpt6WX/dVzWBHgg+dYZhkC4X+zTDfkTU+Vy9y7Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.29.7.tgz",
+      "integrity": "sha512-6IvRRriEMqnBwD6chtxdLpMYCHWEzN+oL5cyQtjykya19UgzbmKhxmhZgKC/LHxS2nYr9Q/qYPZ5Lr6jOL9+yQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -803,15 +788,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.28.6.tgz",
-      "integrity": "sha512-5suVoXjC14lUN6ZL9OLKIHCNVWCrqGqlmEp/ixdXjvgnEl/kauLvvMO/Xw9NyMc95Joj1AeLVPVMvibBgSoFlA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.29.7.tgz",
+      "integrity": "sha512-2wiIyo2BjtgU7HufSeDnL9L2O7zr8jmhFKuSr65VpRkUiRKRNpb0mdlk56+XPPKoIrfHqzbMuglDvZun0RISsA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -821,14 +805,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-dynamic-import": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.27.1.tgz",
-      "integrity": "sha512-MHzkWQcEmjzzVW9j2q8LGjwGWpG2mjwaaB0BNQwst3FIjqsg8Ct/mIZlvSPJvfi9y2AC8mi/ktxbFVL9pZ1I4A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.29.7.tgz",
+      "integrity": "sha512-giOlEm/EFjfjr+te9NsdjkUo2v4f8rS/SXPumRVHAtbNcyNlvtREkU1dZzaIDclNpnaVhlCqRdFKhJBjBikzLg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -838,15 +821,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-explicit-resource-management": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.28.6.tgz",
-      "integrity": "sha512-Iao5Konzx2b6g7EPqTy40UZbcdXE126tTxVFr/nAIj+WItNxjKSYTEw3RC+A2/ZetmdJsgueL1KhaMCQHkLPIg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.29.7.tgz",
+      "integrity": "sha512-Rstj7coNz8sE+7Ju7ihpHLI564lsK5pUpNNlvptCIC/16E/S5hbl6n3kESPKdNRmqEWlpn5xpS5Q2dvXBsySLw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/plugin-transform-destructuring": "^7.28.5"
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/plugin-transform-destructuring": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -856,14 +838,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-exponentiation-operator": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.28.6.tgz",
-      "integrity": "sha512-WitabqiGjV/vJ0aPOLSFfNY1u9U3R7W36B03r5I2KoNix+a3sOhJ3pKFB3R5It9/UiK78NiO0KE9P21cMhlPkw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.29.7.tgz",
+      "integrity": "sha512-zFpMOTLZBdW5LfObqcSbL6kefg4R4eLdmvS0wbN9M6D5Mym/sKm9toOoWyVOa+xDjvCnuWcHls2YonXwHvH3CQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -873,14 +854,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-export-namespace-from": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.27.1.tgz",
-      "integrity": "sha512-tQvHWSZ3/jH2xuq/vZDy0jNn+ZdXJeM8gHvX4lnJmsc3+50yPlWdZXIc5ay+umX+2/tJIqHqiEqcJvxlmIvRvQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.29.7.tgz",
+      "integrity": "sha512-24B2nOy2TeJSMheqwPD4DDQOV/elLSIlKxjZt4i05H5AgdPdWR3n18HnNrcJ+j76WJd9gbwb9jPjNYUy6RautA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -890,15 +870,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-for-of": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.27.1.tgz",
-      "integrity": "sha512-BfbWFFEJFQzLCQ5N8VocnCtA8J1CLkNTe2Ms2wocj75dd6VpiqS5Z5quTYcUoo4Yq+DN0rtikODccuv7RU81sw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.29.7.tgz",
+      "integrity": "sha512-zeSIHh0+E1Um1WJRXCFlHQYu2ieJNdivLLjlBEp+dIBu3S51n+SZZmIXjxnItw6pz56Cn+KvK68BIBVsxq2JiQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -908,16 +887,15 @@
       }
     },
     "node_modules/@babel/plugin-transform-function-name": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.27.1.tgz",
-      "integrity": "sha512-1bQeydJF9Nr1eBCMMbC+hdwmRlsv5XYOMu03YSWFwNs0HsAmtSxxF1fyuYPqemVldVyFmlCU7w8UE14LupUSZQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.29.7.tgz",
+      "integrity": "sha512-otRWaHXE6fbAGkePvaj/kvs3HsqXfPhlnzwSOlnFgbqCPMd975dW+4wZ00WFBt+/YlBGcJwNrARQTOJOb4ZrIg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-compilation-targets": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/traverse": "^7.27.1"
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -927,14 +905,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-json-strings": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.28.6.tgz",
-      "integrity": "sha512-Nr+hEN+0geQkzhbdgQVPoqr47lZbm+5fCUmO70722xJZd0Mvb59+33QLImGj6F+DkK3xgDi1YVysP8whD6FQAw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.29.7.tgz",
+      "integrity": "sha512-RRnE2+eon1rJAq8MnoF1b5kTpY1vU88twHcvcKMrsqP/jxIRqDVs9iJB5fqPuqyeFAW0wJo4MlUIPpQCq/aRsg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -944,14 +921,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-literals": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.27.1.tgz",
-      "integrity": "sha512-0HCFSepIpLTkLcsi86GG3mTUzxV5jpmbv97hTETW3yzrAij8aqlD36toB1D0daVFJM8NK6GvKO0gslVQmm+zZA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.29.7.tgz",
+      "integrity": "sha512-DZ/oLP21ZuWx1vKqnoNv6/tvEK48AQOBRai40CX9dTjGluvT/YZCyY3rryDtyUqCEoyNroy5KKPwX2iQCiRvyw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -961,14 +937,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-logical-assignment-operators": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.28.6.tgz",
-      "integrity": "sha512-+anKKair6gpi8VsM/95kmomGNMD0eLz1NQ8+Pfw5sAwWH9fGYXT50E55ZpV0pHUHWf6IUTWPM+f/7AAff+wr9A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.29.7.tgz",
+      "integrity": "sha512-A0H91hh6W8MFRkp5TqJmMr39jzGD1A1E1Ysiv2O06Sfbhkapm+XyIzxWCEh5kqwOZ1/8QZ0dY3SeQ7XBqfJd5Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -978,14 +953,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-member-expression-literals": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.27.1.tgz",
-      "integrity": "sha512-hqoBX4dcZ1I33jCSWcXrP+1Ku7kdqXf1oeah7ooKOIiAdKQ+uqftgCFNOSzA5AMS2XIHEYeGFg4cKRCdpxzVOQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.29.7.tgz",
+      "integrity": "sha512-hl1kwFZCCiDyfH25Xmco9jTrkPgnS9pmOzSG7W5I4SaGbLeqKv417hcU2RKmaxoPEgsoJh7ZPOrnPGq99bHoUg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -995,15 +969,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-amd": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.27.1.tgz",
-      "integrity": "sha512-iCsytMg/N9/oFq6n+gFTvUYDZQOMK5kEdeYxmxt91fcJGycfxVP9CnrxoliM0oumFERba2i8ZtwRUCMhvP1LnA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.29.7.tgz",
+      "integrity": "sha512-fxtQoH3m5ywUSIfaH0FGCzWu4McsYon5bD3K4XnskC7f+OyQMj7rsOMi4NvvmJ83WwBAg4UCe+ov4VZlqEvyew==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1013,15 +986,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-commonjs": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.28.6.tgz",
-      "integrity": "sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.29.7.tgz",
+      "integrity": "sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1031,17 +1003,16 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.29.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz",
-      "integrity": "sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.7.tgz",
+      "integrity": "sha512-TM2ZcQLoG2/y4HODiStCo10DibYhWhGWAwVv+EQKmG/7GFl0N+AAmUiXOMKM+aiJ9XBJ9AHVZBvTzMnJ2sM3cQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.29.0"
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1051,15 +1022,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-umd": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.27.1.tgz",
-      "integrity": "sha512-iQBE/xC5BV1OxJbp6WG7jq9IWiD+xxlZhLrdwpPkTX3ydmXdvoCpyfJN7acaIBZaOqTfr76pgzqBJflNbeRK+w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.29.7.tgz",
+      "integrity": "sha512-B4UkaTK3QpgCwJnrxKfMPKdo92CN7OKXAlpAAnM3UPu0Q0lCCk57ylA9AJbRy2v8dDKOPAAWcoR6CMyeoHwRCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1069,15 +1039,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.27.1.tgz",
-      "integrity": "sha512-SstR5JYy8ddZvD6MhV0tM/j16Qds4mIpJTOd1Yu9J9pJjH93bxHECF7pgtc28XvkzTD6Pxcm/0Z73Hvk7kb3Ng==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.29.7.tgz",
+      "integrity": "sha512-vuFoLwr4qnv2xbZ16SQd6uPcH5FNrLHhk/Jzo++0XJFcaDsr4gjJVg6j398oMHiC+83k/GiBzviwF5KBJkPUtQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1087,14 +1056,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-new-target": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.27.1.tgz",
-      "integrity": "sha512-f6PiYeqXQ05lYq3TIfIDu/MtliKUbNwkGApPUvyo6+tc7uaR4cPjPe7DFPr15Uyycg2lZU6btZ575CuQoYh7MQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.29.7.tgz",
+      "integrity": "sha512-fEo41GmsOUhOBlw8ioo6zvjX5Xc2Lqkzlyfqbpsk3eB6TReV18uhxZ0esfEokVbY2+PVJAQHNKxER6lGrzNd3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1104,14 +1072,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.28.6.tgz",
-      "integrity": "sha512-3wKbRgmzYbw24mDJXT7N+ADXw8BC/imU9yo9c9X9NKaLF1fW+e5H1U5QjMUBe4Qo4Ox/o++IyUkl1sVCLgevKg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.29.7.tgz",
+      "integrity": "sha512-idmp1dFaekP9GbcMvG24Kvw2BfhFZjHnNJCkV4WuIY4PskJzwI3f1N5OdgYke38T7rftO6ERulFRn2cFeZwRkg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1121,14 +1088,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-numeric-separator": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.28.6.tgz",
-      "integrity": "sha512-SJR8hPynj8outz+SlStQSwvziMN4+Bq99it4tMIf5/Caq+3iOc0JtKyse8puvyXkk3eFRIA5ID/XfunGgO5i6w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.29.7.tgz",
+      "integrity": "sha512-zR7fv/z14OjgHl4AgRtkDBvBMhIzCxqV/qN/2BCRC7LjFwvuzjYe7gDWxC4Wl/SNsLM6SE1IWvRPYMgSJaUvNw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1138,18 +1104,17 @@
       }
     },
     "node_modules/@babel/plugin-transform-object-rest-spread": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.28.6.tgz",
-      "integrity": "sha512-5rh+JR4JBC4pGkXLAcYdLHZjXudVxWMXbB6u6+E9lRL5TrGVbHt1TjxGbZ8CkmYw9zjkB7jutzOROArsqtncEA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.29.7.tgz",
+      "integrity": "sha512-Ld98jn4c0smUywL57m7SgsHq3OpThOa6LqZJif3G6jYOovPleoFhVrBJ1WegRApSFB2wu4+RelAj9AC9G08Z4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/plugin-transform-destructuring": "^7.28.5",
-        "@babel/plugin-transform-parameters": "^7.27.7",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/plugin-transform-destructuring": "^7.29.7",
+        "@babel/plugin-transform-parameters": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1159,15 +1124,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-object-super": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.27.1.tgz",
-      "integrity": "sha512-SFy8S9plRPbIcxlJ8A6mT/CxFdJx/c04JEctz4jf8YZaVS2px34j7NXRrlGlHkN/M2gnpL37ZpGRGVFLd3l8Ng==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.29.7.tgz",
+      "integrity": "sha512-Ea/diGcw0twB5IlZPO5sgET6fJsLJqPABqTuFWIR+iMPGPZJkATEIWx0wa+aEQ5UY1CBQyP/gkAiLEqn1vBiQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/helper-replace-supers": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-replace-supers": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1177,14 +1141,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-optional-catch-binding": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.28.6.tgz",
-      "integrity": "sha512-R8ja/Pyrv0OGAvAXQhSTmWyPJPml+0TMqXlO5w+AsMEiwb2fg3WkOvob7UxFSL3OIttFSGSRFKQsOhJ/X6HQdQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.29.7.tgz",
+      "integrity": "sha512-sLsyndxK2VwX6yNUOakMb7Sh553ZTe/vVM1XJ+9Z5aW1ytsc8xOIwmyk05NNjN60vkc5/KqoTH6hB4V41LJhng==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1194,15 +1157,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-optional-chaining": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.28.6.tgz",
-      "integrity": "sha512-A4zobikRGJTsX9uqVFdafzGkqD30t26ck2LmOzAuLL8b2x6k3TIqRiT2xVvA9fNmFeTX484VpsdgmKNA0bS23w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.29.7.tgz",
+      "integrity": "sha512-6GM1dhvK3gNODkXcEcMCOLEDCLSoZ/sBbro2Ax8HURyasQ4NshagQixkRFdh5niI6E4gmA/jYI/4aT7rRos3ZQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1212,14 +1174,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-parameters": {
-      "version": "7.27.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.27.7.tgz",
-      "integrity": "sha512-qBkYTYCb76RRxUM6CcZA5KRu8K4SM8ajzVeUgVdMVO9NN9uI/GaVmBg/WKJJGnNokV9SY8FxNOVWGXzqzUidBg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.29.7.tgz",
+      "integrity": "sha512-ZDOBqV/qLYJI0YElr8DcENEyARsFQeESqWXH6gZlghYXuPPjvweuDhP4VyEi4BlUBlLRFZVjxoZDMjxhLW766g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1229,15 +1190,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-private-methods": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.28.6.tgz",
-      "integrity": "sha512-piiuapX9CRv7+0st8lmuUlRSmX6mBcVeNQ1b4AYzJxfCMuBfB0vBXDiGSmm03pKJw1v6cZ8KSeM+oUnM6yAExg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.29.7.tgz",
+      "integrity": "sha512-/6Rz4DK1ETDEM/bWHsPHcaEe7ZaT1EqSXjtSP/L0DijOYuaUhiRiOKcwpZ8P7zR4xXEHc2ITdiCgBm9Tpyv9ug==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.28.6",
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-create-class-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1247,16 +1207,15 @@
       }
     },
     "node_modules/@babel/plugin-transform-private-property-in-object": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.28.6.tgz",
-      "integrity": "sha512-b97jvNSOb5+ehyQmBpmhOCiUC5oVK4PMnpRvO7+ymFBoqYjeDHIU9jnrNUuwHOiL9RpGDoKBpSViarV+BU+eVA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.29.7.tgz",
+      "integrity": "sha512-+BNo06dnrzdNNqCm1X6YUaVv0DKk8Q+JYcoZfOkLhYWNCXzlwTSRq8zGWayT1csjcpNXV9CQTBRRbmTLZac5cA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.3",
-        "@babel/helper-create-class-features-plugin": "^7.28.6",
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-create-class-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1266,14 +1225,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-property-literals": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.27.1.tgz",
-      "integrity": "sha512-oThy3BCuCha8kDZ8ZkgOg2exvPYUlprMukKQXI1r1pJ47NCvxfkEy8vK+r/hT9nF0Aa4H1WUPZZjHTFtAhGfmQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.29.7.tgz",
+      "integrity": "sha512-bOMRLQuI0A5ZqHq3OWJ89/rXpJ/NJrbVhXiP4zwPGMs6kpcVsuTUNjwoE30K0Qm3mf48a/TnRYYD6vPNqcg6jA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1283,14 +1241,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-regenerator": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.28.6.tgz",
-      "integrity": "sha512-eZhoEZHYQLL5uc1gS5e9/oTknS0sSSAtd5TkKMUp3J+S/CaUjagc0kOUPsEbDmMeva0nC3WWl4SxVY6+OBuxfw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.29.7.tgz",
+      "integrity": "sha512-rNNFV0DBAJp988xW2DOntfDoYn1eR8GGF5AT5vYc+rjyfaQkM242c9tZUHHPe7KYaiJizXPWhQTzzdbXySyhBw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1300,15 +1257,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-regexp-modifiers": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.28.6.tgz",
-      "integrity": "sha512-QGWAepm9qxpaIs7UM9FvUSnCGlb8Ua1RhyM4/veAxLwt3gMat/LSGrZixyuj4I6+Kn9iwvqCyPTtbdxanYoWYg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.29.7.tgz",
+      "integrity": "sha512-mB5Fs0VWrJ42ZCmc8114v60qetdaUVNkj9PmSZRmanCZM3S9hm0CFRLjRmYIsuXav14l2jvZ+4T8iiCGnhj3nQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1318,14 +1274,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-reserved-words": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.27.1.tgz",
-      "integrity": "sha512-V2ABPHIJX4kC7HegLkYoDpfg9PVmuWy/i6vUM5eGK22bx4YVFD3M5F0QQnWQoDs6AGsUWTVOopBiMFQgHaSkVw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.29.7.tgz",
+      "integrity": "sha512-5+YhdpVgmfSmwZyLMftfaiffLRMHjzIRHFHHLdibcSyJm2pasMrKHrO3Ptrt2DRshjvpgjEJJ1zVW14WPq/6QA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1335,14 +1290,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-shorthand-properties": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.27.1.tgz",
-      "integrity": "sha512-N/wH1vcn4oYawbJ13Y/FxcQrWk63jhfNa7jef0ih7PHSIHX2LB7GWE1rkPrOnka9kwMxb6hMl19p7lidA+EHmQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.29.7.tgz",
+      "integrity": "sha512-I+WYbGBAiCn7nA6xBrlgPH+MB7HWb4u8pv5S0Pv7OtwNvIFvCCb24YlttKEeUFVurfBCEaOTnuhlqsb7f0Z5Dg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1352,15 +1306,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-spread": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.28.6.tgz",
-      "integrity": "sha512-9U4QObUC0FtJl05AsUcodau/RWDytrU6uKgkxu09mLR9HLDAtUMoPuuskm5huQsoktmsYpI+bGmq+iapDcriKA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.29.7.tgz",
+      "integrity": "sha512-/u5K1QWada7tbYNqTjMh96718g9NTwh9tfPJMsSmVsQwGT447FskV+KcfeXkXq2GWki4EM/MuTdmBec+hOuVTQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1370,14 +1323,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-sticky-regex": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.27.1.tgz",
-      "integrity": "sha512-lhInBO5bi/Kowe2/aLdBAawijx+q1pQzicSgnkB6dUPc1+RC8QmJHKf2OjvU+NZWitguJHEaEmbV6VWEouT58g==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.29.7.tgz",
+      "integrity": "sha512-BCHzNYJGe9l7EpwwDBN/ztlL2NYFFq8hp9ddjtUEM9f2O7S7kKV/lL6Fwo7IF7NSkYhPK2vO+86nIGltA90MsA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1387,14 +1339,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-template-literals": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.27.1.tgz",
-      "integrity": "sha512-fBJKiV7F2DxZUkg5EtHKXQdbsbURW3DZKQUWphDum0uRP6eHGGa/He9mc0mypL680pb+e/lDIthRohlv8NCHkg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.29.7.tgz",
+      "integrity": "sha512-NCSEJ4sLFU2gqAub45HYh4fus2yQ36rr6ei6vpU7NdoJqCpxvEG8E6eJpscGyXP3VHD2Ny+fSXr04k1hoUrFqA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1404,14 +1355,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-typeof-symbol": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.27.1.tgz",
-      "integrity": "sha512-RiSILC+nRJM7FY5srIyc4/fGIwUhyDuuBSdWn4y6yT6gm652DpCHZjIipgn6B7MQ1ITOUnAKWixEUjQRIBIcLw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.29.7.tgz",
+      "integrity": "sha512-223mNGoTkBiTEWFoK+Q6Go3tueMRclO8vxxxxquNCYuNI4jWOofFKJRRDu6SDrB8Sgo1UEGW9T4GAQ8ZyRso1A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1421,14 +1371,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-unicode-escapes": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.27.1.tgz",
-      "integrity": "sha512-Ysg4v6AmF26k9vpfFuTZg8HRfVWzsh1kVfowA23y9j/Gu6dOuahdUVhkLqpObp3JIv27MLSii6noRnuKN8H0Mg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.29.7.tgz",
+      "integrity": "sha512-jCfXxSjf94lf4E0hKE0AByxF6F3/pVFqRdUUNkDJhsY0m1ZKjnN6ZYyMeHNpzflxb/0q5b7t3p+BE+SLF1WOtA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1438,15 +1387,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-unicode-property-regex": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.28.6.tgz",
-      "integrity": "sha512-4Wlbdl/sIZjzi/8St0evF0gEZrgOswVO6aOzqxh1kDZOl9WmLrHq2HtGhnOJZmHZYKP8WZ1MDLCt5DAWwRo57A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.29.7.tgz",
+      "integrity": "sha512-OgZ+zoAJgZLUCunsTRQ5LAjOywDv5zzZ2/hQ5aMw1pGXyY2rtE8/chXYUmu3AlVHKpm10KEdG9aMwbI/K76ZGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1456,15 +1404,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-unicode-regex": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.27.1.tgz",
-      "integrity": "sha512-xvINq24TRojDuyt6JGtHmkVkrfVV3FPT16uytxImLeBZqW3/H52yN+kM1MGuyPkIQxrzKwPHs5U/MP3qKyzkGw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.29.7.tgz",
+      "integrity": "sha512-7D/x/23/d/3VqZ0QA+LGbZMlGwZjztBygSWWWsfTPoQ1oQ6Q1P6Mr3d0kk42XabyUVw+fha3LqdRsFqeKqvCyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1474,15 +1421,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-unicode-sets-regex": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.28.6.tgz",
-      "integrity": "sha512-/wHc/paTUmsDYN7SZkpWxogTOBNnlx7nBQYfy6JJlCT7G3mVhltk3e++N7zV0XfgGsrqBxd4rJQt9H16I21Y1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.29.7.tgz",
+      "integrity": "sha512-BLOhLht9DOJwIxlmp91wHvkXv1lguuHS3/FwUO8HL1H0u8s4hR1gASVFyilu9iGtcTRYqjTZmlsFFeQletntEg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.28.5",
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-create-regexp-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1492,82 +1438,82 @@
       }
     },
     "node_modules/@babel/preset-env": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.28.6.tgz",
-      "integrity": "sha512-GaTI4nXDrs7l0qaJ6Rg06dtOXTBCG6TMDB44zbqofCIC4PqC7SEvmFFtpxzCDw9W5aJ7RKVshgXTLvLdBFV/qw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.7.tgz",
+      "integrity": "sha512-GYzX36n1nsciIb0uyH0GHwxwtNwPQIcpxSeiVLDtG/B7jB5xXgchnmL1f/jCX5o+pwnaDBtO60ONSJhEBJfxYA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
-        "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.28.5",
-        "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.27.1",
-        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.27.1",
-        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.27.1",
-        "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.28.6",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.29.7",
+        "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.29.7",
+        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.29.7",
+        "@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": "^7.29.7",
+        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.29.7",
+        "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.29.7",
         "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
-        "@babel/plugin-syntax-import-assertions": "^7.28.6",
-        "@babel/plugin-syntax-import-attributes": "^7.28.6",
+        "@babel/plugin-syntax-import-assertions": "^7.29.7",
+        "@babel/plugin-syntax-import-attributes": "^7.29.7",
         "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
-        "@babel/plugin-transform-arrow-functions": "^7.27.1",
-        "@babel/plugin-transform-async-generator-functions": "^7.28.6",
-        "@babel/plugin-transform-async-to-generator": "^7.28.6",
-        "@babel/plugin-transform-block-scoped-functions": "^7.27.1",
-        "@babel/plugin-transform-block-scoping": "^7.28.6",
-        "@babel/plugin-transform-class-properties": "^7.28.6",
-        "@babel/plugin-transform-class-static-block": "^7.28.6",
-        "@babel/plugin-transform-classes": "^7.28.6",
-        "@babel/plugin-transform-computed-properties": "^7.28.6",
-        "@babel/plugin-transform-destructuring": "^7.28.5",
-        "@babel/plugin-transform-dotall-regex": "^7.28.6",
-        "@babel/plugin-transform-duplicate-keys": "^7.27.1",
-        "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.28.6",
-        "@babel/plugin-transform-dynamic-import": "^7.27.1",
-        "@babel/plugin-transform-explicit-resource-management": "^7.28.6",
-        "@babel/plugin-transform-exponentiation-operator": "^7.28.6",
-        "@babel/plugin-transform-export-namespace-from": "^7.27.1",
-        "@babel/plugin-transform-for-of": "^7.27.1",
-        "@babel/plugin-transform-function-name": "^7.27.1",
-        "@babel/plugin-transform-json-strings": "^7.28.6",
-        "@babel/plugin-transform-literals": "^7.27.1",
-        "@babel/plugin-transform-logical-assignment-operators": "^7.28.6",
-        "@babel/plugin-transform-member-expression-literals": "^7.27.1",
-        "@babel/plugin-transform-modules-amd": "^7.27.1",
-        "@babel/plugin-transform-modules-commonjs": "^7.28.6",
-        "@babel/plugin-transform-modules-systemjs": "^7.28.5",
-        "@babel/plugin-transform-modules-umd": "^7.27.1",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.27.1",
-        "@babel/plugin-transform-new-target": "^7.27.1",
-        "@babel/plugin-transform-nullish-coalescing-operator": "^7.28.6",
-        "@babel/plugin-transform-numeric-separator": "^7.28.6",
-        "@babel/plugin-transform-object-rest-spread": "^7.28.6",
-        "@babel/plugin-transform-object-super": "^7.27.1",
-        "@babel/plugin-transform-optional-catch-binding": "^7.28.6",
-        "@babel/plugin-transform-optional-chaining": "^7.28.6",
-        "@babel/plugin-transform-parameters": "^7.27.7",
-        "@babel/plugin-transform-private-methods": "^7.28.6",
-        "@babel/plugin-transform-private-property-in-object": "^7.28.6",
-        "@babel/plugin-transform-property-literals": "^7.27.1",
-        "@babel/plugin-transform-regenerator": "^7.28.6",
-        "@babel/plugin-transform-regexp-modifiers": "^7.28.6",
-        "@babel/plugin-transform-reserved-words": "^7.27.1",
-        "@babel/plugin-transform-shorthand-properties": "^7.27.1",
-        "@babel/plugin-transform-spread": "^7.28.6",
-        "@babel/plugin-transform-sticky-regex": "^7.27.1",
-        "@babel/plugin-transform-template-literals": "^7.27.1",
-        "@babel/plugin-transform-typeof-symbol": "^7.27.1",
-        "@babel/plugin-transform-unicode-escapes": "^7.27.1",
-        "@babel/plugin-transform-unicode-property-regex": "^7.28.6",
-        "@babel/plugin-transform-unicode-regex": "^7.27.1",
-        "@babel/plugin-transform-unicode-sets-regex": "^7.28.6",
+        "@babel/plugin-transform-arrow-functions": "^7.29.7",
+        "@babel/plugin-transform-async-generator-functions": "^7.29.7",
+        "@babel/plugin-transform-async-to-generator": "^7.29.7",
+        "@babel/plugin-transform-block-scoped-functions": "^7.29.7",
+        "@babel/plugin-transform-block-scoping": "^7.29.7",
+        "@babel/plugin-transform-class-properties": "^7.29.7",
+        "@babel/plugin-transform-class-static-block": "^7.29.7",
+        "@babel/plugin-transform-classes": "^7.29.7",
+        "@babel/plugin-transform-computed-properties": "^7.29.7",
+        "@babel/plugin-transform-destructuring": "^7.29.7",
+        "@babel/plugin-transform-dotall-regex": "^7.29.7",
+        "@babel/plugin-transform-duplicate-keys": "^7.29.7",
+        "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.29.7",
+        "@babel/plugin-transform-dynamic-import": "^7.29.7",
+        "@babel/plugin-transform-explicit-resource-management": "^7.29.7",
+        "@babel/plugin-transform-exponentiation-operator": "^7.29.7",
+        "@babel/plugin-transform-export-namespace-from": "^7.29.7",
+        "@babel/plugin-transform-for-of": "^7.29.7",
+        "@babel/plugin-transform-function-name": "^7.29.7",
+        "@babel/plugin-transform-json-strings": "^7.29.7",
+        "@babel/plugin-transform-literals": "^7.29.7",
+        "@babel/plugin-transform-logical-assignment-operators": "^7.29.7",
+        "@babel/plugin-transform-member-expression-literals": "^7.29.7",
+        "@babel/plugin-transform-modules-amd": "^7.29.7",
+        "@babel/plugin-transform-modules-commonjs": "^7.29.7",
+        "@babel/plugin-transform-modules-systemjs": "^7.29.7",
+        "@babel/plugin-transform-modules-umd": "^7.29.7",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.29.7",
+        "@babel/plugin-transform-new-target": "^7.29.7",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.29.7",
+        "@babel/plugin-transform-numeric-separator": "^7.29.7",
+        "@babel/plugin-transform-object-rest-spread": "^7.29.7",
+        "@babel/plugin-transform-object-super": "^7.29.7",
+        "@babel/plugin-transform-optional-catch-binding": "^7.29.7",
+        "@babel/plugin-transform-optional-chaining": "^7.29.7",
+        "@babel/plugin-transform-parameters": "^7.29.7",
+        "@babel/plugin-transform-private-methods": "^7.29.7",
+        "@babel/plugin-transform-private-property-in-object": "^7.29.7",
+        "@babel/plugin-transform-property-literals": "^7.29.7",
+        "@babel/plugin-transform-regenerator": "^7.29.7",
+        "@babel/plugin-transform-regexp-modifiers": "^7.29.7",
+        "@babel/plugin-transform-reserved-words": "^7.29.7",
+        "@babel/plugin-transform-shorthand-properties": "^7.29.7",
+        "@babel/plugin-transform-spread": "^7.29.7",
+        "@babel/plugin-transform-sticky-regex": "^7.29.7",
+        "@babel/plugin-transform-template-literals": "^7.29.7",
+        "@babel/plugin-transform-typeof-symbol": "^7.29.7",
+        "@babel/plugin-transform-unicode-escapes": "^7.29.7",
+        "@babel/plugin-transform-unicode-property-regex": "^7.29.7",
+        "@babel/plugin-transform-unicode-regex": "^7.29.7",
+        "@babel/plugin-transform-unicode-sets-regex": "^7.29.7",
         "@babel/preset-modules": "0.1.6-no-external-plugins",
-        "babel-plugin-polyfill-corejs2": "^0.4.14",
-        "babel-plugin-polyfill-corejs3": "^0.13.0",
-        "babel-plugin-polyfill-regenerator": "^0.6.5",
-        "core-js-compat": "^3.43.0",
+        "babel-plugin-polyfill-corejs2": "^0.4.15",
+        "babel-plugin-polyfill-corejs3": "^0.14.0",
+        "babel-plugin-polyfill-regenerator": "^0.6.6",
+        "core-js-compat": "^3.48.0",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -1583,7 +1529,6 @@
       "integrity": "sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/types": "^7.4.4",
@@ -1594,35 +1539,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -1630,15 +1573,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1651,6 +1593,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@fontsource/archivo": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/archivo/-/archivo-5.2.8.tgz",
+      "integrity": "sha512-Fc4yuMt85MmcYooUVpYHAJRJTymPv2+J9HsMP2f5mxR/0pIWgE2V5XfgNTavPpklX2rJFprdT36iE6Rr8ds9MA==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/ibm-plex-mono": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@fontsource/ibm-plex-mono/-/ibm-plex-mono-5.2.7.tgz",
+      "integrity": "sha512-MKAb8qV+CaiMQn2B0dIi1OV3565NYzp3WN5b4oT6LTkk+F0jR6j0ZN+5BKJiIhffDC3rtBULsYZE65+0018z9w==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@fortawesome/fontawesome-pro": {
@@ -1727,6 +1687,7 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -1738,7 +1699,6 @@
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -1748,6 +1708,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1756,6 +1717,7 @@
       "version": "0.3.11",
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
       "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -1765,12 +1727,14 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -2393,34 +2357,12 @@
         "node": ">=10"
       }
     },
-    "node_modules/@types/eslint": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
-      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
-    },
-    "node_modules/@types/eslint-scope": {
-      "version": "3.7.7",
-      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
-      "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/eslint": "*",
-        "@types/estree": "*"
-      }
-    },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "license": "MIT",
-      "peer": true
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/geojson": {
       "version": "7946.0.16",
@@ -2465,22 +2407,14 @@
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
-    },
-    "node_modules/@types/leaflet": {
-      "version": "1.9.21",
-      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.21.tgz",
-      "integrity": "sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/geojson": "*"
-      }
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true
     },
     "node_modules/@types/node": {
       "version": "25.0.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.10.tgz",
       "integrity": "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -2528,8 +2462,8 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
       "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/helper-numbers": "1.13.2",
         "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
@@ -2539,29 +2473,29 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
       "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
-      "license": "MIT",
-      "peer": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-api-error": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
       "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
-      "license": "MIT",
-      "peer": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-buffer": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
       "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
-      "license": "MIT",
-      "peer": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-numbers": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
       "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/floating-point-hex-parser": "1.13.2",
         "@webassemblyjs/helper-api-error": "1.13.2",
@@ -2572,15 +2506,15 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
       "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
-      "license": "MIT",
-      "peer": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-wasm-section": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
       "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -2592,8 +2526,8 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
       "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@xtuc/ieee754": "^1.2.0"
       }
@@ -2602,8 +2536,8 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
       "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
+      "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@xtuc/long": "4.2.2"
       }
@@ -2612,15 +2546,15 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
       "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
-      "license": "MIT",
-      "peer": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/wasm-edit": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
       "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -2636,8 +2570,8 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
       "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
@@ -2650,8 +2584,8 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
       "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -2663,8 +2597,8 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
       "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-api-error": "1.13.2",
@@ -2678,8 +2612,8 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
       "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@xtuc/long": "4.2.2"
@@ -2733,20 +2667,21 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
       "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@xtuc/long": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
-      "license": "Apache-2.0",
-      "peer": true
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -2759,8 +2694,8 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
       "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.13.0"
       },
@@ -2799,6 +2734,7 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -2815,6 +2751,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dev": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -2831,6 +2768,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       },
@@ -2864,9 +2802,9 @@
       }
     },
     "node_modules/babel-loader": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-10.0.0.tgz",
-      "integrity": "sha512-z8jt+EdS61AMw22nSfoNJAZ0vrtmhPRVi6ghL3rCeRZI8cdNYFiV5xeV3HbE7rlZZNmGH8BVccwWt8/ED0QOHA==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-10.1.1.tgz",
+      "integrity": "sha512-JwKSzk2kjIe7mgPK+/lyZ2QAaJcpahNAdM+hgR2HI8D0OJVkdj8Rl6J3kaLYki9pwF7P2iWnD8qVv80Lq1ABtg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2876,20 +2814,28 @@
         "node": "^18.20.0 || ^20.10.0 || >=22.0.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.12.0",
+        "@babel/core": "^7.12.0 || ^8.0.0-beta.1",
+        "@rspack/core": "^1.0.0 || ^2.0.0-0",
         "webpack": ">=5.61.0"
+      },
+      "peerDependenciesMeta": {
+        "@rspack/core": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
-      "version": "0.4.15",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.15.tgz",
-      "integrity": "sha512-hR3GwrRwHUfYwGfrisXPIDP3JcYfBrW7wKE7+Au6wDYl7fm/ka1NEII6kORzxNU556JjfidZeBsO10kYvtV1aw==",
+      "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.17.tgz",
+      "integrity": "sha512-aTyf30K/rqAsNwN76zYrdtx8obu0E4KoUME29B1xj+B3WxgvWkp943vYQ+z8Mv3lw9xHXMHpvSPOBxzAkIa94w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/compat-data": "^7.28.6",
-        "@babel/helper-define-polyfill-provider": "^0.6.6",
+        "@babel/helper-define-polyfill-provider": "^0.6.8",
         "semver": "^6.3.1"
       },
       "peerDependencies": {
@@ -2897,29 +2843,27 @@
       }
     },
     "node_modules/babel-plugin-polyfill-corejs3": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.13.0.tgz",
-      "integrity": "sha512-U+GNwMdSFgzVmfhNm8GJUX88AadB3uo9KpJqS3FaqNIPKgySuvMb+bHPsOmmuWyIcuqZj/pzt1RUIUZns4y2+A==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.14.2.tgz",
+      "integrity": "sha512-coWpDLJ410R781Npmn/SIBZEsAetR4xVi0SxLMXPaMO4lSf1MwnkGYMtkFxew0Dn8B3/CpbpYxN0JCgg8mn67g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.6.5",
-        "core-js-compat": "^3.43.0"
+        "@babel/helper-define-polyfill-provider": "^0.6.8",
+        "core-js-compat": "^3.48.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
     },
     "node_modules/babel-plugin-polyfill-regenerator": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.6.tgz",
-      "integrity": "sha512-hYm+XLYRMvupxiQzrvXUj7YyvFFVfv5gI0R71AJzudg1g2AI2vyCPPIFEBjk162/wFzti3inBHo7isWFuEVS/A==",
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.8.tgz",
+      "integrity": "sha512-M762rNHfSF1EV3SLtnCJXFoQbbIIz0OyRwnCmV0KPC7qosSfCO0QLTSuJX3ayAebubhE6oYBAYPrBA5ljowaZg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.6.6"
+        "@babel/helper-define-polyfill-provider": "^0.6.8"
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -2929,6 +2873,7 @@
       "version": "2.9.18",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.18.tgz",
       "integrity": "sha512-e23vBV1ZLfjb9apvfPk4rHVu2ry6RIr2Wfs+O324okSidrX7pTAnEJPCh/O5BtRlr7QtZI7ktOP3vsqr7Z5XoA==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
@@ -2989,6 +2934,7 @@
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
       "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -3022,6 +2968,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/caniuse-api": {
@@ -3041,6 +2988,7 @@
       "version": "1.0.30001766",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001766.tgz",
       "integrity": "sha512-4C0lfJ0/YPjJQHagaE9x2Elb69CIqEPZeG0anQt9SIvIoOH4a4uaRl73IavyO+0qZh6MDLH//DrXThEYKHkmYA==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -3118,8 +3066,8 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
       "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.0"
       }
@@ -3212,8 +3160,7 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/core-js": {
       "version": "3.48.0",
@@ -3227,12 +3174,11 @@
       }
     },
     "node_modules/core-js-compat": {
-      "version": "3.48.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.48.0.tgz",
-      "integrity": "sha512-OM4cAF3D6VtH/WkLtWvyNC56EZVXsZdU3iqaMG2B4WvYrlqU831pc4UtG5yp0sE9z8Y02wVN7PjW5Zf9Gt0f1Q==",
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.49.0.tgz",
+      "integrity": "sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "browserslist": "^4.28.1"
       },
@@ -3573,7 +3519,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -3677,6 +3623,7 @@
       "version": "1.5.279",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.279.tgz",
       "integrity": "sha512-0bblUU5UNdOt5G7XqGiJtpZMONma6WAfq9vsFmtn9x1+joAObr6x1chfqyxFSDCAFwFhCQDrqeAr6MYdpwJ9Hg==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -3696,14 +3643,14 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.18.4",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.4.tgz",
-      "integrity": "sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==",
+      "version": "5.24.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.0.tgz",
+      "integrity": "sha512-SkE2t82KlkkxQRVMVLAGKxLfORGQfrkx5dkj+vlgXRVNEdPc4eZcR+J/Fvj8C+yKSFH5L0q3NFlyufOVQnCcYQ==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.2.0"
+        "tapable": "^2.3.3"
       },
       "engines": {
         "node": ">=10.13.0"
@@ -3741,16 +3688,17 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
-      "license": "MIT",
-      "peer": true
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3760,8 +3708,8 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -3774,8 +3722,8 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "estraverse": "^5.2.0"
       },
@@ -3787,8 +3735,8 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -3797,8 +3745,8 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -3808,7 +3756,7 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true,
-      "peer": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3817,8 +3765,8 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.8.x"
       }
@@ -3826,12 +3774,14 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "node_modules/fast-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
       "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3930,7 +3880,6 @@
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -3960,13 +3909,14 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-      "license": "BSD-2-Clause",
-      "peer": true
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/growly": {
@@ -4000,6 +3950,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4271,14 +4222,14 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -4286,17 +4237,11 @@
         "node": ">=6"
       }
     },
-    "node_modules/json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
     },
     "node_modules/json-stringify-pretty-compact": {
       "version": "4.0.0",
@@ -4382,11 +4327,11 @@
       }
     },
     "node_modules/loader-runner": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
-      "integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.2.tgz",
+      "integrity": "sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.11.5"
       },
@@ -4432,8 +4377,7 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -4455,7 +4399,6 @@
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "yallist": "^3.0.2"
       }
@@ -4508,6 +4451,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/micromatch": {
@@ -4525,24 +4469,11 @@
       }
     },
     "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
       "engines": {
         "node": ">= 0.6"
       }
@@ -4580,7 +4511,7 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/murmurhash-js": {
       "version": "1.0.0",
@@ -4648,6 +4579,7 @@
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/npm": {
@@ -6583,7 +6515,8 @@
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
     },
     "node_modules/picomatch": {
       "version": "2.3.2",
@@ -7280,8 +7213,7 @@
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
       "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/regenerate-unicode-properties": {
       "version": "10.2.2",
@@ -7289,7 +7221,6 @@
       "integrity": "sha512-m03P+zhBeQd1RGnYxrGyDAPpWX/epKirLrp8e3qevZdVkKtnCrjjWczIbYc8+xd6vcTStVlqfycTx1KR4LOr0g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "regenerate": "^1.4.2"
       },
@@ -7315,7 +7246,6 @@
       "integrity": "sha512-0ghuzq67LI9bLXpOX/ISfve/Mq33a4aFRzoQYhnnok1JOFpmE/A2TBGkNVenOGEeSBCjIiWcc6MVOG5HEQv0sA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "regenerate": "^1.4.2",
         "regenerate-unicode-properties": "^10.2.2",
@@ -7333,16 +7263,14 @@
       "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.8.0.tgz",
       "integrity": "sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/regjsparser": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.0.tgz",
-      "integrity": "sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.1.tgz",
+      "integrity": "sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "jsesc": "~3.1.0"
       },
@@ -7367,6 +7295,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7549,6 +7478,7 @@
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+      "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",
@@ -7568,7 +7498,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
-      "peer": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -7640,6 +7570,7 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -7726,6 +7657,7 @@
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -7852,9 +7784,11 @@
       }
     },
     "node_modules/tapable": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
-      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       },
@@ -7867,6 +7801,7 @@
       "version": "5.46.0",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.0.tgz",
       "integrity": "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -7882,9 +7817,10 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.4.0.tgz",
-      "integrity": "sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.6.1.tgz",
+      "integrity": "sha512-201R5j+sJpK8nFWwKVyNfZot8FaJbLZDq5evriVzbV1wDtSXDjRUDRfJzHpAaxFDMEhsZL1QkeqM61wgsS3KaQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
@@ -7903,10 +7839,37 @@
         "webpack": "^5.1.0"
       },
       "peerDependenciesMeta": {
+        "@minify-html/node": {
+          "optional": true
+        },
         "@swc/core": {
           "optional": true
         },
+        "@swc/css": {
+          "optional": true
+        },
+        "@swc/html": {
+          "optional": true
+        },
+        "clean-css": {
+          "optional": true
+        },
+        "cssnano": {
+          "optional": true
+        },
+        "csso": {
+          "optional": true
+        },
         "esbuild": {
+          "optional": true
+        },
+        "html-minifier-terser": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "postcss": {
           "optional": true
         },
         "uglify-js": {
@@ -7918,6 +7881,7 @@
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
       "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -7932,6 +7896,7 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyqueue": {
@@ -7986,6 +7951,7 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -7994,7 +7960,6 @@
       "integrity": "sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -8005,7 +7970,6 @@
       "integrity": "sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "unicode-canonical-property-names-ecmascript": "^2.0.0",
         "unicode-property-aliases-ecmascript": "^2.0.0"
@@ -8020,7 +7984,6 @@
       "integrity": "sha512-JQ84qTuMg4nVkx8ga4A16a1epI9H6uTXAknqxkGF/aFfRLw1xC/Bp24HNLaZhHSkWd3+84t8iXnp1J0kYcZHhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -8031,7 +7994,6 @@
       "integrity": "sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -8040,6 +8002,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -8094,13 +8057,12 @@
       }
     },
     "node_modules/watchpack": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
-      "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.2.tgz",
+      "integrity": "sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
       },
       "engines": {
@@ -8108,37 +8070,35 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.104.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.104.1.tgz",
-      "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
+      "version": "5.107.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.107.2.tgz",
+      "integrity": "sha512-v7RhXaJbpMlV0D7hC7lb2EbnxkoeUqf9qhKr6lozx3Q48pmFrqqNRmZFUEGmi7pSwm6fCQ2H1IjvCkHqdpVdjQ==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
         "@types/json-schema": "^7.0.15",
         "@webassemblyjs/ast": "^1.14.1",
         "@webassemblyjs/wasm-edit": "^1.14.1",
         "@webassemblyjs/wasm-parser": "^1.14.1",
-        "acorn": "^8.15.0",
+        "acorn": "^8.16.0",
         "acorn-import-phases": "^1.0.3",
         "browserslist": "^4.28.1",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.17.4",
-        "es-module-lexer": "^2.0.0",
+        "enhanced-resolve": "^5.22.0",
+        "es-module-lexer": "^2.1.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.2.11",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.3.1",
-        "mime-types": "^2.1.27",
+        "loader-runner": "^4.3.2",
+        "mime-db": "^1.54.0",
         "neo-async": "^2.6.2",
         "schema-utils": "^4.3.3",
         "tapable": "^2.3.0",
-        "terser-webpack-plugin": "^5.3.16",
-        "watchpack": "^2.4.4",
-        "webpack-sources": "^3.3.3"
+        "terser-webpack-plugin": "^5.5.0",
+        "watchpack": "^2.5.1",
+        "webpack-sources": "^3.5.0"
       },
       "bin": {
         "webpack": "bin/webpack.js"
@@ -8274,11 +8234,11 @@
       }
     },
     "node_modules/webpack/node_modules/webpack-sources": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.3.tgz",
-      "integrity": "sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.5.0.tgz",
+      "integrity": "sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.13.0"
       }
@@ -8318,8 +8278,7 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/yargs-parser": {
       "version": "21.1.1",

--- a/package.json
+++ b/package.json
@@ -13,19 +13,25 @@
     "build": "encore production --progress"
   },
   "devDependencies": {
+    "@babel/core": "^7.29.7",
+    "@babel/preset-env": "^7.29.7",
     "@fortawesome/fontawesome-pro": "^5.15.3",
     "@hotwired/stimulus": "^3.2.2",
     "@symfony/stimulus-bridge": "^4.0.1",
     "@symfony/webpack-encore": "^6.0.0",
+    "babel-loader": "^10.1.1",
     "core-js": "^3.48.0",
     "regenerator-runtime": "^0.13.2",
     "sass": "^1.97.3",
     "sass-loader": "^16.0.6",
+    "webpack": "^5.107.2",
     "webpack-notifier": "^1.6.0"
   },
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@fontsource/archivo": "^5.2.8",
+    "@fontsource/ibm-plex-mono": "^5.2.7",
     "@maplibre/maplibre-gl-leaflet": "^0.1.3",
     "@popperjs/core": "^2.11.8",
     "bootstrap": "^5.3.0",


### PR DESCRIPTION
## Summary

- **Schriften selbst gehostet:** Archivo (400–800) und IBM Plex Mono (500/600) als `@fontsource`-Pakete, Import in `app.js` — kein Google-CDN (DSGVO), woff2 landet per Encore in `public/build/fonts/`
- **Bootstrap-Tokens** (`assets/scss/bootstrap5.scss`): Akzent `#f4581c`, Hintergrund `#f2f3f5`, Tinte `#16181c`, Archivo als Basisschrift, IBM Plex Mono als Monospace, neue Radien — färbt Buttons/Links/Karten der gesamten Anwendung ins neue System
- **Neues `assets/scss/redesign/`:** `_tokens.scss` (CSS-Variablen `--cm-*`) und `_components.scss` mit additiven `cm-*`-Komponenten (Aktivitätskarte, Statistikband, Kudosbar, Avatare/Facepile, Tabs, Terminzeilen, Datums-Badge, Ranking, Status-Chips, mobile Tab-Leiste) für die Folge-PRs
- **Build-Reparatur:** `webpack`, `babel-loader`, `@babel/core`, `@babel/preset-env` sind jetzt explizite devDependencies — sie waren nur Peer-Dependencies und fehlten im Lockfile, frische Installs (`npm ci`) konnten nicht bauen
- Designreferenz: 16 verlinkte HTML-Prototypen (lokal in `design-prototypes/`, inkl. `UMSETZUNG.md` mit PR-Plan); dieser PR ist Schritt 1, es folgen Topbar/Chrome und die Timeline-Startseite

## Test Plan

- [ ] `npm install --legacy-peer-deps && npm run dev` läuft fehlerfrei durch (auch auf frischem Checkout)
- [ ] `public/build/app.css` enthält `--cm-accent` und `.cm-kbtn`, `public/build/fonts/` enthält Archivo/Plex-Mono-woff2
- [ ] Anwendung lokal öffnen: Grundfarben (Orange-Akzent, graue Fläche) und Archivo greifen auf allen Seiten
- [ ] Stichprobe Formulare, Modals, Pagination, Navbar: durch den `$primary`-Wechsel nichts unleserlich
- [ ] Keine Twig-/PHP-Änderungen enthalten — rein Assets + Abhängigkeiten

🤖 Generated with [Claude Code](https://claude.com/claude-code)