### PR TITLE
Fix 500 when adding a social profile to a city (#1366)

### DIFF
--- a/src/ValueResolver/RideValueResolver.php
+++ b/src/ValueResolver/RideValueResolver.php
@@ -60,11 +60,13 @@ class RideValueResolver implements ValueResolverInterface
     private function findRideBySlugs(Request $request): ?Ride
     {
         $citySlug = $request->get('citySlug');
-        $rideIdentifier = rtrim($request->get('rideIdentifier'), '-');
+        $rideIdentifier = $request->get('rideIdentifier');
 
         if (!$citySlug || !$rideIdentifier) {
             return null;
         }
+
+        $rideIdentifier = rtrim($rideIdentifier, '-');
 
         preg_match('/^([0-9]{4})\-([0-9]{1,2})(?:\-?)([0-9]{1,2})?$/', $rideIdentifier, $matches);
 

--- a/tests/Controller/SocialNetworkControllerTest.php
+++ b/tests/Controller/SocialNetworkControllerTest.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Controller;
+
+/**
+ * Regression coverage for #1366: opening the "add social network profile" page
+ * for a city returned a 500. The city route has no {rideIdentifier}, but the
+ * controller's nullable ?Ride argument still triggers RideValueResolver, which
+ * called rtrim() on the missing (null) rideIdentifier and raised a TypeError.
+ */
+class SocialNetworkControllerTest extends AbstractControllerTestCase
+{
+    public function testCityAddPageLoadsForLoggedInUser(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, 'testuser@criticalmass.in');
+
+        $client->request('GET', '/hamburg/socialnetwork/add');
+
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testCityAddPageRedirectsAnonymousToLogin(): void
+    {
+        $client = static::createClient();
+
+        $client->request('GET', '/hamburg/socialnetwork/add');
+
+        self::assertResponseRedirects();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1366 — opening *Soziales Netzwerk hinzufügen* for a **city** returned a **500**.

**Root cause:** the route `/{citySlug}/socialnetwork/add` has no `{rideIdentifier}`, but `SocialNetworkController::addAction` declares a nullable `?Ride $ride` argument. That still triggers `RideValueResolver`, whose `findRideBySlugs()` called `rtrim($request->get('rideIdentifier'), '-')` — `rideIdentifier` is `null` here, so `rtrim(null, …)` raises a `TypeError` on PHP 8 before the controller runs.

## Changes
- Read `rideIdentifier` first and return early on null/empty **before** `rtrim()`. Fixes every route resolving a nullable `Ride` without a `rideIdentifier`.
- Regression test `SocialNetworkControllerTest` (logged-in → 200, anonymous → redirect); both were 500 before.

## Test Plan
- `vendor/bin/phpunit tests/Controller/SocialNetworkControllerTest.php` → green; verified failing against old resolver.
- `vendor/bin/phpstan analyse` on changed files → no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)