### PR TITLE
Unified upload: photo housekeeping + review thumbnails

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **criticalmass.in** — web platform for coordinating and documenting Critical Mass bicycle rides worldwide. Manages cities, rides/events, participants, GPS tracks, photos, forums, and statistics.
 
-**Stack:** Symfony 7.2, Doctrine ORM 3 / DBAL 4, PHP 8.2+, MariaDB 10.9+, Bootstrap 5, Webpack Encore with Stimulus
+**Stack:** Symfony 7.4 (LTS), Doctrine ORM 3 / DBAL 4, PHP 8.2+, MariaDB 10.9+, Bootstrap 5, Webpack Encore with Stimulus
 
 ## Common Commands
 
@@ -59,14 +59,18 @@ docker-compose up -d      # MariaDB (port 8002), Redis, Memcached, Mailcatcher (
 
 Notable pattern: entities are annotated with `#[Routing\DefaultRoute]` and `#[Routing\RouteParameter]` attributes. The `DelegatedRouterManager` in `src/Criticalmass/Router/` generates canonical URLs for any entity by introspecting these attributes. Used extensively in Twig via `RouterTwigExtension`.
 
-### Track Upload (GPX/FIT)
+### Unified Upload (tracks + photos)
 
-Users add ride tracks by **file upload**, not via the Strava API. The Strava data-import path is being retired: the API Agreement's retention/deletion rules (Policy §6.2/§6.3/§7.4) forbid permanently and publicly archiving API-sourced data (see PR #1389 / epic #1388). Two flows:
+Users upload GPX/FIT **tracks and photos through one form** at `/upload` (`UnifiedUploadController`, Uppy dashboard, one POST per file to `/upload/file`). The Strava data-import path is being retired: the API Agreement's retention/deletion rules (Policy §6.2/§6.3/§7.4) forbid permanently and publicly archiving API-sourced data (epic #1388). `UploadDispatcher` (`Criticalmass/Upload/`) routes each file by extension to a handler that parses it into a **candidate** and either matches it to a ride or parks it for review:
 
-- **Single upload** per ride: `TrackUploadController` (`/{city}/{ride}/addtrack`) → `VichFileType` → `TrackValidator` → `TrackUploadedEvent` → `TrackEventSubscriber` enrichment.
-- **Bulk upload**: `BulkTrackUploadController` (per-file POST, Dropzone — one request per file) → `UploadedTrackCandidateFactory` → `TrackImportCandidate` → `TrackDecider` (voters in `Criticalmass/MassTrackImport/Voter/`, threshold 0.75, wired via `TrackVoterPass`) assigns a ride or parks the candidate → `FileTrackImporter` turns a confirmed candidate into a `Track`.
+- **Tracks** (`.gpx`, `.fit`) → `TrackUploadHandler` → `UploadedTrackCandidateFactory` → `TrackImportCandidate` → `TrackDecider` (voters in `Criticalmass/MassTrackImport/Voter/`, threshold 0.75, wired via `TrackVoterPass`) → `FileTrackImporter` turns a confirmed candidate into a `Track`. FIT is normalised to GPX on ingest (`Geo/FitService/FitToGpxConverter`), so everything downstream stays GPX-only.
+- **Images** (`.jpg/.jpeg/.png/.webp/.gif/.heic/.heif`) → `PhotoUploadHandler` → `PhotoCandidateFactory` → `PhotoImportCandidate` (staged **outside the web root** in `var/photo-candidates`, #1395) → `PhotoDecider` (date + GPS proximity) → `PhotoCandidateImporter` turns a confirmed gallery into `Photo`s via the normal `PhotoUploadedEvent` enrichment. HEIC/HEIF are normalised to JPEG on ingest (`PhotoImport/Normalizer/ImagickPhotoNormalizer`, EXIF preserved for date/GPS matching).
 
-**FIT files are normalised to GPX on ingest** (`Criticalmass/Geo/FitService/FitToGpxConverter`), so everything downstream stays GPX-only. `TrackImportCandidate` is source-agnostic (`source`, `fileHash`, `originalName`).
+The photo pipeline in `Criticalmass/PhotoImport/` deliberately mirrors the track pipeline in `Criticalmass/MassTrackImport/` (`PhotoImportCandidate`↔`TrackImportCandidate`, factory/decider/importer, HEIC→JPEG ↔ FIT→GPX). Both candidate entities are source-agnostic (`source`/`fileHash`/`originalName`).
+
+Everything is confirmed on **one review page** at `/upload/review` (`UnifiedReviewController`): **photos are reviewed per whole gallery** (grouped by capture date via `UploadReviewAssembler`, never per single photo) — confirm to the suggested ride, reassign to another ride **on the same date**, or reject the whole gallery; tracks are confirmed/rejected or reassigned to a same-date ride. The old `/trackupload/bulk` (Dropzone) and `/trackupload/review` routes redirect here. Housekeeping: `criticalmass:photos:purge-import-candidates` (mirrors the track variant, #1387). Per-ride single uploads still exist: `TrackUploadController` (`/{city}/{ride}/addtrack`) and `PhotoUploadController` (`/{city}/{ride}/addphoto`).
+
+**Frontend note:** the uploader is **Uppy** (`assets/controllers/unified_upload_controller.js`), no Compressor plugin so image EXIF survives. The `@uppy/*` packages are declared in `package.json`, but `package-lock.json` is **frozen** — `webpack`/`@babel/core` are not declared deps and survive only via the committed lock, so any re-resolution (`npm install`/`yarn install`) breaks the tree; use `npm ci`, and regenerate the lock deliberately when adding frontend deps. Frontend assets are **not** built in CI.
 
 ### Frontend (`assets/`)
 

--- a/src/Command/Photo/PurgePhotoImportCandidatesCommand.php
+++ b/src/Command/Photo/PurgePhotoImportCandidatesCommand.php
@@ -1,0 +1,160 @@
+<?php declare(strict_types=1);
+
+namespace App\Command\Photo;
+
+use App\Entity\PhotoImportCandidate;
+use App\Repository\PhotoImportCandidateRepository;
+use Carbon\Carbon;
+use Doctrine\Persistence\ManagerRegistry;
+use League\Flysystem\FilesystemException;
+use League\Flysystem\FilesystemOperator;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Housekeeping for the unified upload's photo candidates (mirrors the track variant,
+ * #1387): removes rejected and expired, never-confirmed photo candidates together with
+ * their staged files, and deletes orphaned files in the candidate storage that no
+ * candidate references. Confirmed candidates are already removed on import.
+ */
+#[AsCommand(
+    name: 'criticalmass:photos:purge-import-candidates',
+    description: 'Remove rejected/expired upload photo candidates and orphaned staged files',
+)]
+class PurgePhotoImportCandidatesCommand extends Command
+{
+    private const DEFAULT_MAX_AGE_DAYS = 30;
+
+    public function __construct(
+        private readonly ManagerRegistry $registry,
+        private readonly FilesystemOperator $photoCandidateFilesystem,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('max-age', null, InputOption::VALUE_REQUIRED, 'Maximum age in days for never-confirmed candidates', (string) self::DEFAULT_MAX_AGE_DAYS)
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Show what would be deleted without deleting anything');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $dryRun = (bool) $input->getOption('dry-run');
+        $maxAgeDays = max(0, (int) $input->getOption('max-age'));
+        $expiredBefore = Carbon::now()->subDays($maxAgeDays);
+
+        if ($dryRun) {
+            $io->note('Dry run — nothing will be deleted.');
+        }
+
+        $io->section('Rejected & expired photo candidates');
+        $removedCandidates = $this->purgeCandidates($io, $expiredBefore, $dryRun);
+
+        $io->section('Orphaned staged files');
+        $removedFiles = $this->purgeOrphanedFiles($io, $dryRun);
+
+        $io->success(sprintf(
+            '%s %d candidate(s) and %d orphaned file(s).',
+            $dryRun ? 'Would remove' : 'Removed',
+            $removedCandidates,
+            $removedFiles,
+        ));
+
+        return Command::SUCCESS;
+    }
+
+    private function purgeCandidates(SymfonyStyle $io, \DateTimeInterface $expiredBefore, bool $dryRun): int
+    {
+        /** @var PhotoImportCandidateRepository $repository */
+        $repository = $this->registry->getRepository(PhotoImportCandidate::class);
+        $candidates = $repository->findPurgeable($expiredBefore);
+
+        if ($candidates === []) {
+            $io->writeln('No candidates to purge.');
+
+            return 0;
+        }
+
+        $manager = $this->registry->getManager();
+        $count = 0;
+
+        foreach ($candidates as $candidate) {
+            $reason = $candidate->isRejected() ? 'rejected' : 'expired';
+            $storagePath = $candidate->getStagedFilename();
+
+            $io->writeln(sprintf(
+                ' - #%d "%s" (%s, created %s)',
+                (int) $candidate->getId(),
+                (string) $candidate->getOriginalName(),
+                $reason,
+                $candidate->getCreatedAt()?->format('Y-m-d') ?? '?',
+            ));
+
+            if (!$dryRun) {
+                if ($storagePath !== null && $this->photoCandidateFilesystem->fileExists($storagePath)) {
+                    $this->photoCandidateFilesystem->delete($storagePath);
+                }
+
+                $manager->remove($candidate);
+            }
+
+            ++$count;
+        }
+
+        if (!$dryRun) {
+            $manager->flush();
+        }
+
+        return $count;
+    }
+
+    private function purgeOrphanedFiles(SymfonyStyle $io, bool $dryRun): int
+    {
+        /** @var PhotoImportCandidateRepository $repository */
+        $repository = $this->registry->getRepository(PhotoImportCandidate::class);
+        $referenced = array_flip($repository->findReferencedStagedFilenames());
+
+        $count = 0;
+
+        try {
+            // Staged photos live at the storage root (filename = "<hash>.<ext>").
+            foreach ($this->photoCandidateFilesystem->listContents('', false) as $item) {
+                if (!$item->isFile()) {
+                    continue;
+                }
+
+                $path = $item->path();
+
+                if (isset($referenced[$path])) {
+                    continue;
+                }
+
+                $io->writeln(sprintf(' - %s', $path));
+
+                if (!$dryRun) {
+                    $this->photoCandidateFilesystem->delete($path);
+                }
+
+                ++$count;
+            }
+        } catch (FilesystemException $exception) {
+            $io->writeln('Candidate storage is not accessible yet.');
+
+            return 0;
+        }
+
+        if ($count === 0) {
+            $io->writeln('No orphaned files found.');
+        }
+
+        return $count;
+    }
+}

--- a/src/Controller/Upload/UnifiedReviewController.php
+++ b/src/Controller/Upload/UnifiedReviewController.php
@@ -4,6 +4,7 @@ namespace App\Controller\Upload;
 
 use App\Controller\AbstractController;
 use App\Criticalmass\PhotoImport\PhotoCandidateImporter\PhotoCandidateImporterInterface;
+use App\Criticalmass\PhotoImport\Review\CandidatePreviewThumbnailer;
 use App\Criticalmass\PhotoImport\Review\UploadReviewAssembler;
 use App\Entity\PhotoImportCandidate;
 use App\Entity\Ride;
@@ -153,6 +154,7 @@ class UnifiedReviewController extends AbstractController
     public function photoPreviewAction(
         #[MapEntity(id: 'id')] PhotoImportCandidate $candidate,
         FilesystemOperator $photoCandidateFilesystem,
+        CandidatePreviewThumbnailer $thumbnailer,
         #[CurrentUser] User $user,
     ): Response {
         if ($candidate->getUser() !== $user) {
@@ -165,8 +167,11 @@ class UnifiedReviewController extends AbstractController
             throw new NotFoundHttpException();
         }
 
-        return new Response($photoCandidateFilesystem->read($storagePath), Response::HTTP_OK, [
-            'Content-Type' => $candidate->getMimeType() ?? 'application/octet-stream',
+        $bytes = $photoCandidateFilesystem->read($storagePath);
+        $thumbnail = $thumbnailer->thumbnail($bytes);
+
+        return new Response($thumbnail ?? $bytes, Response::HTTP_OK, [
+            'Content-Type' => $thumbnail !== null ? 'image/jpeg' : ($candidate->getMimeType() ?? 'application/octet-stream'),
             'Cache-Control' => 'private, max-age=300',
         ]);
     }

--- a/src/Criticalmass/PhotoImport/Review/CandidatePreviewThumbnailer.php
+++ b/src/Criticalmass/PhotoImport/Review/CandidatePreviewThumbnailer.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+namespace App\Criticalmass\PhotoImport\Review;
+
+/**
+ * Produces small JPEG thumbnails of staged candidate images for the review page.
+ *
+ * Staged photos live outside the web root and are served owner-only, so they cannot go
+ * through the public LiipImagine cache. Thumbnailing is therefore done in-process via
+ * ImageMagick (present in production); when it is unavailable (e.g. CI) this returns null
+ * and the caller falls back to streaming the original bytes.
+ */
+class CandidatePreviewThumbnailer
+{
+    private const MAX_SIZE = 320;
+
+    /**
+     * @return string|null JPEG thumbnail bytes, or null if no thumbnail could be produced
+     */
+    public function thumbnail(string $bytes): ?string
+    {
+        if (!\extension_loaded('imagick')) {
+            return null;
+        }
+
+        $imagick = new \Imagick();
+
+        try {
+            $imagick->readImageBlob($bytes);
+            $imagick->setImageFormat('jpeg');
+            $imagick->thumbnailImage(self::MAX_SIZE, self::MAX_SIZE, true);
+            $imagick->setImageCompressionQuality(80);
+            // A preview needs no metadata — strip it to keep the thumbnail small.
+            $imagick->stripImage();
+
+            return $imagick->getImageBlob();
+        } catch (\Throwable $exception) {
+            return null;
+        } finally {
+            $imagick->clear();
+        }
+    }
+}

--- a/src/Repository/PhotoImportCandidateRepository.php
+++ b/src/Repository/PhotoImportCandidateRepository.php
@@ -40,4 +40,42 @@ class PhotoImportCandidateRepository extends ServiceEntityRepository
             ->getQuery()
             ->getResult();
     }
+
+    /**
+     * Candidates that are rejected or older than the given threshold and were never
+     * confirmed (confirmed candidates are removed on import) — i.e. safe to purge.
+     *
+     * @return list<PhotoImportCandidate>
+     */
+    public function findPurgeable(\DateTimeInterface $expiredBefore): array
+    {
+        $builder = $this->createQueryBuilder('c');
+
+        $builder
+            ->where($builder->expr()->orX(
+                $builder->expr()->eq('c.rejected', ':rejected'),
+                $builder->expr()->lt('c.createdAt', ':expiredBefore'),
+            ))
+            ->setParameter('rejected', true)
+            ->setParameter('expiredBefore', $expiredBefore)
+            ->orderBy('c.createdAt', 'ASC');
+
+        return $builder->getQuery()->getResult();
+    }
+
+    /**
+     * All staged file paths still referenced by a candidate row.
+     *
+     * @return list<string>
+     */
+    public function findReferencedStagedFilenames(): array
+    {
+        $builder = $this->createQueryBuilder('c');
+
+        $builder
+            ->select('c.stagedFilename')
+            ->where($builder->expr()->isNotNull('c.stagedFilename'));
+
+        return array_column($builder->getQuery()->getScalarResult(), 'stagedFilename');
+    }
 }

--- a/tests/Command/Photo/PurgePhotoImportCandidatesCommandTest.php
+++ b/tests/Command/Photo/PurgePhotoImportCandidatesCommandTest.php
@@ -1,0 +1,131 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Command\Photo;
+
+use App\Command\Photo\PurgePhotoImportCandidatesCommand;
+use App\Entity\PhotoImportCandidate;
+use App\Repository\PhotoImportCandidateRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectManager;
+use League\Flysystem\DirectoryListing;
+use League\Flysystem\FileAttributes;
+use League\Flysystem\FilesystemException;
+use League\Flysystem\FilesystemOperator;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class PurgePhotoImportCandidatesCommandTest extends TestCase
+{
+    private MockObject&ManagerRegistry $registry;
+    private MockObject&PhotoImportCandidateRepository $repository;
+    private MockObject&ObjectManager $manager;
+    private MockObject&FilesystemOperator $filesystem;
+    private CommandTester $commandTester;
+
+    protected function setUp(): void
+    {
+        $this->registry = $this->createMock(ManagerRegistry::class);
+        $this->repository = $this->createMock(PhotoImportCandidateRepository::class);
+        $this->manager = $this->createMock(ObjectManager::class);
+        $this->filesystem = $this->createMock(FilesystemOperator::class);
+
+        $this->registry->method('getRepository')->willReturn($this->repository);
+        $this->registry->method('getManager')->willReturn($this->manager);
+
+        $command = new PurgePhotoImportCandidatesCommand($this->registry, $this->filesystem);
+
+        $application = new Application();
+        $application->add($command);
+
+        $this->commandTester = new CommandTester($application->find('criticalmass:photos:purge-import-candidates'));
+    }
+
+    private function makeCandidate(bool $rejected, string $file): PhotoImportCandidate
+    {
+        return (new PhotoImportCandidate())
+            ->setRejected($rejected)
+            ->setOriginalName($file)
+            ->setStagedFilename($file);
+    }
+
+    public function testDryRunDeletesNothing(): void
+    {
+        $this->repository->method('findPurgeable')->willReturn([$this->makeCandidate(true, 'a.jpg')]);
+        $this->repository->method('findReferencedStagedFilenames')->willReturn(['keep.jpg']);
+        $this->filesystem->method('listContents')->willReturn(new DirectoryListing(new \ArrayIterator([
+            new FileAttributes('keep.jpg'),
+            new FileAttributes('orphan.jpg'),
+        ])));
+
+        $this->manager->expects($this->never())->method('remove');
+        $this->manager->expects($this->never())->method('flush');
+        $this->filesystem->expects($this->never())->method('delete');
+
+        $this->commandTester->execute(['--dry-run' => true]);
+
+        $display = $this->commandTester->getDisplay();
+        $this->assertStringContainsString('Dry run', $display);
+        $this->assertStringContainsString('Would remove 1 candidate(s) and 1 orphaned file(s)', $display);
+        $this->assertSame(0, $this->commandTester->getStatusCode());
+    }
+
+    public function testPurgeRemovesCandidatesAndOrphanedFiles(): void
+    {
+        $this->repository->method('findPurgeable')->willReturn([
+            $this->makeCandidate(true, 'a.jpg'),
+            $this->makeCandidate(false, 'b.jpg'),
+        ]);
+        $this->repository->method('findReferencedStagedFilenames')->willReturn(['a.jpg', 'b.jpg']);
+
+        $this->filesystem->method('fileExists')->willReturn(true);
+        $this->filesystem->method('listContents')->willReturn(new DirectoryListing(new \ArrayIterator([
+            new FileAttributes('a.jpg'),
+            new FileAttributes('b.jpg'),
+            new FileAttributes('orphan.jpg'),
+        ])));
+
+        // Two candidate files + one orphan should be deleted.
+        $this->filesystem->expects($this->exactly(3))->method('delete');
+        $this->manager->expects($this->exactly(2))->method('remove');
+        $this->manager->expects($this->atLeastOnce())->method('flush');
+
+        $this->commandTester->execute([]);
+
+        $display = $this->commandTester->getDisplay();
+        $this->assertStringContainsString('Removed 2 candidate(s) and 1 orphaned file(s)', $display);
+        $this->assertSame(0, $this->commandTester->getStatusCode());
+    }
+
+    public function testNothingToPurgeWithEmptyStorage(): void
+    {
+        $this->repository->method('findPurgeable')->willReturn([]);
+        $this->repository->method('findReferencedStagedFilenames')->willReturn([]);
+        $this->filesystem->method('listContents')->willReturn(new DirectoryListing(new \ArrayIterator([])));
+
+        $this->commandTester->execute([]);
+
+        $display = $this->commandTester->getDisplay();
+        $this->assertStringContainsString('No candidates to purge', $display);
+        $this->assertStringContainsString('No orphaned files found', $display);
+        $this->assertStringContainsString('Removed 0 candidate(s) and 0 orphaned file(s)', $display);
+        $this->assertSame(0, $this->commandTester->getStatusCode());
+    }
+
+    public function testUnreadableStorageIsHandledGracefully(): void
+    {
+        $this->repository->method('findPurgeable')->willReturn([]);
+        $this->repository->method('findReferencedStagedFilenames')->willReturn([]);
+        $this->filesystem->method('listContents')->willThrowException(
+            new class('storage unavailable') extends \RuntimeException implements FilesystemException {},
+        );
+
+        $this->commandTester->execute([]);
+
+        $display = $this->commandTester->getDisplay();
+        $this->assertStringContainsString('Candidate storage is not accessible yet', $display);
+        $this->assertStringContainsString('Removed 0 candidate(s) and 0 orphaned file(s)', $display);
+        $this->assertSame(0, $this->commandTester->getStatusCode());
+    }
+}

--- a/tests/Criticalmass/PhotoImport/Review/CandidatePreviewThumbnailerTest.php
+++ b/tests/Criticalmass/PhotoImport/Review/CandidatePreviewThumbnailerTest.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Criticalmass\PhotoImport\Review;
+
+use App\Criticalmass\PhotoImport\Review\CandidatePreviewThumbnailer;
+use PHPUnit\Framework\TestCase;
+
+class CandidatePreviewThumbnailerTest extends TestCase
+{
+    /**
+     * Invalid input yields null in every environment: without ImageMagick the guard
+     * returns null, and with it the decode fails and is caught — so the caller can
+     * always rely on the null fallback.
+     */
+    public function testInvalidImageYieldsNull(): void
+    {
+        self::assertNull((new CandidatePreviewThumbnailer())->thumbnail('this is not an image'));
+    }
+
+    public function testEmptyInputYieldsNull(): void
+    {
+        self::assertNull((new CandidatePreviewThumbnailer())->thumbnail(''));
+    }
+}


### PR DESCRIPTION
> **Stacked on #1435** (→ #1434 → #1433). Optional polish for the unified upload. Merge order: #1433 → #1434 → #1435 → this.

## Summary

Two follow-ups to round out the unified upload.

### 1. Photo-candidate housekeeping
`PurgePhotoImportCandidatesCommand` (`criticalmass:photos:purge-import-candidates`) — the photo counterpart to the track housekeeping (#1387):
- removes **rejected** and **expired, never-confirmed** photo candidates together with their staged files (confirmed ones are already removed on import),
- deletes **orphaned** files in the candidate storage that no candidate references.
- Options: `--dry-run`, `--max-age=<days>` (default 30).

New repository finders: `findPurgeable()` and `findReferencedStagedFilenames()`. Ready to wire into the same cron as the track purge.

### 2. Review preview thumbnails
The gallery preview endpoint now serves **small JPEG thumbnails** (max 320 px) instead of the full image. Staged photos are **private** (owner-only, outside the web root), so they can't use the public LiipImagine cache — thumbnailing runs in-process via ImageMagick (`CandidatePreviewThumbnailer`) and **falls back to the original bytes** when ImageMagick is unavailable (e.g. CI). The endpoint stays owner-only and `private`-cached.

## Test Plan
- `vendor/bin/phpunit tests/Command/Photo` — dry-run, purge (candidates + orphans), empty storage, unreadable storage. Green.
- `vendor/bin/phpunit tests/Criticalmass/PhotoImport/Review/CandidatePreviewThumbnailerTest.php` — null fallback on invalid/empty input (deterministic across environments). Green.
- `vendor/bin/phpunit tests/Controller/UnifiedReviewControllerTest.php` — existing preview test covers the endpoint's raw fallback. Green.
- `vendor/bin/phpstan analyse` (whole project) → no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)