### PR TITLE
Harden networkIcon() against feed items without a profile (#1305)

### DIFF
--- a/src/Twig/Extension/SocialNetworkTwigExtension.php
+++ b/src/Twig/Extension/SocialNetworkTwigExtension.php
@@ -64,14 +64,19 @@ class SocialNetworkTwigExtension extends AbstractExtension
             $networkIdentifier = $param->getNetwork();
         } elseif (is_string($param)) {
             $networkIdentifier = $param;
+        } elseif (null === $param) {
+            // Templates pass e.g. item.socialNetworkProfile.network, which is
+            // null for a feed item whose profile was removed (#1305).
+            $networkIdentifier = null;
         } else {
             throw new \InvalidArgumentException('Parameter must be instance of SocialNetworkFeedItem or SocialNetworkProfile or a string identifying the network.');
         }
 
-        /** @var NetworkInterface $network */
-        $network = $this->networkManager->getNetworkList()[$networkIdentifier];
+        if (null === $networkIdentifier || !$this->networkManager->hasNetwork($networkIdentifier)) {
+            return '';
+        }
 
-        return $network->getIcon();
+        return $this->networkManager->getNetwork($networkIdentifier)->getIcon();
     }
 
     public function getNetwork(string $identifier): ?NetworkInterface

--- a/tests/Twig/SocialNetworkTwigExtensionNetworkIconTest.php
+++ b/tests/Twig/SocialNetworkTwigExtensionNetworkIconTest.php
@@ -1,0 +1,68 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Twig;
+
+use App\Criticalmass\SocialNetwork\Network\NetworkInterface;
+use App\Criticalmass\SocialNetwork\NetworkManager\NetworkManagerInterface;
+use App\Entity\SocialNetworkFeedItem;
+use App\Entity\SocialNetworkProfile;
+use App\Twig\Extension\SocialNetworkTwigExtension;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression coverage for #1305: a feed item whose SocialNetworkProfile was
+ * removed makes getSocialNetworkProfile() return null. networkIcon() then
+ * looked the network up by a null identifier and called getIcon() on the
+ * missing entry, raising a TypeError (500).
+ */
+class SocialNetworkTwigExtensionNetworkIconTest extends TestCase
+{
+    private function createExtension(): SocialNetworkTwigExtension
+    {
+        $twitter = $this->createMock(NetworkInterface::class);
+        $twitter->method('getIcon')->willReturn('fa-twitter');
+
+        $networkManager = $this->createMock(NetworkManagerInterface::class);
+        $networkManager->method('hasNetwork')->willReturnCallback(
+            static fn (string $identifier): bool => $identifier === 'twitter'
+        );
+        $networkManager->method('getNetwork')->willReturnCallback(
+            static fn (string $identifier): NetworkInterface => match ($identifier) {
+                'twitter' => $twitter,
+                default => throw new \OutOfBoundsException($identifier),
+            }
+        );
+
+        return new SocialNetworkTwigExtension($networkManager);
+    }
+
+    public function testFeedItemWithoutProfileReturnsNoIconInsteadOfCrashing(): void
+    {
+        $feedItem = new SocialNetworkFeedItem();
+
+        self::assertNull($feedItem->getSocialNetworkProfile());
+        self::assertSame('', $this->createExtension()->networkIcon($feedItem));
+    }
+
+    public function testNullReturnsNoIcon(): void
+    {
+        self::assertSame('', $this->createExtension()->networkIcon(null));
+    }
+
+    public function testUnknownNetworkReturnsNoIcon(): void
+    {
+        self::assertSame('', $this->createExtension()->networkIcon('does-not-exist'));
+    }
+
+    public function testKnownNetworkReturnsItsIcon(): void
+    {
+        $profile = (new SocialNetworkProfile())->setNetwork('twitter');
+        $feedItem = (new SocialNetworkFeedItem())->setSocialNetworkProfile($profile);
+
+        $extension = $this->createExtension();
+
+        self::assertSame('fa-twitter', $extension->networkIcon('twitter'));
+        self::assertSame('fa-twitter', $extension->networkIcon($profile));
+        self::assertSame('fa-twitter', $extension->networkIcon($feedItem));
+    }
+}


### PR DESCRIPTION
## Summary

Addresses #1305 — a `SocialNetworkFeedItem` whose `SocialNetworkProfile` was removed returns `null` from `getSocialNetworkProfile()`. The nullable return type and the `?->` call sites were already fixed; the one remaining unguarded path was `SocialNetworkTwigExtension::networkIcon()`:

```php
$network = $this->networkManager->getNetworkList()[$networkIdentifier]; // null key
return $network->getIcon();                                            // getIcon() on null → 500
```

With a null profile, `$networkIdentifier` is null and this crashes. Twig templates also pass `item.socialNetworkProfile.network` (null for such items) straight into `network_icon()`.

## Changes
- Resolve the network via `hasNetwork()`/`getNetwork()` and return an **empty icon** for a null or unknown identifier; also accept a `null` argument. No more `getIcon()`-on-null.
- Unit test `SocialNetworkTwigExtensionNetworkIconTest` covering: feed item without profile, `null`, unknown network, and known network. Fails (TypeError) against the old code, passes with the fix.

Note: this fixes the code path. Cleaning up / re-associating orphaned feed-item rows in the database (as the issue also suggests) remains a separate operational task.

## Test Plan
- `vendor/bin/phpunit tests/Twig/SocialNetworkTwigExtensionNetworkIconTest.php` → green; verified failing against the previous extension.
- `vendor/bin/phpstan analyse` on the changed files → no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)