### PR TITLE
Unified upload: photo-candidate backend (#1395)

### DIFF
--- a/config/packages/oneup_flysystem.yaml
+++ b/config/packages/oneup_flysystem.yaml
@@ -18,6 +18,9 @@ oneup_flysystem:
         track_track_adapter:
             local:
                 location: '%upload_destination.track%'
+        photo_candidate_adapter:
+            local:
+                location: '%upload_destination.photo_candidate%'
 
     filesystems:
         flysystem_photo_photo:
@@ -43,3 +46,7 @@ oneup_flysystem:
         flysystem_track_track:
             adapter: track_track_adapter
             mount: flysystem_track_track
+
+        flysystem_photo_candidate:
+            adapter: photo_candidate_adapter
+            mount: flysystem_photo_candidate

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -31,6 +31,9 @@ parameters:
     upload_destination.ride_photo: '%kernel.project_dir%/public/rides'
     upload_destination.frontpage_teaser: '%kernel.project_dir%/public/teaser'
     upload_destination.user_photo: '%kernel.project_dir%/public/users'
+    # Staging für hochgeladene, noch nicht bestätigte Fotos — bewusst AUSSERHALB
+    # public/ (kein Web-Root, #1395), wird bei Bestätigung/Verwerfen geleert.
+    upload_destination.photo_candidate: '%kernel.project_dir%/var/photo-candidates'
     assets_version: '%env(ASSETS_VERSION)%'
     friendlycaptcha_api_key: '%env(FRIENDLYCAPTCHA_API_KEY)%'
     friendlycaptcha_site_key: '%env(FRIENDLYCAPTCHA_SITE_KEY)%'
@@ -51,6 +54,7 @@ services:
             $uploadDestinationTrack: '%upload_destination.track%'
             $uploadDestinationUserPhoto: '%upload_destination.user_photo%'
             $trackFilesystem: '@oneup_flysystem.flysystem_track_track_filesystem'
+            $photoCandidateFilesystem: '@oneup_flysystem.flysystem_photo_candidate_filesystem'
             $stravaClientId: '%strava.client_id%'
             $stravaSecret: '%strava.secret%'
             $cachedTimelineTtl: '%timeline.ttl%'

--- a/migrations/Version20260618171157.php
+++ b/migrations/Version20260618171157.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Create the photo_candidate table: staged photos awaiting review in the
+ * unified upload (parallel to track_candidate for the track side).
+ */
+final class Version20260618171157 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create photo_candidate table (staged photos for the unified upload review)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE photo_candidate (id INT AUTO_INCREMENT NOT NULL, fileHash VARCHAR(40) NOT NULL, stagedFilename VARCHAR(255) NOT NULL, originalName VARCHAR(255) DEFAULT NULL, mimeType VARCHAR(255) DEFAULT NULL, exifCreationDate DATETIME DEFAULT NULL, latitude DOUBLE PRECISION DEFAULT NULL, longitude DOUBLE PRECISION DEFAULT NULL, createdAt DATETIME NOT NULL, rejected TINYINT DEFAULT 0 NOT NULL, user_id INT NOT NULL, ride_id INT DEFAULT NULL, INDEX IDX_C54CD865A76ED395 (user_id), INDEX IDX_C54CD865302A8A70 (ride_id), PRIMARY KEY (id)) DEFAULT CHARACTER SET utf8mb4');
+        $this->addSql('ALTER TABLE photo_candidate ADD CONSTRAINT FK_C54CD865A76ED395 FOREIGN KEY (user_id) REFERENCES user (id)');
+        $this->addSql('ALTER TABLE photo_candidate ADD CONSTRAINT FK_C54CD865302A8A70 FOREIGN KEY (ride_id) REFERENCES ride (id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE photo_candidate DROP FOREIGN KEY FK_C54CD865A76ED395');
+        $this->addSql('ALTER TABLE photo_candidate DROP FOREIGN KEY FK_C54CD865302A8A70');
+        $this->addSql('DROP TABLE photo_candidate');
+    }
+}

--- a/src/Criticalmass/PhotoImport/Normalizer/ImagickPhotoNormalizer.php
+++ b/src/Criticalmass/PhotoImport/Normalizer/ImagickPhotoNormalizer.php
@@ -1,0 +1,71 @@
+<?php declare(strict_types=1);
+
+namespace App\Criticalmass\PhotoImport\Normalizer;
+
+/**
+ * Passes JPEG/PNG/WebP/GIF through unchanged and converts HEIC/HEIF to JPEG via
+ * ImageMagick (preserving the EXIF profile, so date/GPS survive for matching and
+ * gallery display). HEIC support requires ImageMagick with the libheif delegate
+ * (present in production via the LiipImagine imagick driver); when it is missing
+ * the conversion fails closed with a clear message instead of a 500.
+ */
+final class ImagickPhotoNormalizer implements PhotoNormalizerInterface
+{
+    private const PASSTHROUGH = [
+        'jpg' => 'image/jpeg',
+        'jpeg' => 'image/jpeg',
+        'png' => 'image/png',
+        'webp' => 'image/webp',
+        'gif' => 'image/gif',
+    ];
+
+    private const HEIC = ['heic', 'heif'];
+
+    public function normalize(string $filePath, string $originalName): NormalizedImage
+    {
+        $extension = strtolower(pathinfo($originalName, PATHINFO_EXTENSION));
+
+        if (isset(self::PASSTHROUGH[$extension])) {
+            $bytes = @file_get_contents($filePath);
+
+            if ($bytes === false) {
+                throw new \RuntimeException('Die Bilddatei konnte nicht gelesen werden.');
+            }
+
+            return new NormalizedImage($bytes, self::PASSTHROUGH[$extension], $extension === 'jpeg' ? 'jpg' : $extension);
+        }
+
+        if (\in_array($extension, self::HEIC, true)) {
+            return $this->convertHeicToJpeg($filePath);
+        }
+
+        throw new \RuntimeException(sprintf('Das Bildformat „.%s“ wird nicht unterstützt.', $extension));
+    }
+
+    private function convertHeicToJpeg(string $filePath): NormalizedImage
+    {
+        if (!\extension_loaded('imagick')) {
+            throw new \RuntimeException('HEIC/HEIF wird auf diesem Server nicht unterstützt (ImageMagick nicht verfügbar).');
+        }
+
+        $imagick = new \Imagick();
+
+        if ([] === $imagick->queryFormats('HEIC')) {
+            throw new \RuntimeException('HEIC/HEIF wird auf diesem Server nicht unterstützt (kein HEIF-Delegate).');
+        }
+
+        try {
+            $imagick->readImage($filePath);
+            $imagick->setImageFormat('jpeg');
+            $imagick->setImageCompressionQuality(90);
+            // EXIF-Profil NICHT strippen → Datum/GPS bleiben erhalten.
+            $bytes = $imagick->getImageBlob();
+        } catch (\ImagickException $exception) {
+            throw new \RuntimeException(sprintf('Die HEIC-Datei konnte nicht konvertiert werden: %s', $exception->getMessage()), 0, $exception);
+        } finally {
+            $imagick->clear();
+        }
+
+        return new NormalizedImage($bytes, 'image/jpeg', 'jpg');
+    }
+}

--- a/src/Criticalmass/PhotoImport/Normalizer/NormalizedImage.php
+++ b/src/Criticalmass/PhotoImport/Normalizer/NormalizedImage.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace App\Criticalmass\PhotoImport\Normalizer;
+
+/**
+ * Result of normalising an uploaded image: the bytes to stage, the resulting
+ * MIME type and the file extension to store under (HEIC/HEIF become JPEG).
+ */
+final readonly class NormalizedImage
+{
+    public function __construct(
+        public string $bytes,
+        public string $mimeType,
+        public string $extension,
+    ) {
+    }
+}

--- a/src/Criticalmass/PhotoImport/Normalizer/PhotoNormalizerInterface.php
+++ b/src/Criticalmass/PhotoImport/Normalizer/PhotoNormalizerInterface.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace App\Criticalmass\PhotoImport\Normalizer;
+
+interface PhotoNormalizerInterface
+{
+    /**
+     * Normalise an uploaded image for staging: HEIC/HEIF are converted to JPEG
+     * (so everything downstream stays in web-friendly formats), other supported
+     * formats pass through unchanged.
+     *
+     * @throws \RuntimeException if the format is unsupported or cannot be read/converted
+     */
+    public function normalize(string $filePath, string $originalName): NormalizedImage;
+}

--- a/src/Criticalmass/PhotoImport/PhotoCandidate/ParsedPhotoUpload.php
+++ b/src/Criticalmass/PhotoImport/PhotoCandidate/ParsedPhotoUpload.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace App\Criticalmass\PhotoImport\PhotoCandidate;
+
+use App\Entity\PhotoImportCandidate;
+
+/**
+ * Result of parsing an uploaded image: the (not yet persisted) candidate with
+ * its extracted EXIF metadata, plus the normalised image bytes to be staged so
+ * the file can later be turned into a Photo (see PhotoCandidateImporter).
+ */
+final readonly class ParsedPhotoUpload
+{
+    public function __construct(
+        private PhotoImportCandidate $candidate,
+        private string $imageBytes,
+    ) {
+    }
+
+    public function getCandidate(): PhotoImportCandidate
+    {
+        return $this->candidate;
+    }
+
+    public function getImageBytes(): string
+    {
+        return $this->imageBytes;
+    }
+}

--- a/src/Criticalmass/PhotoImport/PhotoCandidate/PhotoCandidateFactory.php
+++ b/src/Criticalmass/PhotoImport/PhotoCandidate/PhotoCandidateFactory.php
@@ -1,0 +1,114 @@
+<?php declare(strict_types=1);
+
+namespace App\Criticalmass\PhotoImport\PhotoCandidate;
+
+use App\Criticalmass\Image\ExifWrapper\ExifWrapperInterface;
+use App\Criticalmass\PhotoImport\Normalizer\PhotoNormalizerInterface;
+use App\Entity\PhotoImportCandidate;
+use App\Entity\User;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * Builds a PhotoImportCandidate from an uploaded image file.
+ *
+ * HEIC/HEIF are normalised to JPEG (see PhotoNormalizer), so the staged file is
+ * always a web-friendly format. EXIF is read from the *normalised* bytes, which
+ * keeps the capture date and GPS coordinates available even for HEIC originals —
+ * these drive the gallery grouping and the ride matching (PhotoDecider).
+ */
+class PhotoCandidateFactory
+{
+    private const SUPPORTED_EXTENSIONS = ['jpg', 'jpeg', 'png', 'webp', 'gif', 'heic', 'heif'];
+
+    public function __construct(
+        private readonly PhotoNormalizerInterface $normalizer,
+        private readonly ExifWrapperInterface $exifWrapper,
+    ) {
+    }
+
+    /**
+     * @throws \RuntimeException if the file type is unsupported or cannot be read
+     */
+    public function createFromUpload(string $filePath, string $originalName, User $user): ParsedPhotoUpload
+    {
+        $extension = strtolower(pathinfo($originalName, PATHINFO_EXTENSION));
+
+        if (!in_array($extension, self::SUPPORTED_EXTENSIONS, true)) {
+            throw new \RuntimeException(sprintf('Das Dateiformat „.%s“ wird nicht unterstützt — bitte lade nur Bilddateien hoch.', $extension));
+        }
+
+        $normalized = $this->normalizer->normalize($filePath, $originalName);
+
+        $exifDate = null;
+        $latitude = null;
+        $longitude = null;
+
+        $this->withTemporaryFile($normalized->bytes, function (string $tmpPath) use (&$exifDate, &$latitude, &$longitude): void {
+            $exif = $this->exifWrapper->readExifDataFromFile($tmpPath);
+
+            if ($exif === null) {
+                return;
+            }
+
+            $creationDate = $exif->getCreationDate();
+            if ($creationDate instanceof \DateTimeInterface) {
+                // Wall-clock capture time as recorded by the camera; kept as-is so a
+                // photo groups and matches on the day it was actually taken.
+                $exifDate = \DateTime::createFromInterface($creationDate);
+            }
+
+            $coords = $this->extractCoordinates($exif->getGPS());
+            if ($coords !== null) {
+                [$latitude, $longitude] = $coords;
+            }
+        });
+
+        $hash = sha1_file($filePath);
+        $fileHash = $hash !== false ? $hash : sha1($originalName);
+
+        $candidate = new PhotoImportCandidate();
+        $candidate
+            ->setUser($user)
+            ->setFileHash($fileHash)
+            ->setStagedFilename(sprintf('%s.%s', $fileHash, $normalized->extension))
+            ->setOriginalName($originalName)
+            ->setMimeType($normalized->mimeType)
+            ->setExifCreationDate($exifDate)
+            ->setLatitude($latitude)
+            ->setLongitude($longitude);
+
+        return new ParsedPhotoUpload($candidate, $normalized->bytes);
+    }
+
+    /**
+     * @param callable(string): void $callback
+     */
+    private function withTemporaryFile(string $bytes, callable $callback): void
+    {
+        $filesystem = new Filesystem();
+        $tmpPath = $filesystem->tempnam(sys_get_temp_dir(), 'photo-exif-');
+
+        try {
+            $filesystem->dumpFile($tmpPath, $bytes);
+            $callback($tmpPath);
+        } finally {
+            $filesystem->remove($tmpPath);
+        }
+    }
+
+    /**
+     * Mirrors PhotoGps: php-exif returns the GPS position as a "lat,lon" string.
+     *
+     * @return array{0: float, 1: float}|null
+     */
+    private function extractCoordinates(mixed $gps): ?array
+    {
+        if (!is_string($gps) || !str_contains($gps, ',')) {
+            return null;
+        }
+
+        [$lat, $lon] = explode(',', $gps);
+
+        return [(float) $lat, (float) $lon];
+    }
+}

--- a/src/Criticalmass/PhotoImport/PhotoCandidateImporter/PhotoCandidateImporter.php
+++ b/src/Criticalmass/PhotoImport/PhotoCandidateImporter/PhotoCandidateImporter.php
@@ -1,0 +1,100 @@
+<?php declare(strict_types=1);
+
+namespace App\Criticalmass\PhotoImport\PhotoCandidateImporter;
+
+use App\Criticalmass\UploadFaker\UploadFakerInterface;
+use App\Entity\Photo;
+use App\Entity\PhotoImportCandidate;
+use App\Entity\Ride;
+use App\Event\Photo\PhotoUploadedEvent;
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectManager;
+use League\Flysystem\FilesystemOperator;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * Converts a confirmed gallery of photo candidates into Photos. Each candidate's
+ * staged file (already a normalised, EXIF-carrying image) is injected via
+ * UploadFaker and the PhotoUploadedEvent runs the usual enrichment — EXIF date and
+ * GPS/track geolocation — exactly as a regular photo upload would. This mirrors
+ * FileTrackImporter on the track side.
+ */
+class PhotoCandidateImporter implements PhotoCandidateImporterInterface
+{
+    public function __construct(
+        private readonly ManagerRegistry $registry,
+        private readonly UploadFakerInterface $uploadFaker,
+        private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly FilesystemOperator $photoCandidateFilesystem,
+    ) {
+    }
+
+    public function importGallery(array $candidates, Ride $ride): array
+    {
+        $manager = $this->registry->getManager();
+
+        $photos = [];
+
+        foreach ($candidates as $candidate) {
+            $photo = $this->importCandidate($candidate, $ride, $manager);
+
+            if ($photo !== null) {
+                $photos[] = $photo;
+            }
+        }
+
+        return $photos;
+    }
+
+    private function importCandidate(PhotoImportCandidate $candidate, Ride $ride, ObjectManager $manager): ?Photo
+    {
+        $storagePath = $candidate->getStagedFilename();
+
+        if ($storagePath === null || !$this->photoCandidateFilesystem->fileExists($storagePath)) {
+            // The staged file is gone (e.g. cleaned up out of band) — nothing to import.
+            return null;
+        }
+
+        $photo = new Photo();
+        $photo
+            ->setUser($candidate->getUser())
+            ->setRide($ride)
+            ->setCity($ride->getCity());
+
+        $tmpFilename = $this->uploadFaker->fakeUpload(
+            $photo,
+            'imageFile',
+            $this->photoCandidateFilesystem->read($storagePath),
+            $this->uploadName($candidate),
+        );
+
+        $manager->persist($photo);
+
+        // flush=true plus the temp filename lets the subscriber read EXIF from the
+        // freshly injected file and geolocate against the ride's track.
+        $this->eventDispatcher->dispatch(new PhotoUploadedEvent($photo, true, $tmpFilename), PhotoUploadedEvent::NAME);
+
+        // The candidate has been consumed — drop it and its staged file.
+        $this->photoCandidateFilesystem->delete($storagePath);
+        $manager->remove($candidate);
+        $manager->flush();
+
+        return $photo;
+    }
+
+    /**
+     * A client filename carrying the *normalised* extension, so Vich stores the
+     * file under the format it actually contains (HEIC originals are JPEG by now).
+     */
+    private function uploadName(PhotoImportCandidate $candidate): string
+    {
+        $extension = pathinfo((string) $candidate->getStagedFilename(), PATHINFO_EXTENSION);
+        $baseName = pathinfo((string) $candidate->getOriginalName(), PATHINFO_FILENAME);
+
+        if ($baseName === '') {
+            $baseName = (string) $candidate->getFileHash();
+        }
+
+        return sprintf('%s.%s', $baseName, $extension);
+    }
+}

--- a/src/Criticalmass/PhotoImport/PhotoCandidateImporter/PhotoCandidateImporterInterface.php
+++ b/src/Criticalmass/PhotoImport/PhotoCandidateImporter/PhotoCandidateImporterInterface.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace App\Criticalmass\PhotoImport\PhotoCandidateImporter;
+
+use App\Entity\Photo;
+use App\Entity\PhotoImportCandidate;
+use App\Entity\Ride;
+
+interface PhotoCandidateImporterInterface
+{
+    /**
+     * Turns a confirmed gallery of photo candidates into Photos assigned to the
+     * given ride, consuming the candidates and their staged files.
+     *
+     * @param list<PhotoImportCandidate> $candidates
+     *
+     * @return list<Photo>
+     */
+    public function importGallery(array $candidates, Ride $ride): array;
+}

--- a/src/Criticalmass/PhotoImport/PhotoDecider/PhotoDecider.php
+++ b/src/Criticalmass/PhotoImport/PhotoDecider/PhotoDecider.php
@@ -1,0 +1,110 @@
+<?php declare(strict_types=1);
+
+namespace App\Criticalmass\PhotoImport\PhotoDecider;
+
+use App\Criticalmass\Geo\Coord\Coord;
+use App\Criticalmass\Geo\GeoUtil\GeoUtil;
+use App\Entity\PhotoImportCandidate;
+use App\Entity\Ride;
+use App\Repository\RideRepository;
+
+/**
+ * Decides which ride a gallery of photos belongs to.
+ *
+ * Photos are grouped into a gallery by their capture date, and that date is the
+ * primary signal: a gallery can only match a ride that took place the same day.
+ * Among the rides on that day the decision is then refined by GPS proximity — the
+ * average position of the geotagged photos against each ride's location. When the
+ * photos carry no GPS at all, a match is only made if exactly one ride happened
+ * that day; otherwise the gallery is parked for manual assignment.
+ */
+class PhotoDecider implements PhotoDeciderInterface
+{
+    private const MATCH_RADIUS_KM = 50.0;
+
+    public function __construct(
+        private readonly RideRepository $rideRepository,
+    ) {
+    }
+
+    public function decideForGallery(?\DateTime $galleryDate, array $candidates): ?Ride
+    {
+        if ($galleryDate === null) {
+            return null;
+        }
+
+        /** @var list<Ride> $rides */
+        $rides = $this->rideRepository->findByDate($galleryDate);
+
+        if (count($rides) === 0) {
+            return null;
+        }
+
+        $galleryCoord = $this->averageCoord($candidates);
+
+        if ($galleryCoord === null) {
+            // No GPS to disambiguate — only safe when the day had a single ride.
+            return count($rides) === 1 ? $rides[0] : null;
+        }
+
+        return $this->nearestRideWithinRadius($rides, $galleryCoord);
+    }
+
+    /**
+     * @param list<PhotoImportCandidate> $candidates
+     */
+    private function averageCoord(array $candidates): ?Coord
+    {
+        $latitudes = [];
+        $longitudes = [];
+
+        foreach ($candidates as $candidate) {
+            $latitude = $candidate->getLatitude();
+            $longitude = $candidate->getLongitude();
+
+            if ($latitude !== null && $longitude !== null) {
+                $latitudes[] = $latitude;
+                $longitudes[] = $longitude;
+            }
+        }
+
+        if ($latitudes === []) {
+            return null;
+        }
+
+        return new Coord(
+            array_sum($latitudes) / count($latitudes),
+            array_sum($longitudes) / count($longitudes),
+        );
+    }
+
+    /**
+     * @param list<Ride> $rides
+     */
+    private function nearestRideWithinRadius(array $rides, Coord $galleryCoord): ?Ride
+    {
+        $nearestRide = null;
+        $nearestDistance = self::MATCH_RADIUS_KM;
+
+        foreach ($rides as $ride) {
+            $latitude = $ride->getLatitude();
+            $longitude = $ride->getLongitude();
+
+            if ($latitude === null || $longitude === null) {
+                continue;
+            }
+
+            $distance = GeoUtil::calculateDistance(
+                new Coord($latitude, $longitude),
+                $galleryCoord,
+            );
+
+            if ($distance <= $nearestDistance) {
+                $nearestDistance = $distance;
+                $nearestRide = $ride;
+            }
+        }
+
+        return $nearestRide;
+    }
+}

--- a/src/Criticalmass/PhotoImport/PhotoDecider/PhotoDeciderInterface.php
+++ b/src/Criticalmass/PhotoImport/PhotoDecider/PhotoDeciderInterface.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace App\Criticalmass\PhotoImport\PhotoDecider;
+
+use App\Entity\PhotoImportCandidate;
+use App\Entity\Ride;
+
+interface PhotoDeciderInterface
+{
+    /**
+     * Suggests a ride for a gallery of photo candidates that share a capture date,
+     * or null when no confident match exists (the gallery is then parked for manual
+     * assignment in the review UI).
+     *
+     * @param list<PhotoImportCandidate> $candidates
+     */
+    public function decideForGallery(?\DateTime $galleryDate, array $candidates): ?Ride;
+}

--- a/src/Entity/PhotoImportCandidate.php
+++ b/src/Entity/PhotoImportCandidate.php
@@ -1,0 +1,211 @@
+<?php declare(strict_types=1);
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * A photo uploaded via the unified upload that is staged for review before it
+ * becomes a real Photo on a ride. Mirrors TrackImportCandidate for the photo side:
+ * the binary lives in the photo-candidate staging filesystem (outside the web root),
+ * the entity holds the metadata needed to group photos into galleries (exifCreationDate)
+ * and to match a gallery to a ride (date + GPS).
+ */
+#[ORM\Table(name: 'photo_candidate')]
+#[ORM\Entity(repositoryClass: 'App\Repository\PhotoImportCandidateRepository')]
+class PhotoImportCandidate
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    protected ?int $id = null;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: false)]
+    protected ?User $user = null;
+
+    /** Suggested / assigned ride, null while parked for manual review. */
+    #[ORM\ManyToOne(targetEntity: Ride::class)]
+    #[ORM\JoinColumn(nullable: true)]
+    protected ?Ride $ride = null;
+
+    /** SHA1 of the uploaded file, for duplicate detection. */
+    #[ORM\Column(type: 'string', length: 40)]
+    protected ?string $fileHash = null;
+
+    /** Path in the photo-candidate staging filesystem (e.g. "<hash>.jpg"). */
+    #[ORM\Column(type: 'string', length: 255)]
+    protected ?string $stagedFilename = null;
+
+    #[ORM\Column(type: 'string', length: 255, nullable: true)]
+    protected ?string $originalName = null;
+
+    #[ORM\Column(type: 'string', length: 255, nullable: true)]
+    protected ?string $mimeType = null;
+
+    /** EXIF capture date — the gallery grouping key and the matching date. */
+    #[ORM\Column(type: 'datetime', nullable: true)]
+    protected ?\DateTime $exifCreationDate = null;
+
+    #[ORM\Column(type: 'float', nullable: true)]
+    protected ?float $latitude = null;
+
+    #[ORM\Column(type: 'float', nullable: true)]
+    protected ?float $longitude = null;
+
+    #[ORM\Column(type: 'datetime')]
+    protected ?\DateTime $createdAt = null;
+
+    #[ORM\Column(type: 'boolean', options: ['default' => false])]
+    protected bool $rejected = false;
+
+    public function __construct()
+    {
+        $this->createdAt = new \DateTime();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getUser(): ?User
+    {
+        return $this->user;
+    }
+
+    public function setUser(User $user): self
+    {
+        $this->user = $user;
+
+        return $this;
+    }
+
+    public function getRide(): ?Ride
+    {
+        return $this->ride;
+    }
+
+    public function setRide(?Ride $ride): self
+    {
+        $this->ride = $ride;
+
+        return $this;
+    }
+
+    public function getFileHash(): ?string
+    {
+        return $this->fileHash;
+    }
+
+    public function setFileHash(string $fileHash): self
+    {
+        $this->fileHash = $fileHash;
+
+        return $this;
+    }
+
+    public function getStagedFilename(): ?string
+    {
+        return $this->stagedFilename;
+    }
+
+    public function setStagedFilename(string $stagedFilename): self
+    {
+        $this->stagedFilename = $stagedFilename;
+
+        return $this;
+    }
+
+    public function getOriginalName(): ?string
+    {
+        return $this->originalName;
+    }
+
+    public function setOriginalName(?string $originalName): self
+    {
+        $this->originalName = $originalName;
+
+        return $this;
+    }
+
+    public function getMimeType(): ?string
+    {
+        return $this->mimeType;
+    }
+
+    public function setMimeType(?string $mimeType): self
+    {
+        $this->mimeType = $mimeType;
+
+        return $this;
+    }
+
+    public function getExifCreationDate(): ?\DateTime
+    {
+        return $this->exifCreationDate;
+    }
+
+    public function setExifCreationDate(?\DateTime $exifCreationDate): self
+    {
+        $this->exifCreationDate = $exifCreationDate;
+
+        return $this;
+    }
+
+    public function getLatitude(): ?float
+    {
+        return $this->latitude;
+    }
+
+    public function setLatitude(?float $latitude): self
+    {
+        $this->latitude = $latitude;
+
+        return $this;
+    }
+
+    public function getLongitude(): ?float
+    {
+        return $this->longitude;
+    }
+
+    public function setLongitude(?float $longitude): self
+    {
+        $this->longitude = $longitude;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): ?\DateTime
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(\DateTime $createdAt): self
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function isRejected(): bool
+    {
+        return $this->rejected;
+    }
+
+    public function setRejected(bool $rejected): self
+    {
+        $this->rejected = $rejected;
+
+        return $this;
+    }
+
+    /**
+     * Gallery grouping key: the EXIF capture day, or null when undated.
+     */
+    public function getGalleryKey(): ?string
+    {
+        return $this->exifCreationDate?->format('Y-m-d');
+    }
+}

--- a/src/Repository/PhotoImportCandidateRepository.php
+++ b/src/Repository/PhotoImportCandidateRepository.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\PhotoImportCandidate;
+use App\Entity\User;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<PhotoImportCandidate>
+ */
+class PhotoImportCandidateRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, PhotoImportCandidate::class);
+    }
+
+    public function findOneByUserAndFileHash(User $user, string $fileHash): ?PhotoImportCandidate
+    {
+        return $this->findOneBy(['user' => $user, 'fileHash' => $fileHash]);
+    }
+
+    /**
+     * Active (non-rejected) candidates of a user, oldest capture first — the
+     * basis for grouping into galleries on the review page.
+     *
+     * @return list<PhotoImportCandidate>
+     */
+    public function findActiveForUser(User $user): array
+    {
+        return $this->createQueryBuilder('c')
+            ->where('c.user = :user')
+            ->andWhere('c.rejected = :rejected')
+            ->setParameter('user', $user)
+            ->setParameter('rejected', false)
+            ->addOrderBy('c.exifCreationDate', 'ASC')
+            ->addOrderBy('c.id', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+}

--- a/tests/Criticalmass/PhotoImport/PhotoCandidate/PhotoCandidateFactoryTest.php
+++ b/tests/Criticalmass/PhotoImport/PhotoCandidate/PhotoCandidateFactoryTest.php
@@ -1,0 +1,123 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Criticalmass\PhotoImport\PhotoCandidate;
+
+use App\Criticalmass\Image\ExifWrapper\ExifWrapperInterface;
+use App\Criticalmass\PhotoImport\Normalizer\NormalizedImage;
+use App\Criticalmass\PhotoImport\Normalizer\PhotoNormalizerInterface;
+use App\Criticalmass\PhotoImport\PhotoCandidate\PhotoCandidateFactory;
+use App\Entity\User;
+use PHPExif\Exif;
+use PHPUnit\Framework\TestCase;
+
+class PhotoCandidateFactoryTest extends TestCase
+{
+    public function testUnsupportedFileTypeThrows(): void
+    {
+        $this->expectException(\RuntimeException::class);
+
+        $this->withTempFile('whatever', function (string $path): void {
+            $this->factory($this->normalizer(), $this->exifWrapper(null))
+                ->createFromUpload($path, 'notes.txt', $this->createMock(User::class));
+        });
+    }
+
+    public function testBuildsCandidateWithExifDateAndCoordinates(): void
+    {
+        $exif = $this->createMock(Exif::class);
+        $exif->method('getCreationDate')->willReturn(new \DateTime('2024-06-01 18:30:00'));
+        $exif->method('getGPS')->willReturn('52.52,13.40');
+
+        $normalizer = $this->normalizer(new NormalizedImage('JPEGBYTES', 'image/jpeg', 'jpg'));
+        $factory = $this->factory($normalizer, $this->exifWrapper($exif));
+
+        $parsed = $this->withTempFile('heic-bytes', fn (string $path) => $factory->createFromUpload($path, 'IMG_4711.heic', $this->createMock(User::class)));
+
+        $candidate = $parsed->getCandidate();
+
+        self::assertSame(sha1('heic-bytes'), $candidate->getFileHash());
+        self::assertSame(sha1('heic-bytes') . '.jpg', $candidate->getStagedFilename(), 'HEIC is staged as the normalised JPEG.');
+        self::assertSame('IMG_4711.heic', $candidate->getOriginalName());
+        self::assertSame('image/jpeg', $candidate->getMimeType());
+        self::assertSame('2024-06-01 18:30:00', $candidate->getExifCreationDate()?->format('Y-m-d H:i:s'));
+        self::assertSame('2024-06-01', $candidate->getGalleryKey());
+        self::assertEqualsWithDelta(52.52, $candidate->getLatitude(), 0.0001);
+        self::assertEqualsWithDelta(13.40, $candidate->getLongitude(), 0.0001);
+        self::assertSame('JPEGBYTES', $parsed->getImageBytes());
+    }
+
+    public function testBuildsCandidateWithoutExifMetadata(): void
+    {
+        $normalizer = $this->normalizer(new NormalizedImage('PNGBYTES', 'image/png', 'png'));
+        $factory = $this->factory($normalizer, $this->exifWrapper(null));
+
+        $parsed = $this->withTempFile('png-bytes', fn (string $path) => $factory->createFromUpload($path, 'screenshot.PNG', $this->createMock(User::class)));
+
+        $candidate = $parsed->getCandidate();
+
+        self::assertSame(sha1('png-bytes') . '.png', $candidate->getStagedFilename());
+        self::assertNull($candidate->getExifCreationDate());
+        self::assertNull($candidate->getGalleryKey(), 'A dateless photo has no gallery key.');
+        self::assertNull($candidate->getLatitude());
+        self::assertNull($candidate->getLongitude());
+    }
+
+    public function testNonStringGpsYieldsNoCoordinates(): void
+    {
+        $exif = $this->createMock(Exif::class);
+        $exif->method('getCreationDate')->willReturn(new \DateTime('2024-06-01 18:30:00'));
+        $exif->method('getGPS')->willReturn(false);
+
+        $factory = $this->factory($this->normalizer(new NormalizedImage('JPEGBYTES', 'image/jpeg', 'jpg')), $this->exifWrapper($exif));
+
+        $parsed = $this->withTempFile('jpeg-bytes', fn (string $path) => $factory->createFromUpload($path, 'photo.jpg', $this->createMock(User::class)));
+
+        self::assertNull($parsed->getCandidate()->getLatitude());
+        self::assertNull($parsed->getCandidate()->getLongitude());
+        self::assertSame('2024-06-01 18:30:00', $parsed->getCandidate()->getExifCreationDate()?->format('Y-m-d H:i:s'));
+    }
+
+    private function factory(PhotoNormalizerInterface $normalizer, ExifWrapperInterface $exifWrapper): PhotoCandidateFactory
+    {
+        return new PhotoCandidateFactory($normalizer, $exifWrapper);
+    }
+
+    private function normalizer(?NormalizedImage $result = null): PhotoNormalizerInterface
+    {
+        $normalizer = $this->createMock(PhotoNormalizerInterface::class);
+
+        if ($result !== null) {
+            $normalizer->method('normalize')->willReturn($result);
+        }
+
+        return $normalizer;
+    }
+
+    private function exifWrapper(?Exif $exif): ExifWrapperInterface
+    {
+        $wrapper = $this->createMock(ExifWrapperInterface::class);
+        $wrapper->method('readExifDataFromFile')->willReturn($exif);
+
+        return $wrapper;
+    }
+
+    /**
+     * @template T
+     *
+     * @param callable(string): T $callback
+     *
+     * @return T
+     */
+    private function withTempFile(string $contents, callable $callback): mixed
+    {
+        $path = tempnam(sys_get_temp_dir(), 'photo-factory-test-');
+        self::assertIsString($path);
+        file_put_contents($path, $contents);
+
+        try {
+            return $callback($path);
+        } finally {
+            @unlink($path);
+        }
+    }
+}

--- a/tests/Criticalmass/PhotoImport/PhotoCandidateImporter/PhotoCandidateImporterTest.php
+++ b/tests/Criticalmass/PhotoImport/PhotoCandidateImporter/PhotoCandidateImporterTest.php
@@ -1,0 +1,103 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Criticalmass\PhotoImport\PhotoCandidateImporter;
+
+use App\Criticalmass\PhotoImport\PhotoCandidateImporter\PhotoCandidateImporter;
+use App\Criticalmass\UploadFaker\UploadFakerInterface;
+use App\Entity\City;
+use App\Entity\Photo;
+use App\Entity\PhotoImportCandidate;
+use App\Entity\Ride;
+use App\Entity\User;
+use App\Event\Photo\PhotoUploadedEvent;
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectManager;
+use League\Flysystem\FilesystemOperator;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class PhotoCandidateImporterTest extends TestCase
+{
+    public function testImportsGalleryIntoPhotosAndCleansUp(): void
+    {
+        $candidate = $this->candidate('IMG_4711.heic', 'a1b2.jpg');
+        $ride = $this->ride();
+
+        $filesystem = $this->createMock(FilesystemOperator::class);
+        $filesystem->method('fileExists')->willReturn(true);
+        $filesystem->method('read')->willReturn('JPEGBYTES');
+        $filesystem->expects(self::once())->method('delete')->with('a1b2.jpg');
+
+        $uploadFaker = $this->createMock(UploadFakerInterface::class);
+        // HEIC original is staged as JPEG, so the faked upload carries the .jpg name.
+        $uploadFaker->expects(self::once())->method('fakeUpload')
+            ->with(self::isInstanceOf(Photo::class), 'imageFile', 'JPEGBYTES', 'IMG_4711.jpg')
+            ->willReturn('/tmp/whatever');
+
+        $manager = $this->createMock(ObjectManager::class);
+        $manager->expects(self::once())->method('persist')->with(self::isInstanceOf(Photo::class));
+        $manager->expects(self::once())->method('remove')->with($candidate);
+
+        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $dispatcher->expects(self::once())->method('dispatch')
+            ->with(self::isInstanceOf(PhotoUploadedEvent::class), PhotoUploadedEvent::NAME)
+            ->willReturnArgument(0);
+
+        $photos = $this->importer($manager, $uploadFaker, $dispatcher, $filesystem)->importGallery([$candidate], $ride);
+
+        self::assertCount(1, $photos);
+        self::assertSame($ride, $photos[0]->getRide());
+        self::assertSame($ride->getCity(), $photos[0]->getCity());
+    }
+
+    public function testCandidateWithMissingStagedFileIsSkipped(): void
+    {
+        $candidate = $this->candidate('photo.jpg', 'gone.jpg');
+
+        $filesystem = $this->createMock(FilesystemOperator::class);
+        $filesystem->method('fileExists')->willReturn(false);
+        $filesystem->expects(self::never())->method('read');
+        $filesystem->expects(self::never())->method('delete');
+
+        $manager = $this->createMock(ObjectManager::class);
+        $manager->expects(self::never())->method('persist');
+        $manager->expects(self::never())->method('remove');
+
+        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $dispatcher->expects(self::never())->method('dispatch');
+
+        $photos = $this->importer($manager, $this->createMock(UploadFakerInterface::class), $dispatcher, $filesystem)
+            ->importGallery([$candidate], $this->ride());
+
+        self::assertSame([], $photos);
+    }
+
+    private function candidate(string $originalName, string $stagedFilename): PhotoImportCandidate
+    {
+        return (new PhotoImportCandidate())
+            ->setUser($this->createMock(User::class))
+            ->setFileHash('a1b2')
+            ->setStagedFilename($stagedFilename)
+            ->setOriginalName($originalName);
+    }
+
+    private function ride(): Ride
+    {
+        $ride = $this->createMock(Ride::class);
+        $ride->method('getCity')->willReturn($this->createMock(City::class));
+
+        return $ride;
+    }
+
+    private function importer(
+        ObjectManager $manager,
+        UploadFakerInterface $uploadFaker,
+        EventDispatcherInterface $dispatcher,
+        FilesystemOperator $filesystem,
+    ): PhotoCandidateImporter {
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->method('getManager')->willReturn($manager);
+
+        return new PhotoCandidateImporter($registry, $uploadFaker, $dispatcher, $filesystem);
+    }
+}

--- a/tests/Criticalmass/PhotoImport/PhotoDecider/PhotoDeciderTest.php
+++ b/tests/Criticalmass/PhotoImport/PhotoDecider/PhotoDeciderTest.php
@@ -1,0 +1,97 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Criticalmass\PhotoImport\PhotoDecider;
+
+use App\Criticalmass\PhotoImport\PhotoDecider\PhotoDecider;
+use App\Entity\PhotoImportCandidate;
+use App\Entity\Ride;
+use App\Repository\RideRepository;
+use PHPUnit\Framework\TestCase;
+
+class PhotoDeciderTest extends TestCase
+{
+    public function testUndatedGalleryIsParked(): void
+    {
+        $repository = $this->createMock(RideRepository::class);
+        $repository->expects(self::never())->method('findByDate');
+
+        self::assertNull($this->decider($repository)->decideForGallery(null, [$this->candidate()]));
+    }
+
+    public function testGalleryWithoutMatchingRideIsParked(): void
+    {
+        $repository = $this->repositoryReturning([]);
+
+        self::assertNull($this->decider($repository)->decideForGallery(new \DateTime('2024-06-01'), [$this->candidate()]));
+    }
+
+    public function testSingleRideWithoutGpsIsMatchedOnDateAlone(): void
+    {
+        $ride = $this->ride(null, null);
+        $repository = $this->repositoryReturning([$ride]);
+
+        self::assertSame($ride, $this->decider($repository)->decideForGallery(new \DateTime('2024-06-01'), [$this->candidate()]));
+    }
+
+    public function testSeveralRidesWithoutGpsAreParked(): void
+    {
+        $repository = $this->repositoryReturning([$this->ride(null, null), $this->ride(null, null)]);
+
+        // No coordinates to disambiguate between two rides on the same day → park.
+        self::assertNull($this->decider($repository)->decideForGallery(new \DateTime('2024-06-01'), [$this->candidate()]));
+    }
+
+    public function testGpsPicksTheNearestRide(): void
+    {
+        $farRide = $this->ride(0.0, 0.0);
+        $nearRide = $this->ride(52.50, 13.40);
+        $repository = $this->repositoryReturning([$farRide, $nearRide]);
+
+        $candidates = [
+            $this->candidate(52.51, 13.41),
+            $this->candidate(52.49, 13.39),
+        ];
+
+        self::assertSame($nearRide, $this->decider($repository)->decideForGallery(new \DateTime('2024-06-01'), $candidates));
+    }
+
+    public function testGpsBeyondRadiusIsParked(): void
+    {
+        // The only ride that day is ~5800 km away from where the photos were taken.
+        $repository = $this->repositoryReturning([$this->ride(0.0, 0.0)]);
+
+        self::assertNull($this->decider($repository)->decideForGallery(new \DateTime('2024-06-01'), [$this->candidate(52.50, 13.40)]));
+    }
+
+    /**
+     * @param list<Ride> $rides
+     */
+    private function repositoryReturning(array $rides): RideRepository
+    {
+        $repository = $this->createMock(RideRepository::class);
+        $repository->method('findByDate')->willReturn($rides);
+
+        return $repository;
+    }
+
+    private function decider(RideRepository $repository): PhotoDecider
+    {
+        return new PhotoDecider($repository);
+    }
+
+    private function ride(?float $latitude, ?float $longitude): Ride
+    {
+        $ride = $this->createMock(Ride::class);
+        $ride->method('getLatitude')->willReturn($latitude);
+        $ride->method('getLongitude')->willReturn($longitude);
+
+        return $ride;
+    }
+
+    private function candidate(?float $latitude = null, ?float $longitude = null): PhotoImportCandidate
+    {
+        return (new PhotoImportCandidate())
+            ->setLatitude($latitude)
+            ->setLongitude($longitude);
+    }
+}


### PR DESCRIPTION
## Summary

Backend foundation for the **unified upload** — the photo counterpart to the existing bulk-track pipeline. Uploaded images are staged and *parked for review*, then confirmed/reassigned per **gallery** (not per single photo), exactly the way tracks already work. No controller or UI yet — that lands in the follow-up PRs (unified endpoint + Uppy frontend, then the review UI).

This mirrors the track side one-to-one:

| Track side | Photo side (this PR) |
|---|---|
| `TrackImportCandidate` | `PhotoImportCandidate` |
| `UploadedTrackCandidateFactory` | `PhotoCandidateFactory` |
| `TrackDecider` | `PhotoDecider` |
| `FileTrackImporter` | `PhotoCandidateImporter` |
| FIT → GPX on ingest | HEIC → JPEG on ingest |

### What's included
- **`PhotoImportCandidate`** entity + repository + migration. Staged **outside the web root** (`var/photo-candidates`, per #1395), grouped into galleries by EXIF capture date (`Y-m-d`).
- **`PhotoNormalizer`** — converts HEIC/HEIF to JPEG via ImageMagick while **preserving the EXIF profile** (so date/GPS survive for matching and display); JPEG/PNG/WebP/GIF pass through. Behind an interface, with a guard that **fails closed** with a clear message when the libheif delegate is unavailable (e.g. CI without imagick).
- **`PhotoCandidateFactory`** — reads EXIF date + GPS from the *normalised* bytes (works for HEIC too), hashes the **original** file for dedup, builds the candidate.
- **`PhotoDecider`** — suggests a ride for a gallery by **date**, refined by **GPS proximity** to the ride; parks the gallery when the match is ambiguous (no GPS + multiple rides, or nothing within ~50 km).
- **`PhotoCandidateImporter`** — turns a confirmed gallery into `Photo`s via the existing `PhotoUploadedEvent` enrichment (EXIF + track geolocation), then cleans up candidates and staged files.

## Test Plan
- `vendor/bin/phpunit tests/Criticalmass/PhotoImport` → **12 tests, 49 assertions, green** (pure unit tests, no DB — fully mocked, CI-safe without imagick).
  - Decider: undated → park, no ride → park, single ride on date → match, ambiguous no-GPS → park, GPS picks nearest, beyond radius → park.
  - Factory: unsupported type throws, HEIC builds JPEG-staged candidate with EXIF date+GPS, dateless image → no gallery key, non-string GPS → no coords.
  - Importer: gallery → Photos + cleanup, missing staged file → skipped.
- `vendor/bin/phpstan analyse` over all new files + tests → **no errors**.
- Migration `up`/`down` verified against a throwaway MariaDB.
- `debug:container` confirms all four services autowire (incl. the `$photoCandidateFilesystem` binding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)