### PR TITLE
Keep current ride visible 4 hours after start

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,23 @@ vendor/bin/phpunit --filter testMethodName                  # Single test method
 # Use `php bin/console ...` (the bare `bin/console` may report "permission denied").
 ```
 
+**Time-dependent tests:** `phpunit.dist.xml` wires Symfony's `SymfonyExtension` with
+`clock-mock-namespaces=App`, so unqualified `time()` calls inside `App\…` are mockable.
+That is why e.g. `RideRepository` builds "now" via
+`\DateTime::createFromFormat('U', (string)time())` — do not "simplify" this to
+`new \DateTime()`. Test pattern (see `tests/Repository/RideRepositoryTest.php`):
+tag the test `#[Group('time-sensitive')]`, then `ClockMock::register(TheClass::class)` +
+`ClockMock::withClockMock($timestamp)`; reset with `ClockMock::withClockMock(false)` in
+`tearDown()`. Fixtures compute ride dates **relative to load time**
+(`RideFixtures`: `"±N months last friday 19:00"`), so tests must not assume absolute
+dates — read the fixture entity's datetime from the DB and set the mock clock relative
+to it.
+
+**"Current ride" semantics:** `RideRepository::findCurrentRideForCity()` returns the next
+ride with `dateTime >= now − CURRENT_RIDE_GRACE_HOURS` (4 h), i.e. a ride that already
+started stays "current" during the grace period — on the city page, city list,
+`/api/{citySlug}/current` and the MCP `GetCurrentRideTool`.
+
 ### Static Analysis
 ```bash
 vendor/bin/phpstan analyse                  # PHPStan level 6

--- a/src/Repository/RideRepository.php
+++ b/src/Repository/RideRepository.php
@@ -15,6 +15,9 @@ use Doctrine\Persistence\ManagerRegistry;
 
 class RideRepository extends ServiceEntityRepository
 {
+    /** a ride still counts as "current" for this many hours after its start time */
+    public const CURRENT_RIDE_GRACE_HOURS = 4;
+
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, Ride::class);
@@ -22,7 +25,8 @@ class RideRepository extends ServiceEntityRepository
 
     public function findCurrentRideForCity(City $city, bool $cycleMandatory = false, bool $slugsAllowed = true): ?Ride
     {
-        $dateTime = \DateTime::createFromFormat('U', (string)time()); // this will allow to mock the clock in functional tests
+        $dateTime = \DateTime::createFromFormat('U', (string)time()) // this will allow to mock the clock in functional tests
+            ->modify(sprintf('-%d hours', self::CURRENT_RIDE_GRACE_HOURS));
 
         $builder = $this->createQueryBuilder('r');
 

--- a/tests/Repository/RideRepositoryTest.php
+++ b/tests/Repository/RideRepositoryTest.php
@@ -4,7 +4,10 @@ namespace Tests\Repository;
 
 use App\Entity\City;
 use App\Entity\Ride;
+use App\Repository\RideRepository;
 use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\Bridge\PhpUnit\ClockMock;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 class RideRepositoryTest extends KernelTestCase
@@ -55,8 +58,69 @@ class RideRepositoryTest extends KernelTestCase
         }
     }
 
+    #[Group('time-sensitive')]
+    public function testFindCurrentRideForCityIncludesRecentlyStartedRide(): void
+    {
+        [$city, $lastPastRide] = $this->getCityWithLastPastRide();
+
+        // two hours after the start the ride still counts as current
+        ClockMock::register(RideRepository::class);
+        ClockMock::withClockMock((clone $lastPastRide->getDateTime())->modify('+2 hours')->format('U'));
+
+        $currentRide = $this->entityManager->getRepository(Ride::class)->findCurrentRideForCity($city);
+
+        $this->assertNotNull($currentRide);
+        $this->assertEquals($lastPastRide->getId(), $currentRide->getId());
+    }
+
+    #[Group('time-sensitive')]
+    public function testFindCurrentRideForCityExcludesRideAfterGracePeriod(): void
+    {
+        [$city, $lastPastRide] = $this->getCityWithLastPastRide();
+
+        // one minute past the grace period the ride is not current anymore
+        ClockMock::register(RideRepository::class);
+        ClockMock::withClockMock(
+            (clone $lastPastRide->getDateTime())
+                ->modify(sprintf('+%d hours +1 minute', RideRepository::CURRENT_RIDE_GRACE_HOURS))
+                ->format('U')
+        );
+
+        $currentRide = $this->entityManager->getRepository(Ride::class)->findCurrentRideForCity($city);
+
+        if ($currentRide) {
+            $this->assertNotEquals($lastPastRide->getId(), $currentRide->getId());
+            $this->assertGreaterThan($lastPastRide->getDateTime(), $currentRide->getDateTime());
+        } else {
+            $this->assertNull($currentRide);
+        }
+    }
+
+    /** @return array{City, Ride} */
+    private function getCityWithLastPastRide(): array
+    {
+        $city = $this->entityManager->getRepository(City::class)->findOneBy(['city' => 'Hamburg']);
+        $this->assertNotNull($city, 'Hamburg fixture not found');
+
+        $lastPastRide = null;
+        $now = new \DateTime();
+
+        foreach ($this->entityManager->getRepository(Ride::class)->findRidesForCity($city, 'DESC') as $ride) {
+            if ($ride->getDateTime() < $now) {
+                $lastPastRide = $ride;
+                break;
+            }
+        }
+
+        $this->assertNotNull($lastPastRide, 'No past Hamburg ride in fixtures');
+
+        return [$city, $lastPastRide];
+    }
+
     protected function tearDown(): void
     {
+        ClockMock::withClockMock(false);
+
         parent::tearDown();
         $this->entityManager = null;
     }


### PR DESCRIPTION
## Summary
- Fixes the complaint that an ongoing ride (e.g. Frankfurt, started an hour ago) is no longer shown on the city page: `RideRepository::findCurrentRideForCity()` filtered with `dateTime >= now`, so a ride vanished the moment it started.
- Introduces `RideRepository::CURRENT_RIDE_GRACE_HOURS = 4` — a ride now counts as "current" until 4 hours after its announced start time.
- Affects all consumers of the method: city page, city list, `/api/{citySlug}/current` and the MCP `GetCurrentRideTool` (intentionally — "current ride" should include the one happening right now).

## Test Plan
- New `RideRepositoryTest` cases using `ClockMock`: a ride started 2 hours ago is still returned as current; one minute past the grace period it is not (the next ride is returned instead).
- PHPStan passes on the changed repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)