### PR TITLE
Fix 404 when rotating a photo (#1438)

### DIFF
--- a/src/Controller/Photo/PhotoManagementController.php
+++ b/src/Controller/Photo/PhotoManagementController.php
@@ -191,11 +191,9 @@ class PhotoManagementController extends AbstractController
     {
         $this->saveReferer($request);
 
-        $angle = 90;
-
-        if ($request->query->get('rotate') && $request->query->get('rotate') === 'right') {
-            $angle = -90;
-        }
+        // The template links pass ?direction=left|right; rotate right (clockwise)
+        // is the default, rotate left (counter-clockwise) uses a negative angle.
+        $angle = $request->query->get('direction') === 'left' ? -90 : 90;
 
         $photoManipulator
             ->open($photo)

--- a/src/Criticalmass/Image/PhotoManipulator/Cache/PhotoCache.php
+++ b/src/Criticalmass/Image/PhotoManipulator/Cache/PhotoCache.php
@@ -15,10 +15,20 @@ class PhotoCache extends AbstractPhotoCache
 
         $this->cacheManager->remove($filename);
 
-        $this->imagineController->filterAction(new Request(), $filename, 'gallery_photo_thumb');
-        $this->imagineController->filterAction(new Request(), $filename, 'gallery_photo_standard');
-        $this->imagineController->filterAction(new Request(), $filename, 'gallery_photo_large');
-        $this->imagineController->filterAction(new Request(), $filename, 'city_image_wide');
+        // Only warm the filters that actually load from the photo filesystem.
+        // The former `city_image_wide` call used the city loader, so a photo path
+        // was never found there and LiipImagine turned that into a 404 — which
+        // broke the rotate/censor action even though the image had already been
+        // written (#1438).
+        foreach (['gallery_photo_thumb', 'gallery_photo_standard', 'gallery_photo_large'] as $filter) {
+            try {
+                $this->imagineController->filterAction(new Request(), $filename, $filter);
+            } catch (\Throwable) {
+                // Warming the cache is best-effort: a failing filter must never
+                // turn a successful manipulation into an error response. The
+                // derivative is regenerated lazily on the next request.
+            }
+        }
 
         return $this;
     }

--- a/tests/Criticalmass/Image/PhotoManipulator/Cache/PhotoCacheTest.php
+++ b/tests/Criticalmass/Image/PhotoManipulator/Cache/PhotoCacheTest.php
@@ -1,0 +1,77 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Criticalmass\Image\PhotoManipulator\Cache;
+
+use App\Criticalmass\Image\PhotoManipulator\Cache\PhotoCache;
+use App\Criticalmass\Image\PhotoManipulator\PhotoInterface\ManipulateablePhotoInterface;
+use Liip\ImagineBundle\Controller\ImagineController;
+use Liip\ImagineBundle\Imagine\Cache\CacheManager;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Vich\UploaderBundle\Storage\StorageInterface;
+use Vich\UploaderBundle\Templating\Helper\UploaderHelper;
+
+/**
+ * Regression coverage for #1438: rotating/censoring a photo returned a 404 while
+ * the image was already written, because {@see PhotoCache::recachePhoto()} warmed
+ * the LiipImagine cache with the `city_image_wide` filter — whose data loader
+ * reads from the city filesystem, where a photo file never exists. LiipImagine
+ * turns the resulting NotLoadableException into a NotFoundHttpException, which
+ * bubbled up as the response of the user action.
+ */
+class PhotoCacheTest extends TestCase
+{
+    private function createUploaderHelper(string $uri): UploaderHelper
+    {
+        $storage = $this->createMock(StorageInterface::class);
+        $storage->method('resolveUri')->willReturn($uri);
+
+        return new UploaderHelper($storage);
+    }
+
+    public function testRecacheNeverWarmsWithTheCityImageFilter(): void
+    {
+        $usedFilters = [];
+
+        $imagineController = $this->createMock(ImagineController::class);
+        $imagineController->method('filterAction')
+            ->willReturnCallback(function ($request, $path, $filter) use (&$usedFilters): RedirectResponse {
+                $usedFilters[] = $filter;
+
+                return new RedirectResponse('/');
+            });
+
+        $photoCache = new PhotoCache(
+            $this->createUploaderHelper('/photos/example.jpg'),
+            $this->createMock(CacheManager::class),
+            $imagineController,
+        );
+
+        $photoCache->recachePhoto($this->createMock(ManipulateablePhotoInterface::class));
+
+        self::assertNotContains('city_image_wide', $usedFilters, 'A photo must never be warmed with the city filter');
+        self::assertContains('gallery_photo_thumb', $usedFilters);
+        self::assertContains('gallery_photo_standard', $usedFilters);
+        self::assertContains('gallery_photo_large', $usedFilters);
+    }
+
+    public function testRecacheDoesNotBubbleFilterFailures(): void
+    {
+        $imagineController = $this->createMock(ImagineController::class);
+        $imagineController->method('filterAction')
+            ->willThrowException(new NotFoundHttpException('Source image could not be found'));
+
+        $photoCache = new PhotoCache(
+            $this->createUploaderHelper('/photos/example.jpg'),
+            $this->createMock(CacheManager::class),
+            $imagineController,
+        );
+
+        // Warming the cache is best-effort: a failing filter must never turn a
+        // successful manipulation into an error response.
+        $result = $photoCache->recachePhoto($this->createMock(ManipulateablePhotoInterface::class));
+
+        self::assertSame($photoCache, $result);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1438 — clicking **rechts/links rotieren** in *Fotos bearbeiten* returned a **404** even though the image was rotated.

**Root cause:** `PhotoCache::recachePhoto()` warmed the LiipImagine cache with the `city_image_wide` filter. That filter's `data_loader` is `city_image_flysystem_loader` (root `public/cities`), so a **photo** filename is never found there → LiipImagine throws `NotLoadableException`, which its controller converts to `NotFoundHttpException` (404). This happens **after** `PhotoStorage::save()` already wrote the rotated file — hence "404, but the image is rotated anyway". The three `gallery_photo_*` filters use the correct photo loader; only the `city_image_wide` line was a copy-paste leftover.

## Changes
- **Drop the bogus `city_image_wide` warming** — the actual 404 cause.
- **Best-effort cache warming**: wrap the `filterAction` calls so a failing filter can never turn a successful manipulation into an error response (the derivative is regenerated lazily on next request).
- **Fix rotate direction**: the controller read a `rotate` query param while the template links send `direction=left|right`, so *rechts* and *links* rotated the same way. Right = clockwise (+90°) by default, left = −90°.
- **Regression test** `PhotoCacheTest` — a pure unit test with a mocked `ImagineController` (Imagick is unavailable in CI, so a controller test isn't viable). It fails against the old code (city filter present + exception bubbles) and passes with the fix.

## Test Plan
- `vendor/bin/phpunit tests/Criticalmass/Image/PhotoManipulator/Cache/PhotoCacheTest.php` → green; verified it fails against the previous `PhotoCache`.
- `vendor/bin/phpstan analyse` on the changed files → no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)