### PR TITLE
Fix 502 on social network profile creation

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -112,6 +112,9 @@ services:
     App\Criticalmass\SocialNetwork\NetworkManager\NetworkManagerInterface:
         alias: App\Criticalmass\SocialNetwork\FeedsApi\FeedsNetworkManager
 
+    App\Criticalmass\SocialNetwork\FeedsApi\FeedsApiClient:
+        lazy: true
+
     App\Criticalmass\SocialNetwork\FeedsApi\FeedsApiClientInterface:
         alias: App\Criticalmass\SocialNetwork\FeedsApi\FeedsApiClient
 

--- a/src/Controller/Api/SocialNetworkProfileController.php
+++ b/src/Controller/Api/SocialNetworkProfileController.php
@@ -127,7 +127,7 @@ class SocialNetworkProfileController extends BaseController
 
                 $newSocialNetworkProfile->setFeedsProfileId($feedsProfile->getId());
                 $manager->flush();
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 $logger->error('Failed to create profile in Feeds API: ' . $e->getMessage());
             }
         }

--- a/src/Controller/Api/SocialNetworkProfileController.php
+++ b/src/Controller/Api/SocialNetworkProfileController.php
@@ -11,6 +11,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class SocialNetworkProfileController extends BaseController
 {
@@ -94,12 +95,24 @@ class SocialNetworkProfileController extends BaseController
         City $city,
         FeedsApiClientInterface $feedsApiClient,
         LoggerInterface $logger,
+        ValidatorInterface $validator,
     ): JsonResponse {
         $newSocialNetworkProfile = $this->deserializeRequest($request, SocialNetworkProfile::class);
 
         $newSocialNetworkProfile
             ->setCity($city)
             ->setCreatedAt(new \DateTime());
+
+        $errors = $validator->validate($newSocialNetworkProfile);
+
+        if (count($errors) > 0) {
+            $errorMessages = [];
+            foreach ($errors as $error) {
+                $errorMessages[] = $error->getPropertyPath() . ': ' . $error->getMessage();
+            }
+
+            return new JsonResponse(['errors' => $errorMessages], Response::HTTP_BAD_REQUEST);
+        }
 
         $manager = $this->managerRegistry->getManager();
         $manager->persist($newSocialNetworkProfile);

--- a/src/Entity/SocialNetworkProfile.php
+++ b/src/Entity/SocialNetworkProfile.php
@@ -43,6 +43,7 @@ class SocialNetworkProfile
     #[Groups(['ride-list', 'ride-details', 'api-write'])]
     protected ?string $identifier = null;
 
+    #[Assert\NotBlank]
     #[ORM\Column(type: 'string', length: 255)]
     #[Groups(['ride-list', 'ride-details', 'api-write'])]
     protected ?string $network = null;


### PR DESCRIPTION
## Summary

- The API endpoint `PUT /api/{citySlug}/socialnetwork-profiles` returned **HTTP 502** on every create request, while reads and the update endpoint worked. Two independent defects combined:
  - **No validation before persist.** Unlike the sibling create actions (`Cycle`, `Ride`), the handler flushed the deserialized entity without validating. A payload missing the `NOT NULL` `network` column (or with a blank `identifier`) crashed inside `flush()` with an uncaught SQL exception → 500/502 instead of a clean 400. Added `#[Assert\NotBlank]` on `network` and a validate-before-persist block mirroring `CycleController::createCycleAction`.
  - **Eager, hard dependency on the Feeds API.** The create handler injected `FeedsApiClientInterface` eagerly, so a missing `FEEDS_API_URL`/`FEEDS_API_TOKEN` (or any instantiation failure) took the whole endpoint down *before* the existing `try/catch` around the feeds call could run. The update endpoint, which does not inject the client, was unaffected. Marked `FeedsApiClient` as `lazy` so instantiation/env resolution is deferred until first use inside the guarded block, and broadened the catch to `\Throwable` so feeds enrichment stays best-effort.

## Test Plan

- `vendor/bin/phpstan analyse` — no errors on the changed files.
- `php bin/console debug:container FeedsApiClient` — confirms `Lazy: yes`, container compiles.
- Existing API test `testCreateSocialNetworkProfile` (`network=bluesky`) remains valid; new `NotBlank` only rejects missing/blank `network`.
- Manual: creating a profile with a valid `network` succeeds; a missing `network` now returns `400 {"errors":[...]}` instead of 502; feeds outage no longer blocks creation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)