### PR TITLE
Datenschutz: Suchbegriffe der Städtesuche ergänzen

### DIFF
--- a/templates/Static/gdpr.html.twig
+++ b/templates/Static/gdpr.html.twig
@@ -316,7 +316,7 @@
                     </p>
 
                     <p>
-                        Die Messung kommt komplett ohne Cookies aus und deine IP-Adresse wird vor der Speicherung um die letzten beiden Oktette gekürzt, so dass sie sich nicht mehr auf dich zurückführen lässt. Erfasst werden neben den aufgerufenen Seiten lediglich die verweisende Seite (Referrer), dein Browsertyp und deine ungefähre Herkunftsregion.
+                        Die Messung kommt komplett ohne Cookies aus und deine IP-Adresse wird vor der Speicherung um die letzten beiden Oktette gekürzt, so dass sie sich nicht mehr auf dich zurückführen lässt. Erfasst werden neben den aufgerufenen Seiten lediglich deine Suchbegriffe in der Städte- und Toursuche, die verweisende Seite (Referrer), dein Browsertyp und deine ungefähre Herkunftsregion.
                     </p>
 
                     <p>

--- a/templates/Static/privacy.html.twig
+++ b/templates/Static/privacy.html.twig
@@ -328,7 +328,7 @@
                     </p>
 
                     <p>
-                        Die Reichweitenmessung erfolgt cookielos, es werden also keine Cookies auf Ihrem Gerät gespeichert. IP-Adressen werden vor der Speicherung um die letzten beiden Oktette gekürzt und damit anonymisiert, so dass ein Rückschluss auf einzelne Nutzer nicht möglich ist. Erfasst werden die aufgerufenen Seiten (z.B. welche Städte oder Touren aufgerufen werden), die verweisende Seite (Referrer), der Browsertyp sowie die ungefähre Herkunftsregion.
+                        Die Reichweitenmessung erfolgt cookielos, es werden also keine Cookies auf Ihrem Gerät gespeichert. IP-Adressen werden vor der Speicherung um die letzten beiden Oktette gekürzt und damit anonymisiert, so dass ein Rückschluss auf einzelne Nutzer nicht möglich ist. Erfasst werden die aufgerufenen Seiten (z.B. welche Städte oder Touren aufgerufen werden), die Suchbegriffe der Städte- und Toursuche, die verweisende Seite (Referrer), der Browsertyp sowie die ungefähre Herkunftsregion.
                     </p>
 
                     <p>


### PR DESCRIPTION
Die Städtesuche wird in Matomo als Website-Suche ausgewertet (query-Parameter); privacy- und gdpr-Seite nennen die Suchbegriffe jetzt explizit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)