### PR TITLE
Matomo-Tracking (cookielos) + Datenschutz-Abschnitte

### DIFF
--- a/templates/Static/gdpr.html.twig
+++ b/templates/Static/gdpr.html.twig
@@ -312,14 +312,19 @@
                     </h3>
 
                     <p>
-                        Zugriffe auf criticalmass.in werden von der Software <a href="https://matomo.org">Matomo</a>, ehemals Piwik, gemessen. Wir setzen Matomo ein, um ein ungefähres Bild des Interesses der Nutzer an unserer Webseite zu bekommen. Die Zugriffe werden anonymisiert erhoben, unser Server <code>piwik.caldera.cc</code> führt darüberhinaus keine zusätzlichen Logfiles.
+                        Zugriffe auf criticalmass.in werden von der Open-Source-Software <a href="https://matomo.org">Matomo</a>, ehemals Piwik, gemessen. Wir setzen Matomo ein, um ein ungefähres Bild des Interesses der Nutzer an unserer Webseite zu bekommen — etwa welche Städte oder Touren aufgerufen werden. Matomo betreiben wir selbst auf unserem eigenen Server <code>matomo.caldera.cc</code> in Deutschland, deine Daten werden nicht an Dritte weitergegeben.
                     </p>
 
                     <p>
-                        Du kannst dem Tracking entweder über die <a href="https://de.wikipedia.org/wiki/Do_Not_Track_(Software)">„Do not Track"-Einstellungen deines Browsers</a> oder über folgende Checkbox widersprechen:
+                        Die Messung kommt komplett ohne Cookies aus und deine IP-Adresse wird vor der Speicherung um die letzten beiden Oktette gekürzt, so dass sie sich nicht mehr auf dich zurückführen lässt. Erfasst werden neben den aufgerufenen Seiten lediglich die verweisende Seite (Referrer), dein Browsertyp und deine ungefähre Herkunftsregion.
                     </p>
 
-                    <iframe style="border: 0; height: 200px; width: 100%;" src="https://piwik.caldera.cc/index.php?module=CoreAdminHome&action=optOut&language=de&backgroundColor=ffffff&fontColor=000000&fontSize=16px&fontFamily=%22Helvetica%20Neue%22%2C%20Helvetica%2C%20Arial%2C%20sans-serif"></iframe>
+                    <p>
+                        Du kannst dem Tracking entweder über die <a href="https://de.wikipedia.org/wiki/Do_Not_Track_(Software)">„Do not Track"-Einstellungen deines Browsers</a> widersprechen, die wir selbstverständlich respektieren, oder über folgende Checkbox:
+                    </p>
+
+                    <div id="matomo-opt-out"></div>
+                    <script src="https://matomo.caldera.cc/index.php?module=CoreAdminHome&amp;action=optOutJS&amp;divId=matomo-opt-out&amp;language=auto&amp;showIntro=1" async></script>
                 </div>
             </div>
         </div>

--- a/templates/Static/privacy.html.twig
+++ b/templates/Static/privacy.html.twig
@@ -319,6 +319,25 @@
                         ehemalige Bestehen einer Einwilligung bestätigt wird.
                     </p>
 
+                    <h3>
+                        Reichweitenmessung (Matomo)
+                    </h3>
+
+                    <p>
+                        Wir setzen zur statistischen Auswertung der Besucherzugriffe die Open-Source-Software <a href="https://matomo.org">Matomo</a> ein. Matomo wird von uns selbst auf einem eigenen Server in Deutschland betrieben (<code>matomo.caldera.cc</code>); eine Weitergabe von Daten an Dritte findet nicht statt.
+                    </p>
+
+                    <p>
+                        Die Reichweitenmessung erfolgt cookielos, es werden also keine Cookies auf Ihrem Gerät gespeichert. IP-Adressen werden vor der Speicherung um die letzten beiden Oktette gekürzt und damit anonymisiert, so dass ein Rückschluss auf einzelne Nutzer nicht möglich ist. Erfasst werden die aufgerufenen Seiten (z.B. welche Städte oder Touren aufgerufen werden), die verweisende Seite (Referrer), der Browsertyp sowie die ungefähre Herkunftsregion.
+                    </p>
+
+                    <p>
+                        Rechtsgrundlage der Verarbeitung ist Art. 6 Abs. 1 lit. f DSGVO auf Grundlage unseres berechtigten Interesses an der statistischen Auswertung der Nutzung unseres Onlineangebotes. Die „Do-Not-Track"-Einstellung Ihres Browsers wird respektiert. Darüber hinaus können Sie der Erfassung über das folgende Opt-Out-Widget widersprechen:
+                    </p>
+
+                    <div id="matomo-opt-out"></div>
+                    <script src="https://matomo.caldera.cc/index.php?module=CoreAdminHome&amp;action=optOutJS&amp;divId=matomo-opt-out&amp;language=auto&amp;showIntro=1" async></script>
+
                     <p class="mb-0">
                         <a href="https://datenschutz-generator.de">
                             Erstellt mit Datenschutz-Generator.de von RA Dr. Thomas Schwenke

--- a/templates/Template/MasterTemplate.html.twig
+++ b/templates/Template/MasterTemplate.html.twig
@@ -27,6 +27,21 @@
 
     {{ encore_entry_script_tags(entrypoint) }}
 
+    {# Matomo (selbst gehostet, cookielos, IP-anonymisiert — siehe Datenschutzerklärung) #}
+    <script>
+        var _paq = window._paq = window._paq || [];
+        _paq.push(['disableCookies']);
+        _paq.push(['trackPageView']);
+        _paq.push(['enableLinkTracking']);
+        (function () {
+            var u = 'https://matomo.caldera.cc/';
+            _paq.push(['setTrackerUrl', u + 'matomo.php']);
+            _paq.push(['setSiteId', '5']);
+            var d = document, g = d.createElement('script'), s = d.getElementsByTagName('script')[0];
+            g.async = true; g.src = u + 'matomo.js'; s.parentNode.insertBefore(g, s);
+        })();
+    </script>
+
 </head>
 
 <body class="{% if app.user %}logged-in{% else %}not-logged-in{% endif %} {% block bodyClass %}{% endblock %} with-top-navbar">


### PR DESCRIPTION
Selbst gehostetes Matomo auf matomo.caldera.cc (Site 5): Snippet im MasterTemplate mit disableCookies; IP-Anonymisierung serverseitig. Datenschutzerklärung (privacy) um Reichweitenmessung inkl. Opt-Out-Widget ergänzt; auf der GDPR-Seite das piwik.caldera.cc-Relikt durch das neue Opt-Out-Widget ersetzt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)