### PR TITLE
CSP-tauglicher Matomo-Einbau (externes Init-Script)

### DIFF
--- a/public/js/matomo-init.js
+++ b/public/js/matomo-init.js
@@ -1,0 +1,16 @@
+/*
+ * Matomo (selbst gehostet, cookielos, IP-anonymisiert — siehe Datenschutzerklärung).
+ * Als externe Datei statt Inline-Snippet, damit die CSP mit `script-src 'self'`
+ * ohne unsafe-inline/Nonce auskommt.
+ */
+var _paq = window._paq = window._paq || [];
+_paq.push(['disableCookies']);
+_paq.push(['trackPageView']);
+_paq.push(['enableLinkTracking']);
+(function () {
+    var u = 'https://matomo.caldera.cc/';
+    _paq.push(['setTrackerUrl', u + 'matomo.php']);
+    _paq.push(['setSiteId', '5']);
+    var d = document, g = d.createElement('script'), s = d.getElementsByTagName('script')[0];
+    g.async = true; g.src = u + 'matomo.js'; s.parentNode.insertBefore(g, s);
+})();

--- a/src/EventSubscriber/SecurityHeadersEventSubscriber.php
+++ b/src/EventSubscriber/SecurityHeadersEventSubscriber.php
@@ -20,6 +20,8 @@ class SecurityHeadersEventSubscriber implements EventSubscriberInterface
      * nichts, sammelt aber Verstöße (z. B. Inline-Skripte), bevor auf eine
      * erzwingende Policy umgestellt wird. `script-src` bewusst ohne
      * `unsafe-inline`, damit Inline-Skripte sichtbar werden.
+     * matomo.caldera.cc ist unser selbst gehostetes Matomo (Tracker-Loader
+     * matomo.js und das Opt-Out-Widget auf den Datenschutzseiten).
      */
     private const CONTENT_SECURITY_POLICY = "default-src 'self'; "
         . "base-uri 'self'; "
@@ -28,7 +30,7 @@ class SecurityHeadersEventSubscriber implements EventSubscriberInterface
         . "img-src 'self' data: https:; "
         . "font-src 'self' data: https:; "
         . "style-src 'self' 'unsafe-inline'; "
-        . "script-src 'self'; "
+        . "script-src 'self' https://matomo.caldera.cc; "
         . "connect-src 'self' https:";
 
     public function onResponse(ResponseEvent $event): void

--- a/templates/Template/MasterTemplate.html.twig
+++ b/templates/Template/MasterTemplate.html.twig
@@ -27,20 +27,9 @@
 
     {{ encore_entry_script_tags(entrypoint) }}
 
-    {# Matomo (selbst gehostet, cookielos, IP-anonymisiert — siehe Datenschutzerklärung) #}
-    <script>
-        var _paq = window._paq = window._paq || [];
-        _paq.push(['disableCookies']);
-        _paq.push(['trackPageView']);
-        _paq.push(['enableLinkTracking']);
-        (function () {
-            var u = 'https://matomo.caldera.cc/';
-            _paq.push(['setTrackerUrl', u + 'matomo.php']);
-            _paq.push(['setSiteId', '5']);
-            var d = document, g = d.createElement('script'), s = d.getElementsByTagName('script')[0];
-            g.async = true; g.src = u + 'matomo.js'; s.parentNode.insertBefore(g, s);
-        })();
-    </script>
+    {# Matomo (selbst gehostet, cookielos, IP-anonymisiert — siehe Datenschutzerklärung).
+       Externe Datei statt Inline-Snippet, damit die CSP ohne unsafe-inline/Nonce auskommt. #}
+    <script src="{{ asset('js/matomo-init.js') }}" async></script>
 
 </head>
 


### PR DESCRIPTION
Snippet nach public/js/matomo-init.js ausgelagert und script-src um https://matomo.caldera.cc erweitert — damit übersteht das Tracking das spätere Scharfschalten der CSP ohne unsafe-inline/Nonce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)