### PR TITLE
Surface feeds-sync outcome on social profile create

### DIFF
--- a/src/Controller/Api/SocialNetworkProfileController.php
+++ b/src/Controller/Api/SocialNetworkProfileController.php
@@ -118,6 +118,8 @@ class SocialNetworkProfileController extends BaseController
         $manager->persist($newSocialNetworkProfile);
         $manager->flush();
 
+        $feedsSynced = false;
+
         if ($newSocialNetworkProfile->getIdentifier() && $newSocialNetworkProfile->getNetwork()) {
             try {
                 $feedsProfile = $feedsApiClient->createProfile(
@@ -127,11 +129,32 @@ class SocialNetworkProfileController extends BaseController
 
                 $newSocialNetworkProfile->setFeedsProfileId($feedsProfile->getId());
                 $manager->flush();
+                $feedsSynced = true;
+
+                $logger->info('Created Feeds API profile {feedsId} for {network} "{identifier}" (city {city})', [
+                    'feedsId' => $feedsProfile->getId(),
+                    'network' => $newSocialNetworkProfile->getNetwork(),
+                    'identifier' => $newSocialNetworkProfile->getIdentifier(),
+                    'city' => $city->getSlug(),
+                ]);
             } catch (\Throwable $e) {
-                $logger->error('Failed to create profile in Feeds API: ' . $e->getMessage());
+                // Best-effort enrichment, but it must not fail silently: the profile is
+                // created locally while the feed is NOT registered at feeds.maltehuebner.dev.
+                $logger->error('Failed to create profile in Feeds API for {network} "{identifier}" (city {city}): {error}', [
+                    'network' => $newSocialNetworkProfile->getNetwork(),
+                    'identifier' => $newSocialNetworkProfile->getIdentifier(),
+                    'city' => $city->getSlug(),
+                    'error' => $e->getMessage(),
+                    'exception' => $e,
+                ]);
             }
         }
 
-        return $this->createStandardResponse($newSocialNetworkProfile);
+        // Surface the feeds-sync outcome so a failed enrichment is not mistaken for a
+        // fully successful create (feeds_profile_id is null when sync failed).
+        return $this->createStandardResponse(
+            $newSocialNetworkProfile,
+            headerList: ['X-Feeds-Sync' => $feedsSynced ? 'ok' : 'failed'],
+        );
     }
 }


### PR DESCRIPTION
## Summary

Creating a social network profile (`PUT /api/{citySlug}/socialnetwork-profiles`) persists it locally and then best-effort registers it at feeds.maltehuebner.dev. When that feeds call failed, the endpoint still returned **200 with no signal** — a profile could exist locally while the feed was **not** registered in feeds (observed with a new Instagram profile that never reached feeds, and nothing in `prod.log`).

## Change

- Log the outcome with full context (network, identifier, city slug, error + exception) instead of a bare `$e->getMessage()`, so failures are diagnosable.
- Return an **`X-Feeds-Sync: ok|failed`** response header so callers can distinguish a fully-synced create from a local-only one (`feeds_profile_id` is null when sync failed).

No change to status code or response body → existing consumers/tests unaffected.

## Test Plan

- `vendor/bin/phpstan analyse` — no errors on the changed file.
- Existing `testCreateSocialNetworkProfile` still valid (same 200 + body); new header/logging are additive.

The feeds-side root cause (why the sync fails) is tracked in criticalmass-one/socialnetwork-fetcher#129 / #130.

Refs #1452

🤖 Generated with [Claude Code](https://claude.com/claude-code)